### PR TITLE
Only show "see more" link when a URL exists

### DIFF
--- a/developerportal/templates/molecules/article-author.html
+++ b/developerportal/templates/molecules/article-author.html
@@ -18,6 +18,13 @@
     {% elif author.description %}
       {{ author.description | richtext }}
     {% endif %}
-    <p><a href="{% if author.slug %}{% pageurl author %}{% else %}{{ author.url }}{% endif %}">See more</a></p>
+
+    {% if author.slug %}
+      {% pageurl author as page_url %}
+    {% endif %}
+    {% firstof page_url author.url as url %}
+    {% if url %}
+      <p><a href="{{ url }}"{% if not author.slug %} target="_blank" rel="nofollow noopener"{% endif %}>See more</a></p>
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
This changeset addresses a bug where the "see more" link in external author article descriptions would render, even when no URL was supplied.

## Key changes:

- Conditionally render the "see more" author link on articles, hiding when no URL is present.
- Add `target` and `rel` properties to the link when it's an external URL.

## How to test

- Set an article to have an external author without setting a URL. The link shouldn't render.
- Set the external author's URL to a test URL. The link should open in a new tab.