### PR TITLE
Removing port 8080, this port is used by jenkins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     env_file: .env
     ports:
       - "8000:8000"
-      - "8080:8080"
     tty: true
     volumes:
       - dist:/app/dist


### PR DESCRIPTION
Remove port 8080 for the `docker-compose` file, exposing this port causes issues with tests since jenkins runs on port 8080

(Resolves part of #316)

## Key changes:

- Remove port 8080 for the `docker-compose` file
