### PR TITLE
Downgrade Beautiful soup from 4.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ wagtail-bakery==0.3.0
 whitenoise==4.1.3
 ## The following requirements were added by pip freeze:
 appdirs==1.4.3
-beautifulsoup4==4.8.0
+beautifulsoup4==4.6.1
 boto3==1.9.232
 botocore==1.12.232
 certifi==2019.9.11


### PR DESCRIPTION
Because of:
> ERROR: wagtail 2.6 has requirement beautifulsoup4<4.6.1,>=4.5.1, but you'll have beautifulsoup4 4.8.0 which is incompatible.

Was 4.6.0 originally, going with 4.6.1 instead
