### PR TITLE
Add ‘Recent authors’ section to People directory

### DIFF
--- a/developerportal/apps/home/templates/home.html
+++ b/developerportal/apps/home/templates/home.html
@@ -35,6 +35,11 @@
         {% include "organisms/topic-links.html" with topics=page.primary_topics.all pagetheme='home' %}
       </section>
     {% endif %}
+    {% if directory_pages.people.latest_authors %}
+      <section id="latest-authors" class="section">
+        {% include "organisms/people-section.html" with people=directory_pages.people.latest_authors show_link=True %}
+      </section>
+    {% endif %}
     {% if page.about_title %}
       <section id="about" class="section section-background section-background-gray">
         {% include "organisms/homepage-about.html" with title=page.about_title subtitle=page.about_subtitle button_url=page.about_button_url button_text=page.about_button_text %}

--- a/developerportal/apps/people/models.py
+++ b/developerportal/apps/people/models.py
@@ -107,6 +107,24 @@ class People(BasePage):
             "topics": Topic.published_objects.order_by("title"),
         }
 
+    @property
+    def latest_authors(self, limit=3):
+        """
+        Returns a list of authors from the most recently published articles.
+        """
+        from ..articles.models import Article
+
+        authors = []
+        articles = Article.published_objects.order_by("last_published_at").specific()
+        for article in articles:
+            if article.has_author:
+                for author in article.authors:  # pylint: disable=not-an-iterable
+                    if author.block_type == "author" and author.value not in authors:
+                        authors.append(author.value)
+                        if len(authors) >= limit:
+                            return authors  # Limit reached, return early
+        return authors
+
 
 class PersonTag(TaggedItemBase):
     content_object = ParentalKey(

--- a/developerportal/apps/people/models.py
+++ b/developerportal/apps/people/models.py
@@ -107,7 +107,6 @@ class People(BasePage):
             "topics": Topic.published_objects.order_by("title"),
         }
 
-    @property
     def latest_authors(self, limit=3):
         """
         Returns a list of authors from the most recently published articles.

--- a/developerportal/apps/people/templates/people.html
+++ b/developerportal/apps/people/templates/people.html
@@ -8,28 +8,28 @@
 {% block content %}
   <main>
     {% if page.people %}
-      <section class="section{% if not page.recently_published %} section-pattern{% endif %}">
+      <section class="section{% if not page.latest_authors %} section-pattern{% endif %}">
         <div class="container">
           <div class="section-header">
             <h2>Latest authors</h2>
           </div>
-          {% if page.recently_published|length == 1 %}
+          {% if page.latest_authors|length == 1 %}
             {# a single person is rendered full width #}
             <div>
-              {% with page.recently_published.0 as person %}
+              {% with page.latest_authors.0 as person %}
                 {% include "molecules/item-person.html" with person=person type="person" full_width=True %}
               {% endwith %}
             </div>
           {% else %}
             {# 2 or 3 are rendered side-by-side #}
-            <div class="card-container {% if page.recently_published|length == 2 %}card-container-2-wide{% endif %}">
-              {% for person in page.recently_published %}
+            <div class="card-container {% if page.latest_authors|length == 2 %}card-container-2-wide{% endif %}">
+              {% for person in page.latest_authors %}
                 {% include "molecules/item-person.html" with person=person type="person" full_width=False %}
               {% endfor %}
             </div>
           {% endif %}
         </div>
-      {% if page.recently_published %}
+      {% if page.latest_authors %}
       </section>
       <section class="section section-pattern">
       {% endif %}

--- a/developerportal/apps/people/templates/people.html
+++ b/developerportal/apps/people/templates/people.html
@@ -9,30 +9,11 @@
   <main>
     {% if page.people %}
       <section class="section{% if not page.latest_authors %} section-pattern{% endif %}">
-        <div class="container">
-          <div class="section-header">
-            <h2>Latest authors</h2>
-          </div>
-          {% if page.latest_authors|length == 1 %}
-            {# a single person is rendered full width #}
-            <div>
-              {% with page.latest_authors.0 as person %}
-                {% include "molecules/item-person.html" with person=person type="person" full_width=True %}
-              {% endwith %}
-            </div>
-          {% else %}
-            {# 2 or 3 are rendered side-by-side #}
-            <div class="card-container {% if page.latest_authors|length == 2 %}card-container-2-wide{% endif %}">
-              {% for person in page.latest_authors %}
-                {% include "molecules/item-person.html" with person=person type="person" full_width=False %}
-              {% endfor %}
-            </div>
-          {% endif %}
-        </div>
-      {% if page.latest_authors %}
-      </section>
-      <section class="section section-pattern">
-      {% endif %}
+        {% include "organisms/people-section.html" with people=page.latest_authors title="Latest authors" %}
+        {% if page.latest_authors %}
+          </section>
+          <section class="section section-pattern">
+        {% endif %}
         {% include "organisms/filter-list.html" with type="person" resources=page.people initial_resources=10 resources_per_page=4 %}
       </section>
     {% endif %}

--- a/developerportal/apps/people/templates/people.html
+++ b/developerportal/apps/people/templates/people.html
@@ -8,19 +8,31 @@
 {% block content %}
   <main>
     {% if page.people %}
-      <section class="section section-pattern">
+      <section class="section{% if not page.recently_published %} section-pattern{% endif %}">
         <div class="container">
           <div class="section-header">
-            <div>
-              <h2>People</h2>
-              {% if page.description %}
-                <div class="page-description">
-                  {{ page.description | richtext }}
-                </div>
-              {% endif %}
-            </div>
+            <h2>Latest authors</h2>
           </div>
+          {% if page.recently_published|length == 1 %}
+            {# a single person is rendered full width #}
+            <div>
+              {% with page.recently_published.0 as person %}
+                {% include "molecules/item-person.html" with person=person type="person" full_width=True %}
+              {% endwith %}
+            </div>
+          {% else %}
+            {# 2 or 3 are rendered side-by-side #}
+            <div class="card-container {% if page.recently_published|length == 2 %}card-container-2-wide{% endif %}">
+              {% for person in page.recently_published %}
+                {% include "molecules/item-person.html" with person=person type="person" full_width=False %}
+              {% endfor %}
+            </div>
+          {% endif %}
         </div>
+      {% if page.recently_published %}
+      </section>
+      <section class="section section-pattern">
+      {% endif %}
         {% include "organisms/filter-list.html" with type="person" resources=page.people initial_resources=10 resources_per_page=4 %}
       </section>
     {% endif %}

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -221,6 +221,11 @@ class Topic(BasePage):
         )
 
     @property
+    def experts(self):
+        """Return Person instances for topic experts"""
+        return [person.person for person in self.people.all()]
+
+    @property
     def videos(self):
         """Return the latest videos and external videos for this topic. """
         return get_combined_videos(self, topics__topic__pk=self.pk)

--- a/developerportal/apps/topics/templates/topic.html
+++ b/developerportal/apps/topics/templates/topic.html
@@ -53,31 +53,9 @@
       </div>
     </section>
   {% endif %}
-  {% if page.people.all %}
+  {% if page.experts %}
   <section class="section">
-    <div class="container">
-      <div class="section-header">
-        <h2>People</h2>
-        {% if directory_pages.people %}
-          <a href="{% pageurl directory_pages.people %}?topics={{ page.slug }}">See more</a>
-        {% endif %}
-      </div>
-      {% if page.people.count == 1 %}
-        {# a single person is rendered full width #}
-        <div>
-          {% with page.people.all.0 as person %}
-            {% include "molecules/item-person.html" with person=person.person type="person" full_width=True%}
-          {% endwith %}
-        </div>
-      {% else %}
-        {# 2 or 3 are rendered side-by-side #}
-        <div class="card-container {% if page.people.count == 2 %}card-container-2-wide{% endif %}">
-          {% for person in page.people.all|slice:":3" %}
-            {% include "molecules/item-person.html" with person=person.person type="person" full_width=False%}
-          {% endfor %}
-        </div>
-      {% endif %}
-    </div>
+    {% include "organisms/people-section.html" with people=page.experts is_topic=True show_link=True %}
   </section>
   {% endif %}
   {% if page.videos %}

--- a/developerportal/templates/organisms/people-section.html
+++ b/developerportal/templates/organisms/people-section.html
@@ -1,0 +1,33 @@
+{% comment %}
+  Context:
+  * is_topic  - Whether the current page is a Topic page, default: None
+  * people    - Iterable QuerySet or list of Person pages, default: None
+  * show_link - Whether to show ‘See more’ link, default: None
+  * title     - Optional custom title for the section, default: "People"
+{% endcomment %}
+
+{% load wagtailcore_tags %}
+
+<div class="container">
+  <div class="section-header">
+    <h2>{{ title|default:"People" }}</h2>
+    {% if show_link and directory_pages.people %}
+      <a href="{% pageurl directory_pages.people %}{% if is_topic %}?topics={{ page.slug }}{% endif %}">See more</a>
+    {% endif %}
+  </div>
+  {% if people|length == 1 %}
+    {# a single person is rendered full width #}
+    <div>
+      {% with people.0 as person %}
+        {% include "molecules/item-person.html" with person=person type="person" full_width=True %}
+      {% endwith %}
+    </div>
+  {% else %}
+    {# 2 or 3 are rendered side-by-side #}
+    <div class="card-container {% if people|length == 2 %}card-container-2-wide{% endif %}">
+      {% for person in people %}
+        {% include "molecules/item-person.html" with person=person type="person" full_width=False %}
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
This change set adds a ‘Recent authors’ section to the People directory page as per the latest designs. These people are pulled in dynamically based on recently published articles.

## Key changes:

- Add ‘Recent authors’ section to the People page.
- Add ‘People’ section to the home page.
- Refactor section with circular profiles to reusable organism.

## How to test

- Create a new article, assign one or more authors and publish.
- The author(s) should appear at the top of the People directory page.
