### PR TITLE
287: Build a 404.html page during generation of the static site

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -239,6 +239,7 @@ BAKERY_MULTISITE = True
 BAKERY_VIEWS = (
     "developerportal.apps.bakery.views.AllPublishedPagesViewAllowingSecureRedirect",
     "developerportal.apps.bakery.views.S3RedirectManagementView",
+    "bakery.views.Buildable404View",
 )
 AWS_REGION = os.environ.get("AWS_REGION")
 AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME")


### PR DESCRIPTION
Intended to be combined with configuration, this changeset partially addresses the need for a 404 page available in the S3-served website.

(Resolves #287)

## Key changes:

- adds a special view to the `django-bakery` pipeline that renders out the 404 page. It's output to the root of the build dir as `404.html`

## How to test

- Pull this branch
- Shell into the running `app` container (`docker-compose exec app /bin/sh`)
- Run a build: `./manage.py build`
- View the output 404 file: `less /app/build/404.html`