### PR TITLE
201: Enable email on staging

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -30,7 +30,6 @@ SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", get_random_secret_key())
 
 
 # Application definition
-
 INSTALLED_APPS = [
     "developerportal.apps.common",
     "developerportal.apps.articles",
@@ -148,6 +147,16 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
+
+
+# Email setup
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.environ.get("EMAIL_HOST")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_PORT = int(os.environ.get("EMAIL_PORT", 587))
+EMAIL_USE_TLS = bool(os.environ.get("EMAIL_USE_TLS", True))
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
 
 
 # Internationalization

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -27,9 +27,9 @@ export APP_BASE_URL ?= https://${APP_HOST}
 export APP_EXPORTED_SITE_URL ?= https://${APP_EXPORTED_SITE_HOST}
 export APP_MOUNT_PATH ?= /app/media
 
-export EMAIL_HOST ?= email-smtp.us-west-2.amazonaws.com
-export EMAIL_PORT ?= 587
-export EMAIL_USE_TLS ?= True
+export APP_EMAIL_HOST ?= email-smtp.us-west-2.amazonaws.com
+export APP_EMAIL_PORT ?= 587
+export APP_EMAIL_USE_TLS ?= True
 
 export GOOGLE_ANALYTICS ?= 0
 

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -48,11 +48,11 @@
                   name: dev-portal-secrets
                   key: MAPBOX_ACCESS_TOKEN
             - name: EMAIL_HOST
-              value: "{{ EMAIL_HOST }}"
+              value: "{{ APP_EMAIL_HOST }}"
             - name: EMAIL_PORT
-              value: "{{ EMAIL_PORT }}"
+              value: "{{ APP_EMAIL_PORT }}"
             - name: EMAIL_USE_TLS
-              value: "{{ EMAIL_USE_TLS }}"
+              value: "{{ APP_EMAIL_USE_TLS }}"
             - name: DEFAULT_FROM_EMAIL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This changeset addresses the lack of being able to send a password reset email on staging by plugging in the now-available email config vars from the environment.

(Resolves #201)

## Key changes:

- Add `APP_` prefix to env var definitions for consistency
- Enable emailing for deployed site by pulling through the env vars that have been set up already.
  Note that `DEFAULT_FROM_EMAIL` uses an address which has been verified with SES, so there should be no sending issues.

## How to test

If you have SMTP credsits to hand (eg, extract your Gmail ones), you can test the email sending config is correct at the CLI.
- check out the branch locally
- add/edit `settings/local.py` to set `EMAIL_BACKEND` to `'django.core.mail.backends.smtp.EmailBackend'` (because it's set to `ConsoleBackend` in `settings/dev.py`
- add the required vals to your `.env`:

````
    EMAIL_HOST=smtp.gmail.com
    EMAIL_HOST_PASSWORD=<password>
    EMAIL_HOST_USER=<YOUR GMAIL HANDLE HERE>@gmail.com
    EMAIL_PORT=587
    EMAIL_USE_TLS=True
    DEFAULT_FROM_EMAIL=<YOUR GMAIL HANDLE HERE>@gmail.com
````

- Bounce your local build (eg `docker-compose down && docker-compose up`)
- Go to the password reset view at http://localhost:8000/admin/password_reset/ and request a reset. Check your email! :smile:

Alternatively, you can test it in the shell, too:

```
$ docker-compose exec app python manage.py shell
Python 3.7.4 (default, Aug 21 2019, 00:19:59)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from django.core.mail import send_mail
>>> from django.conf import settings
>>> settings.EMAIL_BACKEND
'django.core.mail.backends.smtp.EmailBackend'
>>> send_mail("Test email", "Hello, World!", settings.DEFAULT_FROM_EMAIL, ["steve@somefantastic.co"])
1
```