### PR TITLE
Expose CDN distribution id

### DIFF
--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -73,3 +73,8 @@
                 secretKeyRef:
                   name: dev-portal-secrets
                   key: REDIS_URL
+            - name: DISTRIBUTION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: CLOUDFRONT_DISTRIBUTION_ID


### PR DESCRIPTION
Exposes cloudfront CDN ID, the value is in k8s secret store

(Resolves #293)

## Key changes:

- Exposes cloudfront distribution ID

