### PR TITLE
Don't push changes to eks cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,6 @@ node {
 
     case 'stage-push':
       stage('Deploy') {
-        deploy('stage')
         deploy('stage-oregon')
       }
       break


### PR DESCRIPTION
We have 2 clusters at the moment, this change removes the need for the EKS cluster temporarily. The end goal is to use the EKS cluster at some point but we don't want to push changes there via CI atm.

## Key changes:

- Dont push CI changes to EKS cluster

