### PR TITLE
Use home search_description as default for pages

### DIFF
--- a/developerportal/templates/atoms/social-meta.html
+++ b/developerportal/templates/atoms/social-meta.html
@@ -5,7 +5,7 @@
 
 <meta property="og:title" content="{{ page.title }}">
 {% with page.description|richtext|striptags as rich_description %}
-  {% firstof page.search_description page.card_description rich_description as description %}
+  {% firstof page.search_description page.card_description rich_description fallback_description as description %}
   {% if description %}
     <meta name="description" content="{{ description }}">
     <meta property="og:description" content="{{ description }}">

--- a/developerportal/templates/base.html
+++ b/developerportal/templates/base.html
@@ -40,14 +40,14 @@
           {% endwith %}
         {% endblock %}
       </title>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <link rel="stylesheet" type="text/css" href="{% static 'css/bundle.css' %}">
+      <link rel="shortcut icon" href="{% static 'img/icons/favicon.ico' %}">
+      <link rel="alternate" type="application/rss+xml" href="/article-feed/">
+      {% if page %}
+        {% include "atoms/social-meta.html" with fallback_description=home.search_description %}
+      {% endif %}
     {% endwith %}
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="{% static 'css/bundle.css' %}">
-    <link rel="shortcut icon" href="{% static 'img/icons/favicon.ico' %}">
-    <link rel="alternate" type="application/rss+xml" href="/article-feed/">
-    {% if page %}
-      {% include "atoms/social-meta.html" %}
-    {% endif %}
     {% block head %}
     {% endblock %}
   </head>


### PR DESCRIPTION
This changeset adds support for default page meta descriptions by using the home page's `search_description` field value.

(Related to #354)

## Key changes

- Add default description to base template, using the home page's `search_description` field.

## How to test

- Add a description to the `search_description` field on the home page and observe it added to all pages as the default meta description.
