### PR TITLE
explicitly specify the docker-compose file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,12 +39,14 @@ node {
         sh "docker build --tag ${image}:latest --tag ${image}:${tag} ."
       }
       stage ('Test') {
-        sh "docker-compose -f docker-compose.test.yml up --detach"
-        try {
-            sh "docker-compose exec -T app ./manage.py migrate"
-            sh "docker-compose exec -T app ./manage.py test"
-        } finally {
-            sh "docker-compose down --volumes --remove-orphans"
+        withEnv(["COMPOSE_FILE=docker-compose.test.yml"]) {
+          sh "docker-compose up --detach"
+          try {
+              sh "docker-compose exec -T app ./manage.py migrate"
+              sh "docker-compose exec -T app ./manage.py test"
+          } finally {
+              sh "docker-compose down --volumes --remove-orphans"
+          }
         }
       }
       stage('Push Images') {


### PR DESCRIPTION
This PR fixes a bug where the commands after `docker-compose -f docker-compose.test.yml up --detach` were not using the same docker-compose file.