### PR TITLE
Use filtered items for featured count

### DIFF
--- a/developerportal/apps/home/templates/home.html
+++ b/developerportal/apps/home/templates/home.html
@@ -21,13 +21,15 @@
       </div>
     </section>
     {% endif %}
-    {% if page.featured|published %}
-      <section id="featured" class="section">
-        <div class="container">
-          {% include "organisms/featured.html" with featured=page.featured|published featured_count=page.featured|length %}
-        </div>
-      </section>
-    {% endif %}
+    {% with page.featured|published as featured %}
+      {% if featured %}
+        <section id="featured" class="section">
+          <div class="container">
+            {% include "organisms/featured.html" with featured=featured %}
+          </div>
+        </section>
+      {% endif %}
+    {% endwith %}
     {% if page.primary_topics.all %}
       <section id="topics" class="section">
         {% include "organisms/topic-links.html" with topics=page.primary_topics.all pagetheme='home' %}

--- a/developerportal/apps/topics/templates/topic.html
+++ b/developerportal/apps/topics/templates/topic.html
@@ -13,13 +13,15 @@
 {% block content %}
 <main>
   {% include "organisms/pattern-bg-header.html" with title=page.title description=page.description icon=page.icon %}
-  {% if page.featured|published %}
-    <section class="section">
-      <div class="container">
-        {% include "organisms/featured.html" with featured=page.featured|published featured_count=page.featured|length %}
-      </div>
-    </section>
-  {% endif %}
+  {% with page.featured|published as featured %}
+    {% if featured %}
+      <section class="section">
+        <div class="container">
+          {% include "organisms/featured.html" with featured=featured %}
+        </div>
+      </section>
+    {% endif %}
+  {% endwith %}
   {% if page.tabbed_panels %}
     <section class="section section-background section-background-gray">
       <div class="container">

--- a/developerportal/templates/organisms/featured.html
+++ b/developerportal/templates/organisms/featured.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 
-{% if featured %}
+{% with featured|length as featured_count %}
   <div class="section-header">
     <h2>Featured</h2>
   </div>
@@ -53,4 +53,4 @@
       {% endfor %}
     </div>
   {% endif %}
-{% endif %}
+{% endwith %}


### PR DESCRIPTION
This changeset uses the filtered list of items (i.e. `page.featured|published`) when working out the number of featured items.