### PR TITLE
revert back to build instead of pull in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -62,8 +62,8 @@ POSTGRES_PASSWORD="$(openssl rand -base64 64 | tr -d '+/\n=')"
 POSTGRES_USER=admin
 EOT
 
-log 'Pulling docker images'
-docker-compose pull
+log 'Building Docker services.'
+docker-compose up --build --detach
 
 log 'Running migrations.'
 docker-compose run --rm app python manage.py migrate


### PR DESCRIPTION
https://github.com/mdn/developer-portal/pull/9 modified, among other things, `setup.sh` to use `docker-compose pull` instead of `docker-compose up --build --detach`. This PR reverts that specific change. The problem is that `docker-compose pull` doesn't pick-up immediate changes that affect the build, like changes to `requirements.txt`, and so breaks CI testing (see https://github.com/mdn/developer-portal/commit/db00d2beb626d474c499dea985fbe5dfdc704403#r34155570).