### PR TITLE
133: Address problem of static/S3-site URLs linking back to Wagtail live views

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -212,12 +212,23 @@ WAGTAILIMAGES_IMAGE_MODEL = "mozimages.MozImage"
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 BASE_URL = os.environ.get("BASE_URL")
 
+
 # Wagtail Bakery Settings
 BUILD_DIR = os.path.join(BASE_DIR, "build")
 BAKERY_MULTISITE = True
 BAKERY_VIEWS = ("wagtailbakery.views.AllPublishedPagesView",)
 AWS_REGION = os.environ.get("AWS_REGION")
 AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME")
+
+# Explicit configuration of where the 'baked' site will end up. This needs to match
+# the root URL of the developerportal Site in Wagtail's configuration, because
+# THAT value (Site.hostname) is what determines the domain used in any absolute
+# URLs generated.
+# However, we need to also have that root URL available here, because we must add it to
+# ALLOWED_HOSTS, else we will hit `DisallowedHost:Invalid HTTP_HOST header` during
+# baking in production mode, which then outputs all pages saying "400 Bad Request".
+
+EXPORTED_SITE_URL = os.environ.get("EXPORTED_SITE_URL")  # eg https://example.net
 
 # Static build management commands called in order
 STATIC_BUILD_PIPELINE = (("Build", "build"), ("Publish", "publish"))

--- a/developerportal/settings/production.py
+++ b/developerportal/settings/production.py
@@ -1,12 +1,24 @@
 from urllib.parse import urlparse
 
-from .base import *
+from .base import *  # noqa
 
 DEBUG = False
 DEBUG_PROPAGATE_EXCEPTIONS = True
-ALLOWED_HOSTS = [urlparse(BASE_URL).hostname] if BASE_URL else []
+
+ALLOWED_HOSTS = []
+
+if BASE_URL:
+    # This is the URL that Wagtail's CMS runs on.
+    ALLOWED_HOSTS.append(urlparse(BASE_URL).hostname)
+
+if EXPORTED_SITE_URL:
+    # This is the URL the static/baked site will be served from.
+    # It is different from the BASE_URL (where Wagtail is).
+    # We need it in ALLOWED_HOSTS to avoid `DisallowedHost`
+    # during baking
+    ALLOWED_HOSTS.append(urlparse(EXPORTED_SITE_URL).hostname)
 
 try:
-    from .local import *
+    from .local import *  # noqa
 except ImportError:
     pass

--- a/developerportal/templates/atoms/social-meta.html
+++ b/developerportal/templates/atoms/social-meta.html
@@ -1,5 +1,6 @@
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
+{% load app_tags %}
 
 <meta property="og:title" content="{{ page.title }}">
 {% if page.card_description %}
@@ -11,20 +12,20 @@
     <meta property="og:site_name" content="{{ site_name }}">
   {% endif %}
 {% endwith %}
-{% with request.site.root_url as base_url %}
-  {% if page.card_image or page.image %}
-    {% if page.card_image %}
-      {% image page.card_image width-1200 as image %}
-      <meta property="og:image" content="{{ base_url }}{{ image.url }}">
-      <meta property="og:image:width" content="{{ image.width }}">
-      <meta property="og:image:height" content="{{ image.height }}">
-    {% else %}
-      {% image page.image width-1200 as image %}
-      <meta property="og:image" content="{{ base_url }}{{ image.url }}">
-      <meta property="og:image:width" content="{{ image.width }}">
-      <meta property="og:image:height" content="{{ image.height }}">
-    {% endif %}
+
+{% get_scheme_and_host request as base_url %}
+{% if page.card_image or page.image %}
+  {% if page.card_image %}
+    {% image page.card_image width-1200 as image %}
+    <meta property="og:image" content="{{ base_url }}{{ image.url }}">
+    <meta property="og:image:width" content="{{ image.width }}">
+    <meta property="og:image:height" content="{{ image.height }}">
+  {% else %}
+    {% image page.image width-1200 as image %}
+    <meta property="og:image" content="{{ base_url }}{{ image.url }}">
+    <meta property="og:image:width" content="{{ image.width }}">
+    <meta property="og:image:height" content="{{ image.height }}">
   {% endif %}
-  <meta property="og:url" content="{{ base_url }}{% pageurl page %}">
-{% endwith %}
+{% endif %}
+<meta property="og:url" content="{{ base_url }}{% pageurl page %}">
 <meta name="twitter:card" content="summary_large_image">

--- a/developerportal/templates/header.html
+++ b/developerportal/templates/header.html
@@ -1,14 +1,14 @@
 {% load app_tags %}
 {% load wagtailcore_tags %}
 
-{% with base_url=request.site.root_url home_page=request.site.root_page %}
+{% with home_page=request.site.root_page %}
   <header class="header">
     <div class="mzp-c-navigation">
       <div class="mzp-c-navigation-l-content">
         <div class="mzp-c-navigation-container">
           <button class="mzp-c-navigation-menu-button" type="button" aria-controls="patterns.organisms.navigation.navigation">Menu</button>
           <div class="mzp-c-navigation-logo">
-            <a href="{{ base_url }}">
+            <a href="/">
               <span class="logo"></span>
               <span class="logo-prefix">Mozilla</span><span class="heading5 logo-text">Developers</span>
             </a>
@@ -23,7 +23,7 @@
                         {% if child_pages %}
                         <span class="mzp-c-menu-title" aria-haspopup="true" aria-controls="mzp-c-menu-panel-{{ page.slug }}">{{ page.title }}</span>
                         {% else %}
-                        <a class="mzp-c-menu-title" href="{{ base_url }}{% pageurl page %}">
+                        <a class="mzp-c-menu-title" href="{{ page.url }}">
                           {{ page.title }}
                         </a>
                         {% endif %}
@@ -38,7 +38,7 @@
                                   {% for page in child_pages.public.live.in_menu.specific %}
                                     <li>
                                       <section class="mzp-c-menu-item">
-                                        <a class="mzp-c-menu-item-link" href="{{ base_url }}{% pageurl page %}">
+                                        <a class="mzp-c-menu-item-link" href="{{ page.url }}">
                                           <p class="mzp-c-menu-item-title">{{ page.title }}</p>
                                         </a>
                                       </section>

--- a/developerportal/templatetags/app_tags.py
+++ b/developerportal/templatetags/app_tags.py
@@ -35,3 +35,8 @@ def render_gif(block_value):
     if hasattr(block_value, "file") and hasattr(block_value.file, "name"):
         file_url = settings.MEDIA_URL + block_value.file.name
         return mark_safe(f'<img src="{file_url}" alt="">')
+
+
+@register.simple_tag
+def get_scheme_and_host(request):
+    return f"{request.scheme}://{request.get_host()}"

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -24,6 +24,7 @@ export APP_MEMORY_REQUEST ?= 2Gi
 export APP_GUNICORN_WORKERS ?= 3
 export APP_GUNICORN_TIMEOUT ?= 118
 export APP_BASE_URL ?= https://${APP_HOST}
+export APP_EXPORTED_SITE_URL ?= https://${APP_EXPORTED_SITE_HOST}
 export APP_MOUNT_PATH ?= /app/media
 
 export GOOGLE_ANALYTICS ?= 0

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -5,6 +5,8 @@
               value: "{{ APP_AWS_BUCKET_REGION }}"
             - name: BASE_URL
               value: "{{ APP_BASE_URL }}"
+            - name: EXPORTED_SITE_URL
+              value: "{{ APP_EXPORTED_SITE_URL }}"
             - name: DJANGO_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/k8s/config/stage-oregon.sh
+++ b/k8s/config/stage-oregon.sh
@@ -20,6 +20,7 @@ export APP_MEMORY_LIMIT=4Gi
 export APP_MEMORY_REQUEST=2Gi
 export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-stage.mdn.mozit.cloud
+export APP_EXPORTED_SITE_HOST=developer-portal-published.stage.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
 export APP_AWS_BUCKET_REGION=us-west-2
 export APP_MOUNT_PATH=/app/media

--- a/k8s/config/stage.sh
+++ b/k8s/config/stage.sh
@@ -20,6 +20,7 @@ export APP_MEMORY_LIMIT=4Gi
 export APP_MEMORY_REQUEST=2Gi
 export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-dev.mdn.mozit.cloud
+export APP_EXPORTED_SITE_HOST=developer-portal-published.dev.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
 export APP_AWS_BUCKET_REGION=us-west-2
 export APP_MOUNT_PATH=/app/media


### PR DESCRIPTION
This changeset (when combined with a correct configuration for Site.hostname in Wagtail) fixes the issue where the static/baked site was linking back to live wagtail CMS instead of to itself.

The previous swing at this (#195) ~was too complex, and~ had a shortcoming, so I closed it.

Closes #133

--

**Changes:**

* Removed the use in templates of a `base_url` value that points to the Wagtail CMS. This now means that the URLs in any page (live-on-Wagtail or "baked") are relative rather than absolute, which means they are always appropriate for the site being browsed, whether it's the live Wagtail-hosted one or the S3-hosted baked site.

* In addition, for the moments where the hostname _is_ required to build an absolute URL, the main `Site.hostname` value should be set to the URL of the site where the baked site will be deployed, rather than the CMS URL where it's being made and/or live-viewed. (Wagtail can still serve live pages on that CMS URL, even when the hostname is set to the S3 site's domain).

* Related to the above, there is one area (Open Graph `<meta>` tags) where absolute URLs are definitely needed. For this, I've just added a simple template tag which uses the `HttpRequest` to get the scheme and domain, which is set the first`Site`'s `hostname` when the site is being baked out for copying to S3.

* Add support for an explicit EXPORTED_SITE_URL in settings

    Please read commit b314371 for details

* Update k8s staging config with EXPORTED_SITE_URL

    IMPORTANT: given that `stage.sh` mentions `dev` in the value used for `BASE_URL` while `stage-oregon.sh` mentions `stage` for that variable, I've basically made up a new FQDN for the `stage.sh` dev config, even though it doesn't exist yet (which is "OK", because the dev deployment appears not to be up anyway). Having both of the configurations point to the same published/static staging FQDN didn't seem sensible, because of the confusion it would cause. I'm totally open to being told this isn't legit - please do shout if so 😄 

**TLDR:** 
* I've stopped us using absolute URLs based on the `Site` and made them all relative, apart from OG tags, which do need to be absolute.
* Those absolute URLs are made via a templatetag, from the `HTTPRequest`. That `HTTPRequest` is only correctly configured if `Site.hostname` is set to the value of the S3 bucket's hostname, _not_ Wagtail's operating hostname. 
* I've added an extra configuration variable to allow us to export a static site that's not on the same hostname as the Wagtail CMS (ie, `EXPORTED_SITE_URL` must align with whatever `Site.hostname` is now set to)


**Post-deploy actions**
- [ ] Update the `hostname` of the site in the deployment to refer to the S3 bucket's hostname not the one Wagtail is on.

## How to test

- check out local build
- update the hostname of the Site in Wagtail admin to be something different from the default `localhost` and save
- confirm the CMS site still responds (bounce docker then reload some CMS views, view live pages, etc) -- the Site change won't have broken that.
- edit a page where there's a Card to include an image (eg a `Person` page - the card image will appear in Open Graph `<meta>` links.)
- publish the page
- view the live page for that page with the Card associated and view-source to confirm the `og` tags have absolute URIs in them, while all `a` tags have a relative `href`. eg, here's the source of a live CMS page:

<img width="801" alt="Screenshot 2019-09-23 at 18 14 42" src="https://user-images.githubusercontent.com/101457/65467029-55d4ab80-de58-11e9-92fd-13d73e14121d.png">

- run the static build (just the build is enough - I don't think we need to push to S3 to test this) eg, assuming you've set the hostname to be `example.net`:
```
docker-compose exec -e EXPORTED_SITE_URL="https://example.net" app python manage.py build --settings=developerportal.settings.production -v3
```
- shell into the `app` Docker container 
- cd into `build` 
- inspect the contents of the `index.html` for the page with a card that you edited (the directory structure is the same as the URL path). Where in the CMS Live page you'd have seen `localhost` for the absolute URLs for the `og` tags, you will see the hostname you've configured for the main Site. The hyperlinks between baked-out pages will be relative URLs:

eg:

<img width="733" alt="Screenshot 2019-09-23 at 18 14 30" src="https://user-images.githubusercontent.com/101457/65467045-5ff6aa00-de58-11e9-9c91-f9aeb08e49e9.png">

