### PR TITLE
133: Sort out URL of published static site, so that page links don't point back to the CMS's rendered pages

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -212,12 +212,23 @@ WAGTAILIMAGES_IMAGE_MODEL = "mozimages.MozImage"
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 BASE_URL = os.environ.get("BASE_URL")
 
+
 # Wagtail Bakery Settings
 BUILD_DIR = os.path.join(BASE_DIR, "build")
 BAKERY_MULTISITE = True
 BAKERY_VIEWS = ("wagtailbakery.views.AllPublishedPagesView",)
 AWS_REGION = os.environ.get("AWS_REGION")
 AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME")
+
+# Explicit configuration of where the 'baked' site will end up. This needs to match
+# the root URL of the developerportal Site in Wagtail's configuration, because
+# THAT value (Site.hostname) is what determines the domain used in any absolute
+# URLs generated.
+# However, we need to also have that root URL available here, because we must add it to
+# ALLOWED_HOSTS, else we will hit `DisallowedHost:Invalid HTTP_HOST header` during
+# baking in production mode, which then outputs all pages saying "400 Bad Request".
+
+EXPORTED_SITE_URL = os.environ.get("EXPORTED_SITE_URL")  # eg https://example.net
 
 # Static build management commands called in order
 STATIC_BUILD_PIPELINE = (("Build", "build"), ("Publish", "publish"))

--- a/developerportal/settings/production.py
+++ b/developerportal/settings/production.py
@@ -1,12 +1,24 @@
 from urllib.parse import urlparse
 
-from .base import *
+from .base import *  # noqa
 
 DEBUG = False
 DEBUG_PROPAGATE_EXCEPTIONS = True
-ALLOWED_HOSTS = [urlparse(BASE_URL).hostname] if BASE_URL else []
+
+ALLOWED_HOSTS = []
+
+if BASE_URL:
+    # This is the URL that Wagtail's CMS runs on.
+    ALLOWED_HOSTS.append(urlparse(BASE_URL).hostname)
+
+if EXPORTED_SITE_URL:
+    # This is the URL the static/baked site will be served from.
+    # It is different from the BASE_URL (where Wagtail is).
+    # We need it in ALLOWED_HOSTS to avoid `DisallowedHost`
+    # during baking
+    ALLOWED_HOSTS.append(urlparse(EXPORTED_SITE_URL).hostname)
 
 try:
-    from .local import *
+    from .local import *  # noqa
 except ImportError:
     pass

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -24,6 +24,7 @@ export APP_MEMORY_REQUEST ?= 2Gi
 export APP_GUNICORN_WORKERS ?= 3
 export APP_GUNICORN_TIMEOUT ?= 118
 export APP_BASE_URL ?= https://${APP_HOST}
+export APP_EXPORTED_SITE_URL ?= https://${APP_EXPORTED_SITE_HOST}
 export APP_MOUNT_PATH ?= /app/media
 
 export GOOGLE_ANALYTICS ?= 0

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -5,6 +5,8 @@
               value: "{{ APP_AWS_BUCKET_REGION }}"
             - name: BASE_URL
               value: "{{ APP_BASE_URL }}"
+            - name: EXPORTED_SITE_URL
+              value: "{{ APP_EXPORTED_SITE_URL }}"
             - name: DJANGO_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/k8s/config/stage-oregon.sh
+++ b/k8s/config/stage-oregon.sh
@@ -20,6 +20,7 @@ export APP_MEMORY_LIMIT=4Gi
 export APP_MEMORY_REQUEST=2Gi
 export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-stage.mdn.mozit.cloud
+export APP_EXPORTED_SITE_HOST=developer-portal-published.stage.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
 export APP_AWS_BUCKET_REGION=us-west-2
 export APP_MOUNT_PATH=/app/media

--- a/k8s/config/stage.sh
+++ b/k8s/config/stage.sh
@@ -20,6 +20,7 @@ export APP_MEMORY_LIMIT=4Gi
 export APP_MEMORY_REQUEST=2Gi
 export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-dev.mdn.mozit.cloud
+export APP_EXPORTED_SITE_HOST=developer-portal-published.dev.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
 export APP_AWS_BUCKET_REGION=us-west-2
 export APP_MOUNT_PATH=/app/media


### PR DESCRIPTION
This changeset addresses the problem that the "baked out" (static) site in S3 contains URLs for pages that link back to the original Wagtail CMS site, not the FQDN of the S3 bucket.

The root cause was basically that the configured Wagtail `Site`'s hostname needs to be the FQDN that is mapped to the S3 bucket, rather than the same hostname that the CMS itself is running on.

However, while this initially just looked like a data tweak, work was needed to make available that same hostname as a URL we can use in `settings.ALLOWED_HOSTS`, else the publishing step (in non-DEBUG mode) would blow up with `DisallowedHost:Invalid HTTP_HOST header`.

(Resolves issue #133 )

## Key changes:

- Add support for an explicit EXPORTED_SITE_URL in settings 
  - Please read commit 70d5e01 for details

- Update k8s staging config with EXPORTED_SITE_URL 
  - IMPORTANT: given that `stage.sh` mentions `dev` in the value used for BASE_URL while `stage-oregon.sh` mentions `stage` for that variable, I've basically made up a new FQDN for the `dev` config, even though it doesn't exist yet (which is fine because the dev deployment appears not to be up anyway). Having both of the configurations point to the same published/static staging FQDN didn't seem sensible, because of the confusion it would cause. **I'm totally open to being told this isn't legit** - please do shout if so 😄 

## How to test

- check out local build
- update the hostname of the Site in Wagtail admin to be something different from the default `localhost` and save
- confirm the CMS site still responds (bounce docker then reload some CMS views, view live pages, etc) -- the Site change won't have broken that.
- run the static build (just the build is enough - I don't think we need to push to S3 to test this) with an env setting for EXPORTED_SITE_URL that matches the domain you configured for the site - eg:
```
docker-compose exec -e EXPORTED_SITE_URL="https://example.net" app python manage.py build --settings=developerportal.settings.production -v3
```
- shell into the `app` Docker container 
- cd into `build` 
- inspect the contents of `index.html` -- where previously you'd have seen `localhost` you will see the hostname you've configured for the main Site.

eg:

![Screenshot 2019-09-20 at 15 33 13](https://user-images.githubusercontent.com/101457/65337333-d9c03680-dbbf-11e9-8621-f71528d17113.png)

![Screenshot 2019-09-20 at 15 33 22](https://user-images.githubusercontent.com/101457/65337334-da58cd00-dbbf-11e9-9a89-80fec5dabaaa.png)

If you have an uploaded image in a page,  you will see thatit still has the (expected) relative path:
![Screenshot 2019-09-20 at 15 33 31](https://user-images.githubusercontent.com/101457/65337335-da58cd00-dbbf-11e9-8985-5939da97730a.png)

