### PR TITLE
Revert "Update dependency django-bakery to v0.12.7"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ botocore==1.12.199
 certifi==2019.9.11
 chardet==3.0.4
 cssselect==1.1.0
-django-bakery==0.12.7
+django-bakery==0.12.3
 django-countries==5.5
 django-modelcluster==4.4
 django-taggit==0.24


### PR DESCRIPTION
Reverts mdn/developer-portal#163 -- 0.12.3 is a fixed requirement of wagtail-bakery, so better to wait for the upgrade to be led by that. I'll open an issue over there to check.