### PR TITLE
Handle external resource icons as well as links

### DIFF
--- a/developerportal/templates/molecules/card-featured-primary.html
+++ b/developerportal/templates/molecules/card-featured-primary.html
@@ -18,7 +18,7 @@
       <div class="card-featured-primary-content">
         <div class="featured">Featured</div>
         <div>
-          <h4 class="no-underline">{% firstof resource.card_title resource.title %}{% if external_page %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}</h4>
+          <h4 class="no-underline">{% firstof resource.card_title resource.title %}{% if external_page or resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}</h4>
           {% if resource.card_description %}
             <p>{{ resource.card_description }}</p>
           {% else %}

--- a/developerportal/templates/molecules/card-featured.html
+++ b/developerportal/templates/molecules/card-featured.html
@@ -16,7 +16,7 @@
       <span class="highlighted featured">Featured</span>
     </div>
     <div class="card-featured-caption">
-      <h5 class="no-underline">{% firstof resource.card_title resource.title %}{% if external_page %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}</h5>
+      <h5 class="no-underline">{% firstof resource.card_title resource.title %}{% if external_page or resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}</h5>
     </div>
   </div>
 </a>


### PR DESCRIPTION
This changeset fixes a bug within the icon logic, meaning external resources are now catered for (not just single-use, external links) in featured items.