### PR TITLE
137: Prevent past events from showing in resource lists

### DIFF
--- a/developerportal/apps/articles/templates/articles.html
+++ b/developerportal/apps/articles/templates/articles.html
@@ -5,23 +5,21 @@
 
 {% block content %}
   <main>
-    {% if page.articles %}
-      <section class="section section-pattern">
-        <div class="container">
-          <div class="section-header">
-            <div>
-              <h2>Articles</h2>
-              {% if page.description %}
-                <div class="page-description">
-                  {{ page.description | richtext }}
-                </div>
-              {% endif %}
-            </div>
+    <section class="section section-pattern">
+      <div class="container">
+        <div class="section-header">
+          <div>
+            <h2>Articles</h2>
+            {% if page.description %}
+              <div class="page-description">
+                {{ page.description | richtext }}
+              </div>
+            {% endif %}
           </div>
         </div>
-        {% include "organisms/filter-list.html" with type="article" resources=page.articles initial_resources=6 resources_per_page=4 %}
-      </section>
-    {% endif %}
+      </div>
+      {% include "organisms/filter-list.html" with type="article" resources=page.articles initial_resources=6 resources_per_page=4 no_resources_message="No articles found" %}
+    </section>
     {% include "organisms/newsletter-signup.html" %}
   </main>
 {% endblock content %}

--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -139,7 +139,7 @@ class Events(Page):
     @property
     def events(self):
         """Return events in chronological order"""
-        return get_combined_events(self)
+        return get_combined_events(self, start_date__gte=datetime.date.today())
 
     def get_filters(self):
         from ..topics.models import Topic
@@ -330,7 +330,7 @@ class Event(Page):
     @property
     def is_upcoming(self):
         """Returns whether an event is in the future."""
-        return self.start_date > datetime.date.today()
+        return self.start_date >= datetime.date.today()
 
     @property
     def primary_topic(self):

--- a/developerportal/apps/events/templates/events.html
+++ b/developerportal/apps/events/templates/events.html
@@ -9,25 +9,23 @@
 
 {% block content %}
   <main>
-    {% if page.events %}
-      <section class="section{% if not page.featured %} section-pattern{% endif %}">
-        <div class="container">
-          <div class="section-header">
-            <h2>Events</h2>
-          </div>
-          {% for featured_item in page.featured %}
-            {% with featured_item.value.specific as event %}
-              {% include "molecules/cards/card.html" with resource=event featured=True %}
-            {% endwith %}
-          {% endfor %}
+    <section class="section{% if not page.featured %} section-pattern{% endif %}">
+      <div class="container">
+        <div class="section-header">
+          <h2>Events</h2>
         </div>
+        {% for featured_item in page.featured %}
+          {% with featured_item.value.specific as event %}
+            {% include "molecules/cards/card.html" with resource=event featured=True %}
+          {% endwith %}
+        {% endfor %}
+      </div>
       {% if page.featured %}
-      </section>
-      <section class="section section-pattern">
+        </section>
+        <section class="section section-pattern">
       {% endif %}
-        {% include "organisms/filter-list.html" with type="event" resources=page.events initial_resources=6 resources_per_page=4 %}
-      </section>
-    {% endif %}
+      {% include "organisms/filter-list.html" with type="event" resources=page.events initial_resources=6 resources_per_page=4 no_resources_message="No upcoming events found" %}
+    </section>
     {% include "organisms/newsletter-signup.html" %}
   </main>
 {% endblock content %}

--- a/developerportal/apps/people/templates/people.html
+++ b/developerportal/apps/people/templates/people.html
@@ -7,23 +7,21 @@
 
 {% block content %}
   <main>
-    {% if page.people %}
-      <section class="section section-pattern">
-        <div class="container">
-          <div class="section-header">
-            <div>
-              <h2>People</h2>
-              {% if page.description %}
-                <div class="page-description">
-                  {{ page.description | richtext }}
-                </div>
-              {% endif %}
-            </div>
+    <section class="section section-pattern">
+      <div class="container">
+        <div class="section-header">
+          <div>
+            <h2>People</h2>
+            {% if page.description %}
+              <div class="page-description">
+                {{ page.description | richtext }}
+              </div>
+            {% endif %}
           </div>
         </div>
-        {% include "organisms/filter-list.html" with type="person" resources=page.people initial_resources=10 resources_per_page=4 %}
-      </section>
-    {% endif %}
+      </div>
+      {% include "organisms/filter-list.html" with type="person" resources=page.people initial_resources=10 resources_per_page=4 no_resources_message="No people found" %}
+    </section>
     {% include "organisms/newsletter-signup.html" %}
   </main>
 {% endblock content %}

--- a/developerportal/templates/organisms/filter-list.html
+++ b/developerportal/templates/organisms/filter-list.html
@@ -4,39 +4,45 @@
       {% include "atoms/pattern.html" %}
     </div>
     <div class="container">
-      <div class="filter-list-content">
-        <aside class="filter-list-sidebar">
-          <details class="filter-list-sidebar-content filter-list-sidebar-content-mobile">
-            <summary>Filter</summary>
-            {% include "molecules/filter-form.html" with resources=resources filters=filters initial_resources=initial_resources resources_per_page=resources_per_page %}
-          </details>
-          <div class="filter-list-sidebar-content filter-list-sidebar-content-desktop">
-            {% include "molecules/filter-form.html" with resources=resources filters=filters initial_resources=initial_resources resources_per_page=resources_per_page %}
-          </div>
-        </aside>
-        <div class="filter-list-items">
-          <div class="filter-list-no-results" id="js-filter-list-no-results" hidden>
-            <p>No results found with these filters.</p>
-            <button class="mzp-c-button js-filter-clear" type="button">
-              Clear filters
-            </button>
-          </div>
-          <div class="{% if type != 'event' %}card-container{% endif %}" id="{{ type }}-cards">
-            {% for resource in resources %}
-              {% if type == "article" %}
-                {% include "molecules/cards/card.html" with resource=resource.article filter_target=True show_author=True %}
-              {% elif type == "person" %}
-                {% include "molecules/cards/card.html" with resource=resource.person filter_target=True %}
-              {% elif type == "event" %}
-                {% include "molecules/cards/card.html" with resource=resource.event filter_target=True %}
-              {% endif %}
-            {% endfor %}
-          </div>
-          <div class="filter-list-actions" id="js-filter-list-actions">
-            <button class="mzp-c-button" id="js-filter-list-action-next-page" type="button">See more</button>
+      {% if resources %}
+        <div class="filter-list-content">
+          <aside class="filter-list-sidebar">
+            <details class="filter-list-sidebar-content filter-list-sidebar-content-mobile">
+              <summary>Filter</summary>
+              {% include "molecules/filter-form.html" with resources=resources filters=filters initial_resources=initial_resources resources_per_page=resources_per_page %}
+            </details>
+            <div class="filter-list-sidebar-content filter-list-sidebar-content-desktop">
+              {% include "molecules/filter-form.html" with resources=resources filters=filters initial_resources=initial_resources resources_per_page=resources_per_page %}
+            </div>
+          </aside>
+          <div class="filter-list-items">
+            <div class="filter-list-no-results" id="js-filter-list-no-results" hidden>
+              <p>No results found with these filters.</p>
+              <button class="mzp-c-button js-filter-clear" type="button">
+                Clear filters
+              </button>
+            </div>
+            <div class="{% if type != 'event' %}card-container{% endif %}" id="{{ type }}-cards">
+              {% for resource in resources %}
+                {% if type == "article" %}
+                  {% include "molecules/cards/card.html" with resource=resource.article filter_target=True show_author=True %}
+                {% elif type == "person" %}
+                  {% include "molecules/cards/card.html" with resource=resource.person filter_target=True %}
+                {% elif type == "event" %}
+                  {% include "molecules/cards/card.html" with resource=resource.event filter_target=True %}
+                {% endif %}
+              {% endfor %}
+            </div>
+            <div class="filter-list-actions" id="js-filter-list-actions">
+              <button class="mzp-c-button" id="js-filter-list-action-next-page" type="button">See more</button>
+            </div>
           </div>
         </div>
-      </div>
+      {% else %}
+        <div class="filter-list-no-results">
+          <h2>{{ no_resources_message|default:"No resources found" }}</h2>
+        </div>
+      {% endif %}
     </div>
     <div class="pattern-section-pattern pattern-section-pattern-after">
       {% include "atoms/pattern.html" %}

--- a/src/css/organisms/filter-list.scss
+++ b/src/css/organisms/filter-list.scss
@@ -71,8 +71,12 @@
 }
 
 .filter-list-no-results {
-  padding: 140px 0;
+  padding: 100px 0;
   text-align: center;
+
+  h2::after {
+    margin-bottom: 0;
+  }
 }
 
 .filter-list-actions {


### PR DESCRIPTION
This changeset prevents past events from being shown within the events resource lists.

(Resolves #137)

## Key changes:

- Add filter to only return future events within resource lists.
- Move "no resource" logic into filter list component, and add specific message support.

## How to test

- Add events, one future and one past, and check that only the future one is shown in the event list.
- Change the future event's start date to the past and make sure the events directory is empty.