### PR TITLE
add aws bucket config for bakery publish command

### DIFF
--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -1,4 +1,6 @@
           env:
+            - name: AWS_BUCKET_NAME
+              value: "{{ APP_AWS_BUCKET_NAME }}"
             - name: BASE_URL
               value: "{{ APP_BASE_URL }}"
             - name: DJANGO_SECRET_KEY

--- a/k8s/config/stage.sh
+++ b/k8s/config/stage.sh
@@ -20,3 +20,4 @@ export APP_MEMORY_LIMIT=4Gi
 export APP_MEMORY_REQUEST=2Gi
 export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-stage.mdn.mozit.cloud
+export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767


### PR DESCRIPTION
This PR adds the configuration for the stage S3 bucket used when using django-bakery's `./manage.py publish` command on the stage instance.