### PR TITLE
Fixes certain race conditions on the ci test jobs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ social-auth-app-django==3.1.0
 wagtail==2.6.2
 wagtail-bakery==0.3.0
 whitenoise==4.1.4
+urlwait==0.4
 ## The following requirements were added by pip freeze:
 appdirs==1.4.3
 beautifulsoup4==4.6.0

--- a/scripts/ci-setup
+++ b/scripts/ci-setup
@@ -27,6 +27,12 @@ do
   shift
 done
 
+# Remove env file to get a clean env
+echo "Removing old .env file"
+if [ -f .env ]; then
+    echo "Removing env file"
+    rm -f .env
+fi
 
 echo "Setting up environment"
 
@@ -42,10 +48,18 @@ POSTGRES_PASSWORD=$(openssl rand -base64 64 | tr -d '+/\n=')
 POSTGRES_USER=admin
 EOF
 
+echo "Taking down any existing containers"
+docker-compose down --remove-orphans --volumes
+
 if [ -n "${ARG_BUILD}" ]; then
     echo "Running build"
     docker-compose up --build --detach
 fi
+
+# wait for services to be up
+echo "Waiting on services to come up"
+docker-compose exec -T app urlwait postgresql://db:5432/developerportal 30
+docker-compose exec -T app urlwait redis://redis:6379/0 30
 
 echo "Running migrate"
 docker-compose exec -T app python manage.py migrate

--- a/scripts/ci-setup
+++ b/scripts/ci-setup
@@ -29,7 +29,7 @@ done
 
 # Remove env file to get a clean env
 if [ -f .env ]; then
-    echo "Removing .env file"
+    echo "Removing old .env file"
     rm -f .env
 fi
 

--- a/scripts/ci-setup
+++ b/scripts/ci-setup
@@ -28,7 +28,6 @@ do
 done
 
 # Remove env file to get a clean env
-echo "Removing old .env file"
 if [ -f .env ]; then
     echo "Removing env file"
     rm -f .env

--- a/scripts/ci-setup
+++ b/scripts/ci-setup
@@ -29,7 +29,7 @@ done
 
 # Remove env file to get a clean env
 if [ -f .env ]; then
-    echo "Removing env file"
+    echo "Removing .env file"
     rm -f .env
 fi
 


### PR DESCRIPTION
There are certain conditions that we run into that causes ci jobs fail
and its generally caused by either the database not being ready or a
permission denied error, which to me indicates that the old credentials
are still lingering after a job completes.

This commit hopes to fix that by using the `urlwait` tool to wait for
the database instance to be up and running as well as additional steps
in there that will go ahead and cleanup the environment before a build
and run.

(Resolves #389)

## Key changes:

- Add `urlwait` tool as a requirement
- Remove `.env` file if it exists
- Ensure that there are no running containers when `docker-compose` up gets run
- Add wait conditions in `ci-setup` script

## How to test

- From base directory run `scripts/ci-setup --build` and wait for build to complete
- Run `scripts/ci-tests`

Everything should work and there should be no errors when ran
