### PR TITLE
Fix some logical error that causes slack to notify even when tests pass

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,12 +80,20 @@ node {
         try {
             sh "scripts/ci-setup --build"
             sh "scripts/ci-tests"
-        } finally {
-            sh "docker-compose down --volumes --remove-orphans"
+
             notify_slack([
+              stage: "Running test on tag ${tag}",
+              status: 'success'
+            ])
+
+        } catch (err) {
+          notify_slack([
               stage: "Test run failed on tag ${tag}",
               status: 'failure'
             ])
+            throw err
+        } finally {
+            sh "docker-compose down --volumes --remove-orphans"
         }
       }
       stage('Push Images') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ node {
             ])
 
         } catch (err) {
-          notify_slack([
+            notify_slack([
               stage: "Test run failed on tag ${tag}",
               status: 'failure'
             ])


### PR DESCRIPTION
Fixes a logic error that causes jenkins to notify even when tests passes

(Resolves #55)

## Key changes:

- Added a `catch` block
- Sneaked in a notify when tests are sucessful

