### PR TITLE
141: Add simple pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+This changeset addresses ... by ...
+
+(Resolves issue #XX)
+
+## Key changes:
+
+- summarise changes here, linking to commits as appropriate
+
+## How to test
+
+- add test steps here, including how to set up relevant data/state


### PR DESCRIPTION
Tiny PR to add an initial pull-request template as per https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository. 

Why? Just makes it easier to start thinking about what to write in a PR

Resolves #141 