### PR TITLE
This commit exposes an s3 bucket that will host user uploaded media

### DIFF
--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -3,6 +3,8 @@
               value: "{{ APP_AWS_BUCKET_NAME }}"
             - name: AWS_REGION
               value: "{{ APP_AWS_BUCKET_REGION }}"
+            - name: AWS_STORAGE_BUCKET_NAME
+              value: "{{ APP_AWS_STORAGE_BUCKET_NAME }}"
             - name: BASE_URL
               value: "{{ APP_BASE_URL }}"
             - name: EXPORTED_SITE_URL

--- a/k8s/config/stage-oregon.sh
+++ b/k8s/config/stage-oregon.sh
@@ -22,6 +22,7 @@ export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-stage.mdn.mozit.cloud
 export APP_EXPORTED_SITE_HOST=developer-portal-published.stage.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
+export APP_AWS_STORAGE_BUCKET_NAME=developer-portal-stage-media-178589013767
 export APP_AWS_BUCKET_REGION=us-west-2
 export APP_MOUNT_PATH=/app/media
 

--- a/k8s/config/stage.sh
+++ b/k8s/config/stage.sh
@@ -22,6 +22,7 @@ export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-dev.mdn.mozit.cloud
 export APP_EXPORTED_SITE_HOST=developer-portal-published.dev.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
+export APP_AWS_STORAGE_BUCKET_NAME=developer-portal-stage-media-178589013767
 export APP_AWS_BUCKET_REGION=us-west-2
 export APP_MOUNT_PATH=/app/media
 


### PR DESCRIPTION
This changeset exposes the `AWS_STORAGE_BUCKET_NAME` variable to the developer portal app which will help facilitate uploads of user media and get us away from using EFS

(Resolves #317)

## Key changes:

- Expose storage bucket name

