### PR TITLE
Further downgrade beautifulsoup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ wagtail-bakery==0.3.0
 whitenoise==4.1.3
 ## The following requirements were added by pip freeze:
 appdirs==1.4.3
-beautifulsoup4==4.6.1
+beautifulsoup4==4.6.0
 boto3==1.9.232
 botocore==1.12.232
 certifi==2019.9.11


### PR DESCRIPTION
Effectively reinstating pre-renovatebot version to silence compat grumbles from `pipdeptree`
