### PR TITLE
264: Support automatic creation of S3-side redirects based on Wagtail  Redirects

### DIFF
--- a/developerportal/apps/bakery/tests/test_views.py
+++ b/developerportal/apps/bakery/tests/test_views.py
@@ -1,0 +1,113 @@
+# Tests for the custom views that we feed to wagtail-bakery
+
+from unittest import mock
+
+from django.test import TestCase
+
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.core.models import Page, Site
+
+from developerportal.apps.bakery.views import S3RedirectManagementView
+
+
+class S3RedirectManagementViewTest(TestCase):
+    def setUp(self):
+        self.view = S3RedirectManagementView()
+        self.homepage = Page.objects.last()
+        Site.objects.all().delete()
+        self.site = Site.objects.create(
+            hostname="test", is_default_site=True, root_page=self.homepage
+        )
+
+    @mock.patch("developerportal.apps.bakery.views.get_s3_client")
+    def test_post_publish(self, mock_get_s3_client):
+
+        mock_bucket = mock.Mock("fake-bucket")
+        # Sort out a `name` attribute for the mock S3 Bucket
+        mocked_name = mock.PropertyMock(return_value="devportal_fake")
+        type(mock_bucket).name = mocked_name
+
+        mock_client = mock.Mock("fake-client")
+        mock_put_object = mock.Mock("put_object()")
+        mock_client.put_object = mock_put_object
+
+        mock_resource = mock.Mock("fake-resource")
+
+        mock_get_s3_client.return_value = (mock_client, mock_resource)
+
+        # redirect_to_new_path
+        Redirect.objects.create(
+            old_path="/old_path/here/",
+            redirect_page=self.homepage,  # contrived example, but valid
+            site=self.site,  #  ie, it's only for the default site
+        )
+
+        # redirect_to_separate_url
+        Redirect.objects.create(
+            old_path="/something",
+            redirect_link="https://example.com/test/",
+            site=None,  # ie, it's a pan-Wagtail redirect
+        )
+
+        with self.assertLogs("developerportal.apps.bakery.views", level="INFO") as cm:
+            self.view.post_publish(mock_bucket)
+
+        assert mock_put_object.call_count == 2
+
+        assert mock_put_object.call_args_list[0][1] == {
+            "ACL": "public-read",
+            "Bucket": "devportal_fake",
+            "Key": "old_path/here/",
+            "WebsiteRedirectLocation": "/",
+        }
+
+        assert mock_put_object.call_args_list[1][1] == {
+            "ACL": "public-read",
+            "Bucket": "devportal_fake",
+            "Key": "something",
+            "WebsiteRedirectLocation": "https://example.com/test/",
+        }
+
+        self.assertEqual(
+            cm.output,
+            [
+                (
+                    "INFO:developerportal.apps.bakery.views:Adding S3 Website "
+                    "Redirect in devportal_fake from old_path/here/ to /"
+                ),
+                (
+                    "INFO:developerportal.apps.bakery.views:Adding S3 Website "
+                    "Redirect in devportal_fake from something to "
+                    "https://example.com/test/"
+                ),
+            ],
+        )
+
+    @mock.patch("developerportal.apps.bakery.views.get_s3_client")
+    def test_post_publish__no_redirects_exist(self, mock_get_s3_client):
+
+        mock_bucket = mock.Mock("fake-bucket")
+        mock_client = mock.Mock("fake-client")
+        mock_put_object = mock.Mock("put_object()")
+        mock_client.put_object = mock_put_object
+        mock_resource = mock.Mock("fake-resource")
+
+        mock_get_s3_client.return_value = (mock_client, mock_resource)
+
+        # redirect_to_new_path
+        assert not Redirect.objects.exists()
+
+        with self.assertLogs("developerportal.apps.bakery.views", level="INFO") as cm:
+            self.view.post_publish(mock_bucket)
+
+        assert mock_put_object.call_count == 0
+
+        self.assertEqual(
+            cm.output,
+            [
+                (
+                    "INFO:developerportal.apps.bakery.views:No Wagtail Redirects "
+                    "detected, so no S3 Website Redirects to create."
+                )
+            ],
+        )

--- a/developerportal/apps/bakery/views.py
+++ b/developerportal/apps/bakery/views.py
@@ -1,9 +1,14 @@
 import logging
 
 from django.conf import settings
+from django.db.models import Q
 from django.test.client import RequestFactory
 
-from wagtailbakery.views import AllPublishedPagesView
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.core.models import Site
+
+from bakery.management.commands import get_s3_client
+from wagtailbakery.views import AllPublishedPagesView, WagtailBakeryView
 
 logger = logging.getLogger(__name__)
 
@@ -37,3 +42,73 @@ class AllPublishedPagesViewAllowingSecureRedirect(AllPublishedPagesView):
         self.set_kwargs(obj)
         path = self.get_build_path(obj)
         self.build_file(path, self.get_content(obj))
+
+
+class S3RedirectManagementView(WagtailBakeryView):
+    """Buildable "view" that generates S3-native redirects for each
+    Wagtail Redirect that exists.
+
+    Only produces results upon publish() not build().
+
+    It's a slight hack, in that it's one view that produces multiple
+    redirects in S3 and noops the actual build step, but it slots in
+    nicely to django-bakery's pipeline approach.
+    """
+
+    def build_method(self):
+        # We don't want to do something on Build, only after Publish
+        return None
+
+    def get_redirect_url(self, redirect):
+        """If the redirect points to a Page, generate a relative path,
+        else return the URL to redirect to instead."""
+
+        if redirect.redirect_page:
+            path = redirect.redirect_page.get_url()
+            assert path[0] == "/"  # has to lead with a slash else S3 will choke
+            return path
+
+        return redirect.redirect_link  #  a URL
+
+    def tidy_path(self, path):
+        return path[1:]  #  strip leading slash
+
+    def post_publish(self, bucket):
+        """
+        Set up an S3-side redirect for all Wagtail Redirects
+
+        This is inspired by django-bakery's BuildableRedirectView.post_publish method
+        and gets called as part of the `publish` management command
+        """
+        s3_client, s3_resource = get_s3_client()
+
+        #  For now, we're assuming we're only handling the default site
+        site = Site.objects.filter(is_default_site=True).first()
+        if not site:
+            logger.warning("No default Site found - skipping generation of redirects")
+            return
+
+        no_site_q = Q(site__isnull=True)
+        this_site_q = Q(site=site)
+        redirects = Redirect.objects.filter(no_site_q | this_site_q)
+
+        if not redirects:
+            logger.info(
+                "No Wagtail Redirects detected, so no S3 Website Redirects to create"
+            )
+
+        for redirect in redirects:
+            original_dest = self.tidy_path(redirect.old_path)
+            new_dest = self.get_redirect_url(redirect)
+
+            logger.info(
+                (
+                    "Adding S3 Website Redirect in {bucket_name} from {old} to {new}"
+                ).format(old=original_dest, bucket_name=bucket.name, new=new_dest)
+            )
+            s3_client.put_object(
+                ACL="public-read",
+                Bucket=bucket.name,
+                Key=original_dest,
+                WebsiteRedirectLocation=new_dest,
+            )

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -237,6 +237,7 @@ BUILD_DIR = os.path.join(BASE_DIR, "build")
 BAKERY_MULTISITE = True
 BAKERY_VIEWS = (
     "developerportal.apps.bakery.views.AllPublishedPagesViewAllowingSecureRedirect",
+    "developerportal.apps.bakery.views.S3RedirectManagementView",
 )
 AWS_REGION = os.environ.get("AWS_REGION")
 AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME")


### PR DESCRIPTION
This changeset adds a custom view which is used by wagtail-bakery (django-bakery
really) to set up AWS S3 Webpage Redirects[1] based on any configured Wagtail
Redirects for the default Site or for all Sites.

Once all the regular pages have been published to S3, the new view triggers the
creation of the appropriate S3 Website Redirects. wagtail-bakery/django-bakery
also takes care of tearing down existing redirects before re-adding them. (Note
that these redirects may remain cached by a browser, so if a redirect is removed
from Wagtail and removed from S3, some users may still see the redirection
happen until their browser invalidates the cache, which may be never unless
it's manually zapped.)

[1] (https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html)

(Resolves #264)

## Key changes:

- Add bespoke view with a no-op build step but a post-publish step that sets up S3 redirects
- Ensure this bespoke view is picked up by wagtail-bakery
- Add tests


## See for yourself

I've _temporarily_ pushed a dummy static version of the site to my S3 bucket as [a website](http://devportalstatictest.s3-website-eu-west-1.amazonaws.com/). It's not got real content in pages, of course, but we can still use it to confirm the S3 redirects are working OK.

I have the following redirects enabled:

1. http://devportalstatictest.s3-website-eu-west-1.amazonaws.com/vidz -> http://devportalstatictest.s3-website-eu-west-1.amazonaws.com/videos/

2. http://devportalstatictest.s3-website-eu-west-1.amazonaws.com/things -> http://devportalstatictest.s3-website-eu-west-1.amazonaws.com/topics/

3. http://devportalstatictest.s3-website-eu-west-1.amazonaws.com/foo/bar -> https://example.com/

Try them out!

Also, here you can see confirmation of what gets created in S3:

Internal redirect
<img width="601" alt="Screenshot 2019-10-02 at 15 43 43" src="https://user-images.githubusercontent.com/101457/66086464-126ef100-e56c-11e9-8a06-ae7683aa1f85.png">
<img width="598" alt="Screenshot 2019-10-02 at 15 43 39" src="https://user-images.githubusercontent.com/101457/66086463-126ef100-e56c-11e9-9cfc-eae5b709cab3.png">

External redirect
<img width="598" alt="Screenshot 2019-10-02 at 15 43 53" src="https://user-images.githubusercontent.com/101457/66086485-1ef34980-e56c-11e9-9d07-32eb60696512.png">
<img width="596" alt="Screenshot 2019-10-02 at 15 43 58" src="https://user-images.githubusercontent.com/101457/66086486-1ef34980-e56c-11e9-996f-835a5c653325.png">

And here's an example of CLI output

```
/app # ./manage.py publish
INFO:developerportal.apps.bakery.views:Adding S3 redirect header in devportalstatictest from things to /topics/
INFO:developerportal.apps.bakery.views:Adding S3 redirect header in devportalstatictest from vidz to /videos/
INFO:developerportal.apps.bakery.views:Adding S3 redirect header in devportalstatictest from foo/bar to https://example.com/
INFO:bakery.management.commands.publish:Publish completed, 0 uploaded and 3 deleted files in 2.34 seconds
Publish completed, 0 uploaded and 3 deleted files in 2.34 seconds
```

And here's an example where a redirect that was published to S3 has been removed from Wagtal, resulting in 3 things purged and 2 re-added:
```
/app # ./manage.py publish
Deleting 3 keys
INFO:developerportal.apps.bakery.views:Adding S3 redirect header in devportalstatictest from vidz to /videos/
INFO:developerportal.apps.bakery.views:Adding S3 redirect header in devportalstatictest from foo/bar to https://example.com/
INFO:bakery.management.commands.publish:Publish completed, 0 uploaded and 3 deleted files in 2.47 seconds
Publish completed, 0 uploaded and 3 deleted files in 2.47 seconds
```

While (`"Publish completed, 0 uploaded and 3 deleted files in 2.47 seconds"` isn't the best output, that's from django-bakery, so amending that is not in scope right now)

## How to test

- Set the following in your settings/local.py:

```
    AWS_ACCESS_KEY_ID
    AWS_SECRET_ACCESS_KEY
    AWS_BUCKET_NAME
    AWS_REGION
```
and add `DEBUG = False`

- ensure the target S3 bucket exists
- add some redirects at http://localhost:8000/admin/redirects/
- generate a static build with `docker-compose exec app python manage.py build`
- publish that build with `docker-compose exec app python manage.py publish` -- note the output at the end showing the redirects were made.
- Enable website hosting for your S3 bucket and browse to it.
- Visit a redirection URL and confirm it redirects to the expected destination you set up
- Remove a redirect from the Wagtail admin
- run `docker-compose exec app python manage.py publish` -- see how all the existing redirectsa are torn down before the current one(s) are re-added.
- Visit the same redirection URL, which your browser has cached - it will still redirect
- Clear the browser cache for the last hour or so and try the redirect URL again - this time it will fail 

