### PR TITLE
Added default_from_address

### DIFF
--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -51,6 +51,11 @@
               value: "{{ EMAIL_PORT }}"
             - name: EMAIL_USE_TLS
               value: "{{ EMAIL_USE_TLS }}"
+            - name: DEFAULT_FROM_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: SES_FROM_ADDRESS
             - name: EMAIL_HOST_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This sets a default from address for the django app

(Resolves issue #201)

## Key changes:

- Expose DEFAULT_FROM_ADDRESS as an enviroment variable, and the value
gets pulled from k8s secret