### PR TITLE
Hotfix: remedy duplicated entry for `skip` in isort config

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,7 +3,6 @@ known_first_party=developerportal
 known_third_party=wagtail,modelcluster,six,requests,willow,pillow,taggit
 known_django=django
 default_section=FIRSTPARTY
-skip=migrations
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 multi_line_output=3
 include_trailing_comma=True


### PR DESCRIPTION
This changeset remedies a blocker when using `therapist`, due to a duplicated line in the isort config, so it fails to run.

## Key changes:

- removes duplicated `skip` key

