### PR TITLE
Integration PR: pulling together the Celery work

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 known_first_party=developerportal
-known_third_party=django_countries,modelcluster,pygments,readtime,social_core,taggit,urllib3,wagtail
+known_third_party=celery,django_countries,modelcluster,pygments,readtime,social_core,taggit,urllib3,wagtail
 known_django=django
 default_section=FIRSTPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY src/ /app/src/
 RUN npm run build
 
 
-FROM python:3.7-alpine@sha256:488bfa82d8ac22f1ed9f1d4297613a920bf14913adb98a652af7dbbbf1c3cab9 AS app
+FROM python:3.7-alpine@sha256:488bfa82d8ac22f1ed9f1d4297613a920bf14913adb98a652af7dbbbf1c3cab9 AS app_base
 
 EXPOSE 8000
 WORKDIR /app/
@@ -39,6 +39,15 @@ COPY developerportal/ /app/developerportal/
 COPY src/ /app/src/
 COPY --from=static /app/dist /app/dist/
 
+# Create a non-root user with a fixed UID, no password and a home directory
+RUN adduser -u 1000 -s /bin/bash -D devportaluser \
+  && mkdir -p app \
+  && chown devportaluser:devportaluser /app \
+  && chmod 775 /app
+
 # Collect all of the static files into the static folder
+USER devportaluser
 RUN DJANGO_ENV=production python manage.py collectstatic
-CMD exec gunicorn developerportal.wsgi:application --bind=0.0.0.0:8000 --reload --workers=3
+
+# The following is explicitly called by docker-compose or a k8s manifest
+# CMD exec gunicorn developerportal.wsgi:application --bind=0.0.0.0:8000 --reload --workers=3

--- a/developerportal/apps/staticbuild/__init__.py
+++ b/developerportal/apps/staticbuild/__init__.py
@@ -1,0 +1,5 @@
+from .celery import app as celery_app
+
+# Make sure Celery is always imported when Django starts
+# so that @shared_task will use this app.
+__all__ = ("celery_app",)

--- a/developerportal/apps/staticbuild/celery.py
+++ b/developerportal/apps/staticbuild/celery.py
@@ -1,0 +1,14 @@
+import os
+
+from django.conf import settings
+
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "developerportal.settings.production")
+
+app = Celery("developerportal.apps.staticbuild", broker=settings.CELERY_BROKER_URL)
+
+# Add the Django settings module as a configuration source for Celery
+app.config_from_object("django.conf:settings")
+
+app.autodiscover_tasks()

--- a/developerportal/apps/staticbuild/tests/test_auto_build.py
+++ b/developerportal/apps/staticbuild/tests/test_auto_build.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+from developerportal.apps.home.models import HomePage
+
+
+@override_settings(CELERY_ALWAYS_EAGER=True)
+class TestAutomaticBakingUponPublish(TestCase):
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.call_command")
+    def test_page_publish_triggers_async_tasks(self, mock_call_command):
+        self.homepage = HomePage.objects.get()
+
+        mock_call_command.reset_mock()
+
+        # One doesn't publish a page, one publishes a Revision
+        revision = self.homepage.save_revision()
+        revision.publish()
+
+        assert mock_call_command.call_count == 2
+
+        #  check for the call that builds the static site
+        assert mock_call_command.call_args_list[0][0][0] == "build"
+
+        # now check for the call to sync the static site to S3
+        assert mock_call_command.call_args_list[1][0][0] == "publish"
+
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.call_command")
+    def test_page_unpublish_triggers_async_tasks(self, mock_call_command):
+        self.homepage = HomePage.objects.get()
+        mock_call_command.reset_mock()
+
+        # One can direcly unpublish a page, without needing a revision
+        self.homepage.unpublish()
+        assert mock_call_command.call_count == 2
+
+        #  check for the call that builds the static site
+        assert mock_call_command.call_args_list[0][0][0] == "build"
+
+        # now check for the call to sync the static site to S3
+        assert mock_call_command.call_args_list[1][0][0] == "publish"

--- a/developerportal/apps/staticbuild/wagtail_hooks.py
+++ b/developerportal/apps/staticbuild/wagtail_hooks.py
@@ -1,12 +1,13 @@
 import logging
 import os
-from multiprocessing import Process
 
 from django.conf import settings
 from django.core.management import call_command
 
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.core.signals import page_published, page_unpublished
+
+from developerportal.apps.staticbuild.celery import app
 
 from .models import StaticBuild
 
@@ -23,23 +24,24 @@ class ArticleAdmin(ModelAdmin):
 modeladmin_register(ArticleAdmin)
 
 
-def _static_build_async(force=False, pipeline=settings.STATIC_BUILD_PIPELINE, **kwargs):
+@app.task
+def _static_build_async(force=False, pipeline=settings.STATIC_BUILD_PIPELINE):
     """Calls each command in the static build pipeline in turn."""
     log_prefix = "Static build task"
     for name, command in pipeline:
         if settings.DEBUG and not force:
-            logger.info(f"{log_prefix} ‘{name}’ skipped.")
+            logger.info(f"{log_prefix} (wagtail-bakery) command '{name}' skipped.")
         else:
-            logger.info(f"{log_prefix} ‘{name}’ started.")
+            logger.info(f"{log_prefix} (wagtail-bakery) command '{name}' started.")
             call_command(command)
-            logger.info(f"{log_prefix} ‘{name}’ finished.")
+            logger.info(f"{log_prefix} (wagtail-bakery) command '{name}' finished.")
 
 
 def static_build(**kwargs):
-    """Callback for Wagtail publish and unpublish signals."""
-    # Spawn a process to do the actual build.
-    process = Process(target=_static_build_async, kwargs=kwargs)
-    process.start()
+    """Callback for Wagtail publish and unpublish signals to spawn a
+    task-queue job to do the actual build"""
+    force = kwargs.get("force", False)
+    _static_build_async.delay(force=force)
 
 
 page_published.connect(static_build)

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_celery_results",
 ]
 
 MIDDLEWARE = [
@@ -241,6 +242,8 @@ BAKERY_VIEWS = (
 )
 AWS_REGION = os.environ.get("AWS_REGION")
 AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME")
+AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
 # Explicit configuration of where the 'baked' site will end up. This needs to match
 # the root URL of the developerportal Site in Wagtail's configuration, because
@@ -293,3 +296,10 @@ GOOGLE_ANALYTICS = os.environ.get("GOOGLE_ANALYTICS")
 MAPBOX_ACCESS_TOKEN = os.environ.get("MAPBOX_ACCESS_TOKEN")
 
 COUNTRIES_FIRST = ["US", "GB"]
+
+# Celery settings
+CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+CELERY_RESULT_BACKEND = "django-db"  #  for django-celery-results
+CELERY_ACCEPT_CONTENT = ["application/json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_SERIALIZER = "json"

--- a/developerportal/settings/dev.py
+++ b/developerportal/settings/dev.py
@@ -6,12 +6,15 @@ DEBUG = True
 # SECURITY WARNING: define the correct hosts in production!
 ALLOWED_HOSTS = ["*"]
 
+CELERY_BROKER_URL = "redis://redis:6379/0"
+
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # Disable production defaults that get in the way of local development
 SECURE_SSL_REDIRECT = False
 CSRF_COOKIE_SECURE = False
 SESSION_COOKIE_SECURE = False
+
 
 try:
     from .local import *

--- a/developerportal/settings/test_fast.py
+++ b/developerportal/settings/test_fast.py
@@ -1,0 +1,3 @@
+from .dev import *
+
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,22 +10,39 @@ services:
     volumes:
       - database:/var/lib/postgresql/data
 
-  app:
+  redis:
+    env_file: .env
+    expose:
+      - 6379
+    image: redis:5.0.6-alpine
+    tty: true
+
+  common: &common
     build:
       context: .
-      target: app
-    command: gunicorn developerportal.wsgi:application --bind=0.0.0.0:8000 --reload --workers=3
+      target: app_base
     depends_on:
       - db
+      - redis
     env_file: .env
-    ports:
-      - "8000:8000"
     tty: true
     volumes:
       - dist:/app/dist
       - ./developerportal:/app/developerportal
       - ./media:/app/media
       - ./src:/app/src
+
+  app:
+    <<: *common
+    command: gunicorn developerportal.wsgi:application --bind=0.0.0.0:8000 --reload --workers=3
+    ports:
+      - "8000:8000"
+    user: ${UID:-1000}
+
+  worker:
+    <<: *common
+    command: celery -A developerportal.apps.staticbuild worker -l info
+    user: ${UID:-1000}
 
   static:
     build:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 Django==2.2.6
+celery==4.3.0
+redis==3.3.8
+django-celery-results==1.1.2
 gunicorn==19.9.0
 meinheld==1.0.1
 psycopg2==2.8.3


### PR DESCRIPTION
Contains PRs #325 and #336 so we can deploy them together

-----

* Initial steps moving automatic generation and upload of the static site to a queue-managed background task.

Changes include:
* Update Dockerfile to:
  - rename `app` target as `app_base`, to make it clearer it's being used for multiple things
  - not start gunicorn as part of `app_base`'s build, because that's not needed and is handled by docker-compose or k8s

* Update docker-compose.yml to:
  - add `redis` container
  - update the `app` config to inherit from a new `common` config, which uses the `app_base` target
  - add new `worker` container, inheriting from the `common` config, too

* Add `celery` to the project
  - Stop the use of `subprocess.Process` when a page is published or unpublished.
  - Use a a properly enqueued task to handle the background dump-to-static-then-upload-to-S3 process

* Add django-celery-results to give us easier visibility of job success/failure

This is a temporary and basic solution to give us an eye on whether background tasks are
happy, but it is limited because it only displays tasks after they have completed (ie
once they have a result)

Switching to something that lets us see in-flight tasks would be useful, down the line.
(eg: Flower - https://flower.readthedocs.io/en/latest/)

* Nit: Be explicit about which Redis DB to use

* Ensure Django (and therefore the Celery worker) can get hold of the credentials Celery needs

- Update Makefile to export AWS-related config to the environment
- In Django, pick up AWS-related config from environment

This change assumes the AWS-related config is already available at in the general config
at the k8s level -- this seems reasonable, because they are all already mentioned in the
k8s config files.

* Nit: tidy up output of async logging

* Add test settings to run tests using in-memory SQLite, optionally

* Add light integration tests to show that publishing and unpublishing will trigger static-build-and-sync behaviour

* 139: Remove unnecessary redelcaration of AWS vars (following CR from @limed)

* Update isort config to be aware of celery as as a known third-party

* 139: Update docker config to create a non-root user to use in operations

* Update Dockerfile to add a new user "devportaluser" with a fixed UID, NO PASSWORD and a home dir
* Make them the owner of the mounted /app/ dir

Update docker-compose to run gunicorn in `app` and Celery in `worker` using "devportaluser". This silences "RuntimeWarning: You're running the worker with superuser privileges: this is absolutely not recommended!" from Celery

--
Manually checked that
- `collectstatic` still works
- gunicorn/site serving still works
- wagtail-bakery's `build` and `publish` steps still work

```
$ docker-compose exec app /bin/sh
/app $ whoami
devportaluser

/app $ rm -rf static/*
/app $ python manage.py collectstatic

586 static files copied to '/app/static', 1176 post-processed.

/app $ ./manage.py build
INFO:bakery.management.commands.build:Build started
INFO:bakery.management.commands.build:Build finished
/app $ ./manage.py publish
Uploading /app/build/index.html
... [etc etc] ...
```
