### PR TITLE
Ensure two card layout works after IE fixes

### DIFF
--- a/src/css/molecules/card.scss
+++ b/src/css/molecules/card.scss
@@ -53,7 +53,7 @@
     }
 
     .card {
-      max-width: 320px;
+      max-width: none;
     }
 
     .card.external-promo {


### PR DESCRIPTION
This changeset addresses a bug where the two card layouts would break. This was after IE-specific fixes were added recently, breaking the card layouts on some pages.

Before:
![image](https://user-images.githubusercontent.com/1469007/66211974-f6c33200-e6b4-11e9-9e86-a198871e6cca.png)

After:
![Screen Shot 2019-10-04 at 2 40 16 PM](https://user-images.githubusercontent.com/1469007/66211982-fc207c80-e6b4-11e9-95fb-49acade13aca.png)
