### PR TITLE
add aws region for django-bakery publish

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -213,6 +213,7 @@ BAKERY_MULTISITE = True
 BAKERY_VIEWS = (
 	'wagtailbakery.views.AllPublishedPagesView',
 )
+AWS_REGION = os.environ.get('AWS_REGION')
 AWS_BUCKET_NAME = os.environ.get('AWS_BUCKET_NAME')
 
 # GOOGLE_ANALYTICS

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -1,6 +1,8 @@
           env:
             - name: AWS_BUCKET_NAME
               value: "{{ APP_AWS_BUCKET_NAME }}"
+            - name: AWS_REGION
+              value: "{{ APP_AWS_BUCKET_REGION }}"
             - name: BASE_URL
               value: "{{ APP_BASE_URL }}"
             - name: DJANGO_SECRET_KEY

--- a/k8s/config/stage.sh
+++ b/k8s/config/stage.sh
@@ -21,3 +21,4 @@ export APP_MEMORY_REQUEST=2Gi
 export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-stage.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
+export APP_AWS_BUCKET_REGION=us-west-2


### PR DESCRIPTION
This PR adds the `AWS_REGION` Django setting for django-bakery's `publish` command. It's the region of the S3 bucket that's the target of the `publish` command.