### PR TITLE
136: Fix inappropriate creation of wagtailcore migration

### DIFF
--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -32,6 +32,7 @@ import readtime
 from ..common.blocks import ExternalAuthorBlock, ExternalLinkBlock
 from ..common.constants import RICH_TEXT_FEATURES_SIMPLE
 from ..common.fields import CustomStreamField
+from ..common.forms import BasePageForm
 from ..common.utils import get_combined_articles, get_combined_articles_and_videos
 
 
@@ -45,6 +46,8 @@ class Articles(Page):
     parent_page_types = ["home.HomePage"]
     subpage_types = ["Article"]
     template = "articles.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     description = RichTextField(
@@ -132,6 +135,8 @@ class Article(Page):
     parent_page_types = ["Articles"]
     subpage_types = []
     template = "article.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     description = RichTextField(

--- a/developerportal/apps/common/forms.py
+++ b/developerportal/apps/common/forms.py
@@ -1,0 +1,32 @@
+from wagtail.admin.forms import WagtailAdminPageForm
+from wagtail.core.models import Site
+
+
+def _custom_slug_help_text():
+    # Generate slug help_text that uses the default site’s real URL, falling
+    # back to example.com instead of the Wagtail default.
+    default_site = Site.objects.filter(is_default_site=True).first()
+    base_url = default_site.root_url if default_site else "https://example.com"
+
+    return (
+        f"The name of the page as it will appear in URLs. For example, "
+        f"for an Article: {base_url}/articles/slug/"
+    )
+
+
+class BasePageForm(WagtailAdminPageForm):
+    """Base form class to splice in special behaviour common to all forms
+
+    Currently affects:
+        - SlugField.help_text – adds a Site-aware URL instead of the Wagtail default
+    """
+
+    SLUGFIELD_NAME = "slug"  #  This is default for Wagtail's 'settings' tab
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Find the default slug field, if possible, and patch it
+        slug_field = self.fields.get(self.SLUGFIELD_NAME)
+        if slug_field:
+            slug_field.help_text = _custom_slug_help_text()

--- a/developerportal/apps/common/tests/test_common.py
+++ b/developerportal/apps/common/tests/test_common.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 
-from wagtail.core.models import Page
+from wagtail.admin.edit_handlers import get_form_for_model
+from wagtail.core.models import Page, Site
 
+from ..forms import BasePageForm
 from ..utils import (
     get_combined_articles,
     get_combined_articles_and_videos,
@@ -15,6 +17,7 @@ class UtilsTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
+        # Note: relies on migrations to have populated the test DB
         cls.page = Page.objects.first()
 
     def test_get_combined_articles(self):
@@ -36,3 +39,47 @@ class UtilsTestCase(TestCase):
         """Getting combined articles should not return items."""
         items = get_combined_videos(self.page)
         self.assertEqual(len(items), 0)
+
+
+class BasePageFormTestCase(TestCase):
+    @classmethod
+    def setUp(cls):
+        # Inline import because we need to use a subclass of Page and don't
+        # want to pollute this module more than we have to
+        from developerportal.apps.articles.models import Article
+
+        cls.Article = Article
+
+    def test_help_text_patching__no_site(self):
+        # Note: relies on migrations to have populated the test DB
+        Site.objects.all().delete()
+        assert not Site.objects.exists()
+
+        assert self.Article.base_form_class == BasePageForm
+        FormClass = get_form_for_model(self.Article, form_class=BasePageForm)
+        form = FormClass()
+
+        self.assertEqual(
+            form.fields["slug"].help_text,
+            (
+                "The name of the page as it will appear in URLs. For example, "
+                "for an Article: https://example.com/articles/slug/"
+            ),
+        )
+
+    def test_help_text_patching__has_site(self):
+        # Note: relies on migrations to have populated the test DB
+        assert Site.objects.exists()
+        assert Site.objects.first().hostname == "localhost"
+
+        assert self.Article.base_form_class == BasePageForm
+        FormClass = get_form_for_model(self.Article, form_class=BasePageForm)
+        form = FormClass()
+
+        self.assertEqual(
+            form.fields["slug"].help_text,
+            (
+                "The name of the page as it will appear in URLs. For example, "
+                "for an Article: http://localhost/articles/slug/"
+            ),
+        )

--- a/developerportal/apps/common/wagtail_hooks.py
+++ b/developerportal/apps/common/wagtail_hooks.py
@@ -1,9 +1,7 @@
 # pylint: disable=no-member
-from django.db.utils import ProgrammingError
 from django.utils.html import escape
 
 from wagtail.core import hooks
-from wagtail.core.models import Page, Site
 from wagtail.core.rich_text import LinkHandler
 
 
@@ -26,24 +24,3 @@ class NewWindowExternalLinkHandler(LinkHandler):
 @hooks.register("register_rich_text_features")
 def register_external_link(features):
     features.register_link_type(NewWindowExternalLinkHandler)
-
-
-def _custom_slug_help_text():
-    # Generate slug help_text that uses the default site’s real URL, falling
-    # back to example.com instead of the Wagtail default.
-    default_site = Site.objects.filter(is_default_site=True).first()
-    base_url = default_site.root_url if default_site else "https://example.com"
-    return (
-        f"The name of the page as it will appear in URLs e.g. "
-        f"for an article: {base_url}/articles/slug/"
-    )
-
-
-try:
-    # Apply the custom slug help text to all Page models
-    slug_field = Page._meta.get_field("slug")
-    slug_field.verbose_name = "URL slug"
-    slug_field.help_text = _custom_slug_help_text()
-except ProgrammingError:
-    # This will fail if core migrations have not yet been run
-    pass

--- a/developerportal/apps/content/models.py
+++ b/developerportal/apps/content/models.py
@@ -14,6 +14,7 @@ from wagtail.core.models import Page
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from ..common.fields import CustomStreamField
+from ..common.forms import BasePageForm
 
 
 class ContentPageTag(TaggedItemBase):
@@ -26,6 +27,8 @@ class ContentPage(Page):
     parent_page_types = ["home.HomePage", "content.ContentPage"]
     subpage_types = ["people.People", "content.ContentPage"]
     template = "content.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     hero_image = ForeignKey(

--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -35,6 +35,7 @@ from django_countries.fields import CountryField
 from ..common.blocks import AgendaItemBlock, ExternalSpeakerBlock, FeaturedExternalBlock
 from ..common.constants import RICH_TEXT_FEATURES_SIMPLE
 from ..common.fields import CustomStreamField
+from ..common.forms import BasePageForm
 from ..common.utils import get_combined_events
 
 
@@ -66,6 +67,8 @@ class Events(Page):
     parent_page_types = ["home.HomePage"]
     subpage_types = ["events.Event"]
     template = "events.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     featured = StreamField(
@@ -152,6 +155,8 @@ class Event(Page):
     parent_page_types = ["events.Events"]
     subpage_types = []
     template = "event.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     description = RichTextField(

--- a/developerportal/apps/home/models.py
+++ b/developerportal/apps/home/models.py
@@ -23,6 +23,7 @@ from wagtail.core.models import Page
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from ..common.blocks import FeaturedExternalBlock
+from ..common.forms import BasePageForm
 
 
 class HomePageTag(TaggedItemBase):
@@ -41,6 +42,8 @@ class HomePage(Page):
         "videos.Videos",
     ]
     template = "home.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     subtitle = TextField(max_length=250, blank=True, default="")

--- a/developerportal/apps/people/models.py
+++ b/developerportal/apps/people/models.py
@@ -22,6 +22,7 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 
 from ..common.blocks import PersonalWebsiteBlock
 from ..common.constants import RICH_TEXT_FEATURES_SIMPLE, ROLE_CHOICES
+from ..common.forms import BasePageForm
 from .edit_handlers import CustomLabelFieldPanel
 
 
@@ -35,6 +36,8 @@ class People(Page):
     parent_page_types = ["home.HomePage", "content.ContentPage"]
     subpage_types = ["Person"]
     template = "people.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     description = RichTextField(
@@ -122,6 +125,8 @@ class Person(Page):
     parent_page_types = ["People"]
     subpage_types = []
     template = "person.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     job_title = CharField(max_length=250)

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -35,6 +35,7 @@ from ..common.constants import (
     RESOURCE_COUNT_CHOICES,
     RICH_TEXT_FEATURES_SIMPLE,
 )
+from ..common.forms import BasePageForm
 from ..common.utils import (
     get_combined_articles,
     get_combined_events,
@@ -73,6 +74,8 @@ class Topic(Page):
     parent_page_types = ["Topics"]
     subpage_types = ["Topic"]
     template = "topic.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     description = RichTextField(
@@ -236,6 +239,8 @@ class Topics(Page):
     parent_page_types = ["home.HomePage"]
     subpage_types = ["Topic"]
     template = "topics.html"
+
+    base_form_class = BasePageForm
 
     # Meta fields
     keywords = ClusterTaggableManager(through=TopicsTag, blank=True)

--- a/developerportal/apps/videos/models.py
+++ b/developerportal/apps/videos/models.py
@@ -32,6 +32,7 @@ import readtime
 
 from ..common.blocks import ExternalLinkBlock
 from ..common.constants import RICH_TEXT_FEATURES, RICH_TEXT_FEATURES_SIMPLE, VIDEO_TYPE
+from ..common.forms import BasePageForm
 from ..common.utils import get_combined_articles_and_videos
 
 
@@ -52,6 +53,8 @@ class Videos(Page):
     parent_page_types = ["home.HomePage"]
     subpage_types = ["Video"]
     template = "videos.html"
+
+    base_form_class = BasePageForm
 
     # Meta fields
     keywords = ClusterTaggableManager(through=VideosTag, blank=True)
@@ -105,6 +108,8 @@ class Video(Page):
     parent_page_types = ["Videos"]
     subpage_types = []
     template = "video.html"
+
+    base_form_class = BasePageForm
 
     # Content fields
     description = RichTextField(


### PR DESCRIPTION
This changeset addresses the (minor) risk of somoene accidentially creating `wagtailcore` migrations that then could block an upgrade.

The root seems to be that attempting to patch `SomePageModel.some_field.help_text` at runtime is will change the underlying `Page` class definition by the time the migrations inspector reaches it, triggering the creation of a false/bogus migration.

 (Resolves issue #136 )

## Key changes

I tried patching at the `FieldPanel` level, as done elsewhere in the project for the a `label`, but it turns out (confirmed by a core Wagtail dev in the project Slack) that `help_text` is not currently patchable. Instead, using a base form class became the next workable approach.

Python tests passing. Also added a light test to prove that the update to help_text works.

Manually checked, locally and it's fine. 
eg, when the Site.hostname is localhost, on port 8000 the help text picks it up:

<img width="239" alt="Screenshot 2019-09-19 at 11 17 19" src="https://user-images.githubusercontent.com/101457/65243284-f8e79700-dadf-11e9-80fd-684996a5c619.png">

Note that we could go into detail and make `articles` reflect the actual page type involved, but that felt like a step too far right now.

## How to test

- Check out this branch and get it running
- Add/edit any page which has a slug in its Settings tab (eg Article, People, Video,  Topic etc)
- Confirm help text mentions your local build's hostname, not the Wagtail default of `domain.com` 