### PR TITLE
Add k8s job to set media permissions

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -82,6 +82,13 @@ k8s-rollback:
 k8s-history:
 	${KC} rollout history deploy ${APP_NAME}
 
+k8s-efs-job: k8s-delete-efs-job
+	j2 app.efs-setup.yaml.j2 | ${KC} apply -f -
+	env JOB_NAME=dev-portal-efs-setup ./wait_for_job.sh
+
+k8s-delete-efs-job:
+	${KC} delete --ignore-not-found job dev-portal-efs-setup
+
 k8s-db-migration-job: k8s-delete-db-migration-job
 	j2 db-migration-job.yaml.j2 | ${KC} apply -f -
 	env JOB_NAME=db-migration ./wait_for_job.sh

--- a/k8s/app.efs-setup.yaml.j2
+++ b/k8s/app.efs-setup.yaml.j2
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dev-portal-efs-setup
+spec:
+  template:
+    metadata:
+      name: dev-portal-efs-setup
+    spec:
+      containers:
+        - name: dev-portal-efs-setup
+          image: debian
+          command: [ "/bin/bash", "-c", "mkdir -p /app/media && chown -R 1000:1000 /app/media && chown 1000:1000 /app/media" ]
+          volumeMounts:
+            - name: developer-portal-fs
+              mountPath: {{ APP_MOUNT_PATH }}
+      restartPolicy: Never
+      volumes:
+        - name: developer-portal-fs
+          persistentVolumeClaim:
+            claimName: {{ APP_PVC_NAME }}


### PR DESCRIPTION
This PR adds a k8s job that will create and chown the media directory. By default all folders get created with `root:root` permission, our containers run with GID and UID 1000 so this job fixes that. This job should only be needed once

(Resolves #340)

## Key changes:

- Add k8s job and Makefile targets to fix permission of media files