### PR TITLE
Fix "see more" link wrapping and remove from profiles

### DIFF
--- a/developerportal/apps/people/templates/person.html
+++ b/developerportal/apps/people/templates/person.html
@@ -23,9 +23,6 @@
       <div class="container">
         <div class="section-header">
           <h2>Latest articles</h2>
-          {% if directory_pages.articles %}
-            <a href="{% pageurl directory_pages.articles %}">See more</a>
-          {% endif %}
         </div>
         {% include "organisms/latest-cards.html" with cards=page.articles show_author=True%}
       </div>

--- a/src/css/global/section.scss
+++ b/src/css/global/section.scss
@@ -21,10 +21,16 @@
 }
 
 .section-header {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
   margin-bottom: 24px;
+
+  @media #{$mq-sm} {
+    align-items: center;
+    flex-direction: row;
+  }
 
   .page-description {
     margin: 16px 0 0;
@@ -36,8 +42,14 @@
   }
 
   a {
+    display: inline-block;
     font-weight: bold;
+    margin-top: 8px;
     text-decoration: none;
+
+    @media #{$mq-sm} {
+      margin-top: 0;
+    }
 
     &:hover {
       text-decoration: underline;


### PR DESCRIPTION
This changeset ensures that the "see more" links in some section headers wrap correctly on mobile devices.

Before:
![image](https://user-images.githubusercontent.com/1469007/66848904-cd848a80-ef6d-11e9-85f8-0263684fecf6.png)

After:
![Screen Shot 2019-10-15 at 5 03 54 PM](https://user-images.githubusercontent.com/1469007/66848908-cfe6e480-ef6d-11e9-9035-ce8acfb5a78a.png)

## Key changes

- Wrap "see more" links in section headers on mobile devices.
- Remove "see more" link from profile article section (since it was deemed not to make sense).

## How to test

- Test that section header wraps correctly on small device sizes.