### PR TITLE
Update site name from "developers" to "developer"

### DIFF
--- a/developerportal/apps/common/feed.py
+++ b/developerportal/apps/common/feed.py
@@ -4,7 +4,7 @@ from developerportal.apps.articles.models import Article
 
 
 class RssFeeds(Feed):
-    title = "Mozilla Developers articles feed"
+    title = "Mozilla Developer articles feed"
     link = "/article-feed/"
     description = "Articles published"
 

--- a/developerportal/apps/common/fixtures/common.json
+++ b/developerportal/apps/common/fixtures/common.json
@@ -549,7 +549,7 @@
     "fields": {
       "hostname": "localhost",
       "port": 8000,
-      "site_name": "Mozilla Developers",
+      "site_name": "Mozilla Developer",
       "root_page": 3,
       "is_default_site": true
     }

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -200,7 +200,7 @@ X_FRAME_OPTIONS = "DENY"
 
 # Wagtail settings
 
-WAGTAIL_SITE_NAME = "Mozilla Developers"
+WAGTAIL_SITE_NAME = "Mozilla Developer"
 
 # Add support for CodePen oEmbed
 WAGTAILEMBEDS_FINDERS = [

--- a/developerportal/templates/404.html
+++ b/developerportal/templates/404.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}Page not found{% endblock %}
-{% block title_suffix %}- Mozilla Developers{% endblock %}
+{% block title_suffix %}- Mozilla Developer{% endblock %}
 {% block body_class %}full-height{% endblock %}
 {% block content %}
   <main>

--- a/developerportal/templates/500.html
+++ b/developerportal/templates/500.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}Server error{% endblock %}
-{% block title_suffix %}- Mozilla Developers{% endblock %}
+{% block title_suffix %}- Mozilla Developer{% endblock %}
 {% block body_class %}full-height{% endblock %}
 {% block content %}
   <main>

--- a/developerportal/templates/header.html
+++ b/developerportal/templates/header.html
@@ -10,7 +10,7 @@
           <div class="mzp-c-navigation-logo">
             <a href="{{ base_url }}">
               <span class="logo"></span>
-              <span class="logo-prefix">Mozilla</span><span class="heading5 logo-text">Developers</span>
+              <span class="logo-prefix">Mozilla</span><span class="heading5 logo-text">Developer</span>
             </a>
           </div>
           <div class="mzp-c-navigation-items" id="patterns.organisms.navigation.navigation">

--- a/src/css/molecules/header.scss
+++ b/src/css/molecules/header.scss
@@ -63,7 +63,7 @@
 
     .logo-text {
       font-size: 18px;
-      letter-spacing: -0.2px;
+      letter-spacing: 0.8px;
     }
   }
 


### PR DESCRIPTION
This changeset changes the site's name from Mozilla Developers to Mozilla Developer.