### PR TITLE
265: Support uploading user-media to AWS S3, instead of local filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ After installing Docker, use the **dev-setup** script to run the project locally
 
 This command will create an .env file with unique keys, build docker images and containers, run database migrations, and load fixture data.
 
+It's worth copying `settings/local.py.example` to `settings/local.py` but leaving everything commented out for now. Updating `local.py` can be a handy way to re-enable production-like settings (eg S3 uploads) that are disabled via the default local-development settings.
+
 ### Run locally
 
 With Docker Desktop running in the background, bring up the services by running:

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     "wagtail.search",
     "wagtail.admin",
     "wagtail.core",
+    "storages",
     "bakery",
     "wagtailbakery",
     "modelcluster",
@@ -194,10 +195,6 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 STATIC_URL = "/static/"
 
-MEDIA_ROOT = os.path.join(BASE_DIR, "media")
-MEDIA_URL = "/media/"
-
-
 # Django security settings (see `manage.py check --deploy`)
 
 CSRF_COOKIE_SECURE = True
@@ -242,9 +239,21 @@ BAKERY_VIEWS = (
     "bakery.views.Buildable404View",
 )
 AWS_REGION = os.environ.get("AWS_REGION")
+
+# This bucket is where the static site will be baked to
 AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
+# This bucket is where user-media will be uploaded to
+AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME")
+AWS_S3_CUSTOM_DOMAIN = "%s.s3.amazonaws.com" % AWS_STORAGE_BUCKET_NAME
+DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+AWS_DEFAULT_ACL = "public-read"
+
+MEDIA_URL = "https://%s/" % AWS_S3_CUSTOM_DOMAIN
+# This is critical for django-bakery NOT to try to do a filesystem copy on a URI in S3
+MEDIA_ROOT = None
 
 # Explicit configuration of where the 'baked' site will end up. This needs to match
 # the root URL of the developerportal Site in Wagtail's configuration, because

--- a/developerportal/settings/dev.py
+++ b/developerportal/settings/dev.py
@@ -15,6 +15,10 @@ SECURE_SSL_REDIRECT = False
 CSRF_COOKIE_SECURE = False
 SESSION_COOKIE_SECURE = False
 
+# Swap out the default use of S3 for user media to instead use local machine
+DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+MEDIA_URL = "/media/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 try:
     from .local import *

--- a/developerportal/settings/local.py.example
+++ b/developerportal/settings/local.py.example
@@ -1,0 +1,20 @@
+# Uncomment these, as required, to reset things from settings.dev to more
+# production-like ones for testing features like email sending and S3 use
+
+# DEBUG = False
+
+# EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
+# AWS_ACCESS_KEY_ID = "ADD_ME"
+# AWS_SECRET_ACCESS_KEY = "ADD_ME"
+# AWS_BUCKET_NAME = "BUCKET_NAME_HERE"  # Destination of baked site
+# AWS_REGION = "REGION_NAME_HERE"  # eg eu-west-1
+
+# # Reinstate critical settings for using S3 as user-media storage
+# AWS_STORAGE_BUCKET_NAME = "MEDIA_BUCKET_NAME_HERE"  #  destination of user media
+# DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+
+# AWS_S3_CUSTOM_DOMAIN = "%s.s3.amazonaws.com" % AWS_STORAGE_BUCKET_NAME
+# MEDIA_URL = "https://%s/" % AWS_S3_CUSTOM_DOMAIN
+# MEDIA_ROOT = None
+

--- a/developerportal/templatetags/app_tags.py
+++ b/developerportal/templatetags/app_tags.py
@@ -39,4 +39,7 @@ def render_gif(block_value):
 
 @register.simple_tag
 def get_scheme_and_host(request):
+    if settings.DEFAULT_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
+        # If we're using S3, we don't need to return a "base url" for assets
+        return ""
     return f"{request.scheme}://{request.get_host()}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ redis==3.3.10
 django-celery-results==1.1.2
 gunicorn==19.9.0
 meinheld==1.0.1
+django-storages==1.7.2
+boto3==1.9.247
 psycopg2==2.8.3
 Pygments==2.4.2
 readtime==1.1.1
@@ -14,8 +16,7 @@ whitenoise==4.1.4
 ## The following requirements were added by pip freeze:
 appdirs==1.4.3
 beautifulsoup4==4.6.0
-boto3==1.9.247
-botocore==1.12.247 
+botocore==1.12.247
 certifi==2019.9.11
 chardet==3.0.4
 cssselect==1.1.0


### PR DESCRIPTION
This changeset enables the use _in production_ of `django-storages` to use AWS S3 for custom files/images uploaded into Wagtail, rather than store them in the local filesystem. (Local dev's default remains the same.)

Note that these user-media files go to a DIFFERENT S3 bucket from that configured for holding the baked-out static site.

When a site is built that features S3-hosted images, there is no need to download them only to upload them to the static-site bucket - the HTML and CSS just reference the images in the S3 user-media bucket instead. (It would be good to CNAME this user-media bucket at least - that's ticketed in #318)

This changeset also introduces a template for local settings that make it easier to develop S3-related behaviour while in local development mode (ie, reinstate some prod-like settings that `settings/dev.py` has disabled)

(Resolves #256)

## Key changes:

- add `django-storages` (BSD licence) to the project and configure
- ensure MEDIA_URL is `None` in production mode, so that `django-bakery` doesn't try to copy over files that aren't on the local filesystem
- fix generation of a base URL via `app_tags.get_scheme_and_host` to be aware of when user-media is in S3 (so its URLs are _already_ absolute), so that it doesn't produce a root URL prefix when it is not needed.
- add template `settings.local` with commented-out skeleton

## How to test

- check out local build
- copy `settings/local.py.example` to `settings/local.py`, uncomment all apart from the email backend one.
- fill in your own AWS credentials and ensure an S3 bucket exists for the user media (and, for consistency, also for the static site
- upload some images in Wagtail (http://localhost:8000/admin/images/) and confirm they end up in S3
- use those images in a page or two
- shell into a container (`docker-compose exec app /bin/sh`) and run `manage.py build` 
- inspect the output HTML in `/app/build/` and confirm that S3-hosted images are using a full S3 URI:

eg `<meta property="og:image" content="https://USER_MEDIA_BUCKET_NAME_HERE.s3.amazonaws.com/images/5.width-1200.png">` 
and
`      <div class="card-featured-image" style="background-image: url('https://USER_MEDIA_BUCKET_NAME_HERE.s3.amazonaws.co
m/images/5.width-1024.png')"></div>`

## Follow-up actions
- [ ] Re-upload the dozen or so images that are currently on the filesystem on staging, so that they work from S3 instead. (@stevejalim has downloaded them locally already)