### PR TITLE
Add past events section to events directory

### DIFF
--- a/developerportal/apps/common/utils.py
+++ b/developerportal/apps/common/utils.py
@@ -59,13 +59,14 @@ def get_combined_articles_and_videos(page, **filters):
     )
 
 
-def get_combined_events(page, **filters):
+def get_combined_events(page, reverse=False, **filters):
     """Get internal and external events matching filters."""
     return get_resources(
         page,
         ["events.Event", "externalcontent.ExternalEvent"],
         filters=filters,
         order_by="start_date",
+        reverse=reverse,
     )
 
 

--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -136,8 +136,15 @@ class Events(BasePage):
 
     @property
     def events(self):
-        """Return events in chronological order"""
+        """Return future events in chronological order"""
         return get_combined_events(self, start_date__gte=datetime.date.today())
+
+    @property
+    def past_events(self):
+        """Return past events in reverse chronological order"""
+        return get_combined_events(
+            self, reverse=True, start_date__lt=datetime.date.today()
+        )
 
     def get_filters(self):
         from ..topics.models import Topic

--- a/developerportal/apps/events/templates/events.html
+++ b/developerportal/apps/events/templates/events.html
@@ -10,21 +10,24 @@
 
 {% block content %}
   <main>
-    <section class="section{% if not page.featured|published %} section-pattern{% endif %}">
-      <div class="container">
-        <div class="section-header">
-          <h2>Events</h2>
+    {% if page.featured|published %}
+      <section class="section">
+        <div class="container">
+          <div class="section-header">
+            <h2>Featured</h2>
+          </div>
+          {% for event in page.featured.specific|published|by_key:"value" %}
+            {% include "molecules/cards/card.html" with resource=event featured=True %}
+          {% endfor %}
         </div>
-        {% for event in page.featured.specific|published|by_key:"value" %}
-          {% include "molecules/cards/card.html" with resource=event featured=True %}
-        {% endfor %}
-      </div>
-      {% if page.featured|published %}
-        </section>
-        <section class="section section-pattern">
-      {% endif %}
-      {% include "organisms/filter-list.html" with type="event" resources=page.events initial_resources=6 resources_per_page=4 no_resources_message="No upcoming events found" %}
+      </section>
+    {% endif %}
+    <section class="section section-pattern">
+      {% include "organisms/filter-list.html" with type="event" heading="Upcoming events" resources=page.events initial_resources=6 resources_per_page=4 no_resources_message="No upcoming events found" %}
     </section>
+    {% if page.past_events %}
+      {% include "organisms/past-events.html" with events=page.past_events %}
+    {% endif %}
     {% include "organisms/newsletter-signup.html" %}
   </main>
 {% endblock content %}

--- a/developerportal/apps/events/templates/events.html
+++ b/developerportal/apps/events/templates/events.html
@@ -26,7 +26,14 @@
       {% include "organisms/filter-list.html" with type="event" heading="Upcoming events" resources=page.events initial_resources=6 resources_per_page=4 no_resources_message="No upcoming events found" %}
     </section>
     {% if page.past_events %}
-      {% include "organisms/past-events.html" with events=page.past_events %}
+      <section class="section">
+        <div class="container">
+          <div class="section-header">
+            <h2>Past events</h2>
+          </div>
+          {% include "organisms/past-events.html" with events=page.past_events %}
+        </div>
+      </section>
     {% endif %}
     {% include "organisms/newsletter-signup.html" %}
   </main>

--- a/developerportal/templates/organisms/event-speakers.html
+++ b/developerportal/templates/organisms/event-speakers.html
@@ -13,16 +13,18 @@
       {% endwith %}
     {% endfor %}
   </div>
-  <div class="event-speakers-more">
-    <div class="event-speakers-actions">
-      <button class="mzp-c-button js-toggle" data-controls="#speaker-list" data-hide>See all</button>
+  {% if speakers|list|slice:"6:" %}
+    <div class="event-speakers-more">
+      <div class="event-speakers-actions">
+        <button class="mzp-c-button js-toggle" data-controls="#speaker-list" data-hide>See all</button>
+      </div>
+      <div class="card-container card-container-people" id="speaker-list" hidden>
+        {% for block in speakers|list|slice:"6:" %}
+          {% with block.value as speaker %}
+            {% include "molecules/item-person.html" with person=speaker type=block.block_type %}
+          {% endwith %}
+        {% endfor %}
+      </div>
     </div>
-    <div class="card-container card-container-people" id="speaker-list" hidden>
-      {% for block in speakers|list|slice:"6:" %}
-        {% with block.value as speaker %}
-          {% include "molecules/item-person.html" with person=speaker type=block.block_type %}
-        {% endwith %}
-      {% endfor %}
-    </div>
-  </div>
+  {% endif %}
 </div>

--- a/developerportal/templates/organisms/event-speakers.html
+++ b/developerportal/templates/organisms/event-speakers.html
@@ -13,18 +13,20 @@
       {% endwith %}
     {% endfor %}
   </div>
-  {% if speakers|list|slice:"6:" %}
-    <div class="event-speakers-more">
-      <div class="event-speakers-actions">
-        <button class="mzp-c-button js-toggle" data-controls="#speaker-list" data-hide>See all</button>
+  {% with speakers|list|slice:"6:" as speaker_rest %}
+    {% if speaker_rest %}
+      <div class="event-speakers-more">
+        <div class="event-speakers-actions">
+          <button class="mzp-c-button js-toggle" data-controls="#speaker-list" data-hide>See all</button>
+        </div>
+        <div class="card-container card-container-people" id="speaker-list" hidden>
+          {% for block in speaker_rest %}
+            {% with block.value as speaker %}
+              {% include "molecules/item-person.html" with person=speaker type=block.block_type %}
+            {% endwith %}
+          {% endfor %}
+        </div>
       </div>
-      <div class="card-container card-container-people" id="speaker-list" hidden>
-        {% for block in speakers|list|slice:"6:" %}
-          {% with block.value as speaker %}
-            {% include "molecules/item-person.html" with person=speaker type=block.block_type %}
-          {% endwith %}
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
+    {% endif %}
+  {% endwith %}
 </div>

--- a/developerportal/templates/organisms/filter-list.html
+++ b/developerportal/templates/organisms/filter-list.html
@@ -5,6 +5,9 @@
     </div>
     <div class="container">
       {% if resources %}
+        {% if heading %}
+          <h2>{{ heading }}</h2>
+        {% endif %}
         <div class="filter-list-content">
           <aside class="filter-list-sidebar">
             <details class="filter-list-sidebar-content filter-list-sidebar-content-mobile">

--- a/developerportal/templates/organisms/past-events.html
+++ b/developerportal/templates/organisms/past-events.html
@@ -1,20 +1,13 @@
-<section class="section">
-  <div class="container">
-    <div class="section-header">
-      <h2>Past events</h2>
-    </div>
-    {% for event in events|slice:":3" %}
+{% for event in events|slice:":3" %}
+  {% include "molecules/cards/card.html" with resource=event %}
+{% endfor %}
+{% if events|slice:"3:" %}
+  <div class="filter-list-actions">
+    <button class="mzp-c-button js-toggle" data-controls="#past-event-list" data-hide>See all</button>
+  </div>
+  <div id="past-event-list" hidden>
+    {% for event in events|slice:"3:" %}
       {% include "molecules/cards/card.html" with resource=event %}
     {% endfor %}
-    {% if events|slice:"3:" %}
-      <div class="filter-list-actions">
-        <button class="mzp-c-button js-toggle" data-controls="#past-event-list" data-hide>See all</button>
-      </div>
-      <div id="past-event-list" hidden>
-        {% for event in events|slice:"3:" %}
-          {% include "molecules/cards/card.html" with resource=event %}
-        {% endfor %}
-      </div>
-    {% endif %}
   </div>
-</section>
+{% endif %}

--- a/developerportal/templates/organisms/past-events.html
+++ b/developerportal/templates/organisms/past-events.html
@@ -1,0 +1,20 @@
+<section class="section">
+  <div class="container">
+    <div class="section-header">
+      <h2>Past events</h2>
+    </div>
+    {% for event in events|slice:":3" %}
+      {% include "molecules/cards/card.html" with resource=event %}
+    {% endfor %}
+    {% if events|slice:"3:" %}
+      <div class="filter-list-actions">
+        <button class="mzp-c-button js-toggle" data-controls="#past-event-list" data-hide>See all</button>
+      </div>
+      <div id="past-event-list" hidden>
+        {% for event in events|slice:"3:" %}
+          {% include "molecules/cards/card.html" with resource=event %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+</section>

--- a/src/js/atoms/toggle.js
+++ b/src/js/atoms/toggle.js
@@ -32,7 +32,7 @@ module.exports = class Toggle {
    */
   onToggleClick(event) {
     event.preventDefault();
-    const { controls, hide } = this.toggle.dataset;
+    const { controls } = this.toggle.dataset;
     const targetEls = document.querySelectorAll(controls);
 
     Array.from(targetEls).forEach(targetEl => {
@@ -40,6 +40,6 @@ module.exports = class Toggle {
       targetEl.hidden = !targetEl.hidden;
     });
 
-    if (hide) this.toggle.hidden = false;
+    if ('hide' in this.toggle.dataset) this.toggle.hidden = true;
   }
 };


### PR DESCRIPTION
This changeset adds a "past events" section to the events directory page, allowing users to see historical events and view their respective singular pages.

Screenshot of upcoming/past events sections:

![image](https://user-images.githubusercontent.com/1469007/66920319-f0b94380-f01a-11e9-93ea-0e276beebb1c.png)

## Key changes

- Add a "past events" section to the events directory page.
- Adjust heading structure within directory page to accommodate multiple event lists.
- Fix button hiding bug within toggle component.

## How to test

- Ensure past events are within the system.
- Observe that a "past events" section displays correctly within the events directory page.
- Ensure that after three past events, a "see all" button appears and more events are shown after this button is clicked.