### PR TITLE
225: Ensure Homepage-featured Articles have fallback images

### DIFF
--- a/developerportal/templates/molecules/card-featured-primary.html
+++ b/developerportal/templates/molecules/card-featured-primary.html
@@ -1,7 +1,9 @@
+{% load static %}
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
 {% image resource.image width-1024 as image %}
 {% image resource.card_image width-1024 as card_image %}
+{% static "img/placeholders/article.jpg" as fallback_image_url %}
 
 {% if external_page %}
 <a href="{{ resource.url }}" class="card-link" data-type="external_page">
@@ -10,7 +12,7 @@
 {% endif %}
   <div class="card-featured-primary">
     <div class="card-featured-image-wrapper">
-      <div class="card-featured-image" style="background-image: url('{% firstof card_image.url image.url %}')"></div>
+      <div class="card-featured-image" style="background-image: url('{% firstof card_image.url image.url fallback_image_url %}')"></div>
     </div>
     <div class="card-featured-primary-body">
       <div class="card-featured-primary-content">

--- a/developerportal/templates/molecules/card-featured.html
+++ b/developerportal/templates/molecules/card-featured.html
@@ -1,7 +1,9 @@
+{% load static %}
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
 {% image resource.image width-480 as image %}
 {% image resource.card_image width-480 as card_image %}
+{% static "img/placeholders/article.jpg" as fallback_image_url %}
 
 {% if external_page %}
 <a href="{{ resource.url }}" class="card-link" data-type="external_page">
@@ -9,7 +11,7 @@
 <a href="{% pageurl resource %}" class="card-link" data-type="{{ resource.resource_type }}">
 {% endif %}
   <div class="card-featured">
-    <div class="card-featured-image" style="background-image: url('{% firstof card_image.url image.url %}')"></div>
+    <div class="card-featured-image" style="background-image: url('{% firstof card_image.url image.url fallback_image_url %}')"></div>
     <div class="card-featured-content">
       <span class="highlighted featured">Featured</span>
     </div>


### PR DESCRIPTION
If an Article Page's detail and its Card detail both lack an image, there is no fallback image in use, so when the article is featured on the homepage, there is no image:

![Screenshot 2019-09-25 at 15 18 57](https://user-images.githubusercontent.com/101457/65689990-fea42600-e065-11e9-8139-178dd19e0bb5.png)

This changeset addresses that by using the standard article placeholder image.

(Closes #225)

## Key changes:

- Use the standard placeholder image when nothing better is available.

Note that the 960px-wide image is used for both the 480w (card-featured.html) and 1024w (card-featured-primary.html) use-cases, because we can't create Wagtail renditions of images that are not known of in the database. I am assuming likelihood of a primary-featured article lacking an image is low, so I think we can make do with 960px being upscaled to 1024px, partic as the 960px may already be cached. If I'm wrong, we can add a 1024px version to `src/img/placeholders/`

**After**
![Screenshot 2019-09-26 at 13 41 46](https://user-images.githubusercontent.com/101457/65690003-06fc6100-e066-11e9-9b70-38eb73e22c08.png)

## How to test

- Find (or create and publish) some articles with no images or card images. 
- Edit the homepage to feature these articles and publish it
- View the homepage and confirm the fallback images are used
- Slot in some images for the Page itself and/or its Card and re-publish
- Confirm those images are shown instead of the placeholders (Card images take priority over Page images)

