### PR TITLE
Hotfix: downgrade some production security settings for local dev

### DIFF
--- a/developerportal/settings/dev.py
+++ b/developerportal/settings/dev.py
@@ -8,7 +8,10 @@ ALLOWED_HOSTS = ["*"]
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
+# Disable production defaults that get in the way of local development
 SECURE_SSL_REDIRECT = False
+CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SECURE = False
 
 try:
     from .local import *


### PR DESCRIPTION
These changes are needed to allow a user to log in locally on a non-HTTPS setup
