### PR TITLE
Fix author separators and support multiple avatars

### DIFF
--- a/developerportal/templates/molecules/article-details.html
+++ b/developerportal/templates/molecules/article-details.html
@@ -4,28 +4,36 @@
 
 <div class="article-details">
   {% if authors %}
-    {% with authors.0.value as author %}
-      {% image author.image fill-96x96 as author_image %}
-      {% if author.role == "staff" %}
-        {% static "img/placeholders/mozillian.jpg" as fallback_image %}
-      {% else %}
-        {% static "img/placeholders/person.jpg" as fallback_image %}
-      {% endif %}
-      <img src="{% firstof author_image.url fallback_image %}" alt="">
-    {% endwith %}
-  {% endif %}
-  <div class="article-details-meta">
-    {% if authors %}
-      <p class="article-details-meta-names">
+    <div class="article-details-avatars">
+      {% for block in authors reversed %}
+        {% with block.value as author %}
+          {% image author.image fill-96x96 as author_image %}
+          {% if author.role == "staff" %}
+            {% static "img/placeholders/mozillian.jpg" as fallback_image %}
+          {% else %}
+            {% static "img/placeholders/person.jpg" as fallback_image %}
+          {% endif %}
+          <img src="{% firstof author_image.url fallback_image %}" alt="">
+        {% endwith %}
+      {% endfor %}
+    </div>
+    <div class="article-details-meta">
+      <ul class="article-details-meta-names">
         {% for block in authors %}
           {% with block.value as author %}
-            {% if author.url and not disable_author_links %}
-              <a href="{{ author.url }}">{% endif %}{{ author.title }}{% if author.url and not disable_author_links %}</a>{% if not forloop.last %}, {% endif %}
-            {% endif %}
+            <li>
+              {% if author.url and not disable_author_links %}
+                <a href="{{ author.url }}">
+              {% endif %}
+              {{ author.title }}
+              {% if author.url and not disable_author_links %}
+                </a>
+              {% endif %}
+            </li>
           {% endwith %}
         {% endfor %}
-      </p>
-    {% endif %}
-    <p>{{ date }}</p>
-  </div>
+      </ul>
+      <p>{{ date }}</p>
+    </div>
+  {% endif %}
 </div>

--- a/developerportal/templates/molecules/article-details.html
+++ b/developerportal/templates/molecules/article-details.html
@@ -17,7 +17,9 @@
         {% endwith %}
       {% endfor %}
     </div>
-    <div class="article-details-meta">
+  {% endif %}
+  <div class="article-details-meta">
+    {% if authors %}
       <ul class="article-details-meta-names">
         {% for block in authors %}
           {% with block.value as author %}
@@ -33,7 +35,7 @@
           {% endwith %}
         {% endfor %}
       </ul>
-      <p>{{ date }}</p>
-    </div>
-  {% endif %}
+    {% endif %}
+    <p>{{ date }}</p>
+  </div>
 </div>

--- a/src/css/molecules/article-details.scss
+++ b/src/css/molecules/article-details.scss
@@ -7,6 +7,7 @@
 .article-details-avatars {
   display: flex;
   flex-direction: row-reverse;
+  flex-shrink: 0;
   margin-right: 16px;
 
   img {

--- a/src/css/molecules/article-details.scss
+++ b/src/css/molecules/article-details.scss
@@ -2,12 +2,21 @@
   color: $color-nevada;
   display: flex;
   font-size: 12px;
+}
+
+.article-details-avatars {
+  display: flex;
+  flex-direction: row-reverse;
+  margin-right: 16px;
 
   img {
     border-radius: 50%;
-    height: 48px;
-    margin-right: 16px;
-    width: 48px;
+    height: 42px;
+    width: 42px;
+
+    &:not(:first-child) {
+      margin-right: -16px;
+    }
   }
 }
 
@@ -26,6 +35,20 @@
 
 .article-details-meta-names {
   font-weight: bold;
+  margin-bottom: 4px;
+
+  li {
+    display: inline-block;
+
+    &:not(:last-child) {
+      margin-right: 2px;
+
+      &::after {
+        content: '\00b7';
+        margin-left: 2px;
+      }
+    }
+  }
 
   a {
     color: inherit;

--- a/src/css/molecules/article-details.scss
+++ b/src/css/molecules/article-details.scss
@@ -45,7 +45,7 @@
       margin-right: 2px;
 
       &::after {
-        content: '\00b7';
+        content: '·';
         margin-left: 2px;
       }
     }


### PR DESCRIPTION
This changeset addresses a bug in the author details section where separators were not being added when external authors were present. This changeset fixes the issue by ensuring the separators are added _after_ an external author conditional, and also adds support for multiple overlapping avatars when more than one author is present.

Before:
![Screen Shot 2019-10-02 at 2 59 30 PM](https://user-images.githubusercontent.com/1469007/66050704-981b7e00-e525-11e9-9696-e0bf4cb3526a.png)

After:
![Screen Shot 2019-10-02 at 2 59 04 PM](https://user-images.githubusercontent.com/1469007/66050718-9ea9f580-e525-11e9-9502-08fe1ed1d293.png)

## Key changes

- Ensure separator is added after external author conditional.
- Add overlapping avatars when more than one author is present.

## How to test

- Add multiple authors to an article and ensure the author details section handles these correctly.