### PR TITLE
Setup email environment variables

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -26,6 +26,10 @@ export APP_GUNICORN_TIMEOUT ?= 118
 export APP_BASE_URL ?= https://${APP_HOST}
 export APP_MOUNT_PATH ?= /app/media
 
+export EMAIL_HOST ?= email-smtp.us-west-2.amazonaws.com
+export EMAIL_PORT ?= 587
+export EMAIL_USE_TLS ?= True
+
 export GOOGLE_ANALYTICS ?= 0
 
 ###############################

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -45,3 +45,19 @@
                 secretKeyRef:
                   name: dev-portal-secrets
                   key: MAPBOX_ACCESS_TOKEN
+            - name: EMAIL_HOST
+              value: "{{ EMAIL_HOST }}"
+            - name: EMAIL_PORT
+              value: "{{ EMAIL_PORT }}"
+            - name: EMAIL_USE_TLS
+              value: "{{ EMAIL_USE_TLS }}"
+            - name: EMAIL_HOST_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: SES_USER
+            - name: EMAIL_HOST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: SES_PASSWORD


### PR DESCRIPTION
This change allows us to configure django to send email, the username
and password has been configured under k8s secrets and we expose a
couple of settings to allow django to relay mail via amazon SES

(Resolves issue #201)

## Key changes:

- Exposes some email environment variables that django needs to send
email