### PR TITLE
Mount dev-portal attachments onto celery nodes

### DIFF
--- a/k8s/celery.yaml.j2
+++ b/k8s/celery.yaml.j2
@@ -12,10 +12,17 @@ spec:
       labels:
         app: {{ CELERY_WORKER_NAME }}
     spec:
+      volumes:
+      - name: developer-portal-fs
+        persistentVolumeClaim:
+          claimName: {{ APP_PVC_NAME }}
       containers:
         - name: {{ CELERY_WORKER_NAME }}
           image: "{{ APP_IMAGE }}:{{ APP_IMAGE_TAG }}"
           imagePullPolicy: {{ APP_IMAGE_PULL_POLICY }}
+          volumeMounts:
+            - name: developer-portal-fs
+              mountPath: {{ APP_MOUNT_PATH }}
           command:
             - "celery"
           args:


### PR DESCRIPTION
The celery workers need to have the attachments mounted for it to be able to build the static content this PR mounts the volumes into the pod

(Resolves #341)

## Key changes:

- Mount dev portal attachment EFS to celery worker pod

