### PR TITLE
forgot to add AWS_BUCKET_NAME to settings

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -213,6 +213,7 @@ BAKERY_MULTISITE = True
 BAKERY_VIEWS = (
 	'wagtailbakery.views.AllPublishedPagesView',
 )
+AWS_BUCKET_NAME = os.environ.get('AWS_BUCKET_NAME')
 
 # GOOGLE_ANALYTICS
 GOOGLE_ANALYTICS = os.environ.get('GOOGLE_ANALYTICS')


### PR DESCRIPTION
This adds what I forgot to include in https://github.com/mdn/developer-portal/pull/24, the `AWS_BUCKET_NAME` to the Django settings.