### PR TITLE
set ALLOWED_HOSTS from BASE_URL in production

### DIFF
--- a/developerportal/settings/dev.py
+++ b/developerportal/settings/dev.py
@@ -1,5 +1,3 @@
-import os
-
 from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/developerportal/settings/production.py
+++ b/developerportal/settings/production.py
@@ -1,6 +1,9 @@
+from urllib.parse import urlparse
+
 from .base import *
 
 DEBUG = False
+ALLOWED_HOSTS = [urlparse(BASE_URL).hostname]
 
 try:
     from .local import *


### PR DESCRIPTION
When using the `production` settings, set `ALLOWED_HOSTS` from `BASE_URL`. Also removes unused import in the `dev` settings.