### PR TITLE
Add external icons to external featured cards

### DIFF
--- a/developerportal/templates/molecules/card-featured-primary.html
+++ b/developerportal/templates/molecules/card-featured-primary.html
@@ -16,7 +16,7 @@
       <div class="card-featured-primary-content">
         <div class="featured">Featured</div>
         <div>
-          <h4 class="no-underline">{% firstof resource.card_title resource.title %}</h4>
+          <h4 class="no-underline">{% firstof resource.card_title resource.title %}{% if resource.url %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}</h4>
           {% if resource.card_description %}
             <p>{{ resource.card_description }}</p>
           {% else %}

--- a/developerportal/templates/molecules/card-featured.html
+++ b/developerportal/templates/molecules/card-featured.html
@@ -14,7 +14,7 @@
       <span class="highlighted featured">Featured</span>
     </div>
     <div class="card-featured-caption">
-      <h5 class="no-underline">{% firstof resource.card_title resource.title %}</h5>
+      <h5 class="no-underline">{% firstof resource.card_title resource.title %}{% if resource.url %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}</h5>
     </div>
   </div>
 </a>

--- a/src/css/molecules/card-featured.scss
+++ b/src/css/molecules/card-featured.scss
@@ -18,6 +18,12 @@
       transform: none;
     }
   }
+
+  .icon-external {
+    position: relative;
+    margin-left: 10px;
+    top: -2px;
+  }
 }
 
 .card-featured-primary {


### PR DESCRIPTION
This changeset adds external icons to the headings of external featured cards on the home and topic pages, making it easier for a user to identify that they'll be leaving the site.

## Key changes

- Add icon to headings of external cards.

## How to test

- Add one or more external featured items to either home or topic pages.