### PR TITLE
Fix wrapping with external featured item icons

### DIFF
--- a/developerportal/templates/molecules/card-featured-primary.html
+++ b/developerportal/templates/molecules/card-featured-primary.html
@@ -18,7 +18,9 @@
       <div class="card-featured-primary-content">
         <div class="featured">Featured</div>
         <div>
-          <h4 class="no-underline">{% firstof resource.card_title resource.title %}{% if external_page or resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}</h4>
+          <h4 class="no-underline">
+            {% firstof resource.card_title resource.title %}{% if external_page or resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}
+          </h4>
           {% if resource.card_description %}
             <p>{{ resource.card_description }}</p>
           {% else %}

--- a/developerportal/templates/molecules/card-featured.html
+++ b/developerportal/templates/molecules/card-featured.html
@@ -16,7 +16,9 @@
       <span class="highlighted featured">Featured</span>
     </div>
     <div class="card-featured-caption">
-      <h5 class="no-underline">{% firstof resource.card_title resource.title %}{% if external_page or resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}</h5>
+      <h5 class="no-underline">
+        {% firstof resource.card_title resource.title %}{% if external_page or resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}
+      </h5>
     </div>
   </div>
 </a>

--- a/src/css/molecules/card-featured.scss
+++ b/src/css/molecules/card-featured.scss
@@ -147,14 +147,14 @@
     @media #{$mq-md} {
       top: 0;
     }
+
+    span {
+      display: inline-block;
+    }
   }
 
   .featured {
     margin-bottom: 16px;
-  }
-
-  span {
-    display: inline-block;
   }
 
   p {


### PR DESCRIPTION
This changeset addresses a bug where icons wouldn't wrap correctly in external featured items. This prevents orphaned icons when titles are a specific length.

Before:
![Screen Shot 2019-10-10 at 2 14 42 PM](https://user-images.githubusercontent.com/1469007/66572321-a6dae400-eb68-11e9-83ac-f921aff24582.png)

After:
![Screen Shot 2019-10-10 at 2 17 03 PM](https://user-images.githubusercontent.com/1469007/66572331-a9d5d480-eb68-11e9-9099-fd8562ffcf98.png)

## Key changes

- Remove `inline-block` from incorrectly applied element within featured external items.

## How to test

- Use different length titles within featured external items and test that no length will leave an external icon orphaned without a word.