### PR TITLE
Fix image sizes when small media is uploaded

### DIFF
--- a/src/css/molecules/item-person.scss
+++ b/src/css/molecules/item-person.scss
@@ -114,5 +114,6 @@
   img {
     border-radius: 50%;
     filter: grayscale(1);
+    width: 100%;
   }
 }


### PR DESCRIPTION
This changeset adds a width to the people images to ensure they fit their containers, even when images with smaller dimensions are uploaded. By default, Wagtail won't upscale images – so when images are smaller than intended, they often break layouts.

We have recommended guidelines for images, but this is mainly to prevent the layout from breaking.