### PR TITLE
22: Enable SSL redirect and other security settings

### DIFF
--- a/developerportal/apps/bakery/views.py
+++ b/developerportal/apps/bakery/views.py
@@ -1,0 +1,39 @@
+import logging
+
+from django.conf import settings
+from django.test.client import RequestFactory
+
+from wagtailbakery.views import AllPublishedPagesView
+
+logger = logging.getLogger(__name__)
+
+
+class AllPublishedPagesViewAllowingSecureRedirect(AllPublishedPagesView):
+    """Extension of `AllPublishedPagesView` that detects application-level SSL
+    redirection in order to avoid an issue where rendered pages end up being 0 bytes
+
+    See https://github.com/wagtail/wagtail-bakery/issues/24 for confirmation of the
+    issue and the discussion on https://github.com/wagtail/wagtail-bakery/pull/25
+    that points to a custom view being the (current) workaround. Ideally we'll be
+    able to replace this when that issue is resolved.
+
+    The following code is taken from that closed PR, which adds the `secure_request`
+    variable.
+    """
+
+    def build_object(self, obj):
+        """
+        Build wagtail page and set SERVER_NAME to retrieve corresponding site
+        object.
+        """
+        site = obj.get_site()
+        logger.debug("Building %s" % obj)
+        secure_request = site.port == 443 or getattr(
+            settings, "SECURE_SSL_REDIRECT", False
+        )
+        self.request = RequestFactory(SERVER_NAME=site.hostname).get(
+            self.get_url(obj), secure=secure_request
+        )
+        self.set_kwargs(obj)
+        path = self.get_build_path(obj)
+        self.build_file(path, self.get_content(obj))

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -188,6 +188,16 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = "/media/"
 
 
+# Django security settings (see `manage.py check --deploy`)
+
+CSRF_COOKIE_SECURE = True
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+SECURE_SSL_REDIRECT = True
+SESSION_COOKIE_SECURE = True
+X_FRAME_OPTIONS = "DENY"
+
 # Wagtail settings
 
 WAGTAIL_SITE_NAME = "Mozilla Developers"

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -225,7 +225,9 @@ BASE_URL = os.environ.get("BASE_URL")
 # Wagtail Bakery Settings
 BUILD_DIR = os.path.join(BASE_DIR, "build")
 BAKERY_MULTISITE = True
-BAKERY_VIEWS = ("wagtailbakery.views.AllPublishedPagesView",)
+BAKERY_VIEWS = (
+    "developerportal.apps.bakery.views.AllPublishedPagesViewAllowingSecureRedirect",
+)
 AWS_REGION = os.environ.get("AWS_REGION")
 AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME")
 

--- a/developerportal/settings/dev.py
+++ b/developerportal/settings/dev.py
@@ -8,6 +8,7 @@ ALLOWED_HOSTS = ["*"]
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
+SECURE_SSL_REDIRECT = False
 
 try:
     from .local import *


### PR DESCRIPTION
This changeset deals with the need for an application-level redirect from HTTP to HTTPS without causing a redirect loop.

It also enables all-but-one of the recomended Django security settings as defaults (HSTS being the exception.)

It also deals with a regression that occurs with wagtail-bakery when that SSL redirect is enabled.

When deployed, it should resolve issue #22.

## Key changes:

- **Enable recommended-by-Django security settings as defaults**

    The base settings now follow all-but-one of the recommendations from manage.py `check --deploy`.
    The only one that's not been done in this changeset is SECURE_HSTS_SECONDS, because of the risk of "serious, irreversible problems". That needs to be planned in to enable it properly.

    Note that we're explicitly setting what HTTP header to look for to detect the SSL-forwarded header, which should stop the redirect loop in production.

    Development settings turn off SSL redirect, because the local build isn't set to use HTTPS. (It could be tweaked to use HTTPS, too - but that's out of scope for this piece)

- **Address issue with wagtail-bakery where SECURE_SSL_REDIRECT=True bakes out empty HTML**

    This commit subclasses wagtail-bakery's `AllPublishedPagesView` in a way that detects
    application-level SSL redirection in order to avoid an issue where rendered pages end up
    being 0 bytes.

    See https://github.com/wagtail/wagtail-bakery/issues/24 for confirmation of the
    issue and the discussion on https://github.com/wagtail/wagtail-bakery/pull/25
    that points to a custom view being the (current) workaround. Ideally we'll be
    able to replace this when that issue is resolved.

    The code in this commit is basically taken from that closed PR, which adds the
    `secure_request` variable. Hat-tip to @loicteixeira - thanks!

    No unit test added, but manually tested locally to confirm this does indeed fix the
    static build while `SECURE_SSL_REDIRECT` is `True`

## How to test

Because the local docker setup (currently?) has no HTTPS support, this will need to be tested in staging. However, it is possible to test that the static site can be baked out when `SECURE_SSL_REDIRECT` is `True` by using the same steps as from PR #195 
- check out local build
- update the hostname of the Site in Wagtail admin to be something different from the default `localhost` and save
- confirm the CMS site still responds (bounce docker then reload some CMS views, view live pages, etc) -- the Site change won't have broken that.
- run the static build (just the build is enough - I don't think we need to push to S3 to test this) with an env setting for EXPORTED_SITE_URL that matches the domain you configured for the site - eg:
```
docker-compose exec -e EXPORTED_SITE_URL="https://example.net" app python manage.py build --settings=developerportal.settings.production -v3
```
- shell into the `app` Docker container 
- cd into `build` 
- inspect the contents of `index.html` -- where previously you'd have seen `localhost` you will see the hostname you've configured for the main Site.

eg:

![Screenshot 2019-09-20 at 15 33 13](https://user-images.githubusercontent.com/101457/65337333-d9c03680-dbbf-11e9-8621-f71528d17113.png)


