### PR TITLE
379: Add and use a temporary subdir of BUILD_DIR when baking a site

### DIFF
--- a/developerportal/apps/staticbuild/tests/test_task_queue.py
+++ b/developerportal/apps/staticbuild/tests/test_task_queue.py
@@ -1,0 +1,42 @@
+import datetime
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+import pytz
+from developerportal.apps.staticbuild.wagtail_hooks import (
+    _generate_build_path,
+    _static_build_async,
+)
+
+
+class TaskQueueBuildTests(TestCase):
+    @override_settings(BUILD_DIR="/path/to/build/dir/")
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.tz_now")
+    def test__generate_build_path(self, mock_tz_now):
+        mock_tz_now.return_value = datetime.datetime(
+            2001, 12, 25, 1, 23, 45, 123456, tzinfo=pytz.utc
+        )
+        self.assertEqual(
+            _generate_build_path(),
+            "/path/to/build/dir/2001-12-25T01:23:45.123456+00:00",
+        )
+
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.call_command")
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.shutil.rmtree")
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks._generate_build_path")
+    def test_static_build_async__uses_specific_build_path(
+        self, mock_generate_build_path, mock_rmtree, mock_call_command
+    ):
+        mock_generate_build_path.return_value = "/build/subdir/"
+
+        _static_build_async()
+
+        self.assertEqual(mock_call_command.call_count, 2)
+        assert mock_call_command.call_args_list[0][0][0] == "build"
+        assert mock_call_command.call_args_list[0][1]["build_dir"] == "/build/subdir/"
+
+        assert mock_call_command.call_args_list[1][0][0] == "publish"
+        assert mock_call_command.call_args_list[1][1]["build_dir"] == "/build/subdir/"
+
+        mock_rmtree.assert_called_once_with("/build/subdir/")

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -232,7 +232,12 @@ BASE_URL = os.environ.get("BASE_URL")
 
 
 # Wagtail Bakery Settings
+
+# This is a handy default for local building, but note that when we build in production
+# we're actually using this as a root of a build path, to prevent concurrent builds
+# from clashing.
 BUILD_DIR = os.path.join(BASE_DIR, "build")
+
 BAKERY_MULTISITE = True
 BAKERY_VIEWS = (
     "developerportal.apps.bakery.views.AllPublishedPagesViewAllowingSecureRedirect",


### PR DESCRIPTION
This changeset addresses the issue of Celery worker processes clobbering each other's output directories, resulting in imperfect syncs to S3. It deals with it by ensuring each enqeued job uses a unique (precisely timestamp-based) output directory to build to and publish from, before then deleting that output dir.

(Note that I'll probably add some locking to stop Celery wasting time on parallel builds of the _same_ task, so this is a stopgap, but it's good to keep things on the level.)

(Resolves #379)

## Key changes:

- summarise changes here, linking to commits as appropriate

## How to test

- Have the full local stack up, including Celery worker
- `docker-compose exec app python manage.py shell`
- `from developerportal.apps.staticbuild.wagtail_hooks import static_build`
- `for i in range(4): static_build()` (then double enter to trigger it)

This will put four builds into celery, all of which will (currently) be picked up for processing, but each in their own build folder. Look at the logging to see confirmation of this. eg
`worker_1  | [2019-10-14 16:06:57,177: INFO/ForkPoolWorker-2] Static build task Deleted temporary build dir /app/build/2019-10-14T15:32:41.593149+00:00/2019-10-14T16:06:41.641164+00:00` 
