### PR TITLE
279: Re-architect how we're using our task queue to avoid concurrent builds

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 known_first_party=developerportal
-known_third_party=boto3,celery,django_countries,modelcluster,pygments,readtime,social_core,taggit,urllib3,wagtail
+known_third_party=boto3,celery,django_countries,modelcluster,pytz,pygments,readtime,social_core,taggit,urllib3,wagtail
 known_django=django
 default_section=FIRSTPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/developerportal/apps/common/settings_helpers.py
+++ b/developerportal/apps/common/settings_helpers.py
@@ -1,0 +1,18 @@
+"""Functionality to help with configuring settings.
+DO NOT IMPORT django.conf.settings INTO THIS MODULE because it is imported
+into settings.base
+"""
+import os
+
+from developerportal.regex import REDIS_DB_URL_PATTERN
+
+
+def _get_redis_url_for_cache(redis_cache_db_number):
+    _redis_cache_url = os.environ.get("REDIS_URL", "redis://redis:6379")
+    if REDIS_DB_URL_PATTERN.match(_redis_cache_url):
+        raise RuntimeError(
+            "REDIS_URL specifies a specific database, not just the server"
+        )
+    if _redis_cache_url[-1] == "/":
+        _redis_cache_url = _redis_cache_url[:-1]
+    return _redis_cache_url + f"/{redis_cache_db_number}"

--- a/developerportal/apps/common/tests/test_regex.py
+++ b/developerportal/apps/common/tests/test_regex.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+
+from developerportal import regex as regex_module
+
+
+class TestRegexes(TestCase):
+    def test_redis_url_regex(self):
+        "Test we can spot a Redis URL that features a database component"
+
+        pattern = regex_module.REDIS_DB_URL_PATTERN
+
+        examples = [
+            ("redis://redis:6789", False),
+            ("redis://redis:6789/1", True),
+            ("redis://redis:6789/22", True),
+            ("redis://redis.example.com/some/resource:6789", False),
+            ("redis://redis.example.com/some/resource:6789/0", True),
+            ("redis://redis.example.com/some/resource:6789/22", True),
+        ]
+
+        for (input_, expect_a_hit) in examples:
+            if expect_a_hit:
+                self.assertTrue(pattern.match(input_))
+                self.assertTrue(pattern.search(input_))
+            else:
+                self.assertIsNone(pattern.match(input_))
+                self.assertIsNone(pattern.search(input_))

--- a/developerportal/apps/common/tests/test_settings_helpers.py
+++ b/developerportal/apps/common/tests/test_settings_helpers.py
@@ -1,0 +1,27 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from developerportal.apps.common.settings_helpers import _get_redis_url_for_cache
+
+REDIS_CACHE_DB_NUMBER = 15
+
+
+class TestHelpers(TestCase):
+    def test__get_redis_url_for_cache(self):
+
+        examples = [
+            ("redis://redis:6789", f"redis://redis:6789/{REDIS_CACHE_DB_NUMBER}"),
+            (
+                "redis://redis.example.com/path/to/thing:6789",
+                f"redis://redis.example.com/path/to/thing:6789/{REDIS_CACHE_DB_NUMBER}",
+            ),
+        ]
+        for input_, expected in examples:
+            with mock.patch(
+                "developerportal.apps.common.settings_helpers.os.environ.get"
+            ) as mock_environ_get:
+                mock_environ_get.return_value = input_
+                self.assertEqual(
+                    _get_redis_url_for_cache(REDIS_CACHE_DB_NUMBER), expected
+                )

--- a/developerportal/apps/staticbuild/celery.py
+++ b/developerportal/apps/staticbuild/celery.py
@@ -4,6 +4,8 @@ from django.conf import settings
 
 from celery import Celery
 
+STATIC_BUILD_JOB_ATTEMPT_FREQUENCY = 60.0 * 1  # Check each minute
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "developerportal.settings.production")
 
 app = Celery("developerportal.apps.staticbuild", broker=settings.CELERY_BROKER_URL)
@@ -12,3 +14,13 @@ app = Celery("developerportal.apps.staticbuild", broker=settings.CELERY_BROKER_U
 app.config_from_object("django.conf:settings")
 
 app.autodiscover_tasks()
+
+# Set up a Celery Beat task to try to build the static site every minute
+app.conf.beat_schedule = {
+    "add-every-minute": {
+        "task": "developerportal.apps.staticbuild.wagtail_hooks._static_build_async",
+        "schedule": STATIC_BUILD_JOB_ATTEMPT_FREQUENCY,
+        "args": (),
+    }
+}
+app.conf.timezone = "UTC"

--- a/developerportal/apps/staticbuild/context_managers.py
+++ b/developerportal/apps/staticbuild/context_managers.py
@@ -17,7 +17,7 @@ LOCK_EXPIRE = 60 * 10  # Lock expires in 10 minutes
 @contextmanager
 def redis_lock(lock_id, oid):
     timeout_at = monotonic() + LOCK_EXPIRE - 3
-    # cache.add returns False if the key already exists
+    # cache.add returns None if the key already exists
     status = cache.add(lock_id, oid, LOCK_EXPIRE)
     try:
         yield status

--- a/developerportal/apps/staticbuild/context_managers.py
+++ b/developerportal/apps/staticbuild/context_managers.py
@@ -17,7 +17,7 @@ LOCK_EXPIRE = 60 * 10  # Lock expires in 10 minutes
 @contextmanager
 def redis_lock(lock_id, oid):
     timeout_at = monotonic() + LOCK_EXPIRE - 3
-    # cache.add fails if the key already exists
+    # cache.add returns False if the key already exists
     status = cache.add(lock_id, oid, LOCK_EXPIRE)
     try:
         yield status

--- a/developerportal/apps/staticbuild/context_managers.py
+++ b/developerportal/apps/staticbuild/context_managers.py
@@ -1,0 +1,30 @@
+# Heavily based on
+# https://docs.celeryproject.org/en/latest/tutorials/task-cookbook.html
+# #ensuring-a-task-is-only-executed-one-at-a-time
+
+from contextlib import contextmanager
+
+from django.core.cache import cache
+
+from celery.five import monotonic
+from celery.utils.log import get_task_logger
+
+logger = get_task_logger(__name__)
+
+LOCK_EXPIRE = 60 * 10  # Lock expires in 10 minutes
+
+
+@contextmanager
+def redis_lock(lock_id, oid):
+    timeout_at = monotonic() + LOCK_EXPIRE - 3
+    # cache.add fails if the key already exists
+    status = cache.add(lock_id, oid, LOCK_EXPIRE)
+    try:
+        yield status
+    finally:
+        if monotonic() < timeout_at and status:
+            # Don't release the lock if we exceeded the timeout
+            # to lessen the chance of releasing an expired lock
+            # owned by someone else.
+            # Also don't release the lock if we didn't acquire it.
+            cache.delete(lock_id)

--- a/developerportal/apps/staticbuild/management/commands/enqueue_build_and_sync_task.py
+++ b/developerportal/apps/staticbuild/management/commands/enqueue_build_and_sync_task.py
@@ -2,16 +2,16 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from developerportal.apps.staticbuild.wagtail_hooks import _static_build_async
+from developerportal.apps.staticbuild.wagtail_hooks import static_build
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    """Management to manually queue up a "build-and-sync-to-S3" of the
-    current published state of the site"""
+    """Management to manually enqueue a request for a "build-and-sync-to-S3" of the
+    current/latest published state of the site."""
 
     def handle(self, *args, **options):
-        logger.info("Adding a build-and-sync request to the task queue.")
-        _static_build_async.delay()
-        logger.info("Build-and-sync added to task queue.")
+        logger.info("Adding a request for a build-and-sync request to the task queue.")
+        static_build()
+        logger.info("Build-and-sync request added to task queue.")

--- a/developerportal/apps/staticbuild/tests/test_auto_build.py
+++ b/developerportal/apps/staticbuild/tests/test_auto_build.py
@@ -1,41 +1,31 @@
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from developerportal.apps.home.models import HomePage
 
 
-@override_settings(CELERY_ALWAYS_EAGER=True)
 class TestAutomaticBakingUponPublish(TestCase):
-    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.call_command")
-    def test_page_publish_triggers_async_tasks(self, mock_call_command):
+    @mock.patch(
+        "developerportal.apps.staticbuild.wagtail_hooks._request_static_build.delay"
+    )
+    def test_page_publish_triggers_async_tasks(self, mock_request_static_build_delay):
         self.homepage = HomePage.objects.get()
 
-        mock_call_command.reset_mock()
+        assert not mock_request_static_build_delay.called
 
         # One doesn't publish a page, one publishes a Revision
         revision = self.homepage.save_revision()
         revision.publish()
+        assert mock_request_static_build_delay.call_count == 1
 
-        assert mock_call_command.call_count == 2
-
-        #  check for the call that builds the static site
-        assert mock_call_command.call_args_list[0][0][0] == "build"
-
-        # now check for the call to sync the static site to S3
-        assert mock_call_command.call_args_list[1][0][0] == "publish"
-
-    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.call_command")
-    def test_page_unpublish_triggers_async_tasks(self, mock_call_command):
+    @mock.patch(
+        "developerportal.apps.staticbuild.wagtail_hooks._request_static_build.delay"
+    )
+    def test_page_unpublish_triggers_async_tasks(self, mock_request_static_build_delay):
         self.homepage = HomePage.objects.get()
-        mock_call_command.reset_mock()
+        assert not mock_request_static_build_delay.called
 
         # One can direcly unpublish a page, without needing a revision
         self.homepage.unpublish()
-        assert mock_call_command.call_count == 2
-
-        #  check for the call that builds the static site
-        assert mock_call_command.call_args_list[0][0][0] == "build"
-
-        # now check for the call to sync the static site to S3
-        assert mock_call_command.call_args_list[1][0][0] == "publish"
+        assert mock_request_static_build_delay.call_count == 1

--- a/developerportal/apps/staticbuild/tests/test_task_queue.py
+++ b/developerportal/apps/staticbuild/tests/test_task_queue.py
@@ -1,17 +1,34 @@
 import datetime
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.conf import settings
+from django.core.cache import cache
+from django.test import TestCase
 
 import pytz
 from developerportal.apps.staticbuild.wagtail_hooks import (
+    EXPECTED_BUILD_AND_SYNC_JOB_FUNC_NAME,
+    SENTINEL_KEY_NAME,
+    SENTINEL_LOCK_NAME,
     _generate_build_path,
+    _get_build_needed_sentinel,
+    _is_build_and_sync_job,
+    _request_static_build,
+    _set_build_needed_sentinel,
     _static_build_async,
+    static_build,
 )
 
 
 class TaskQueueBuildTests(TestCase):
-    @override_settings(BUILD_DIR="/path/to/build/dir/")
+    def setUp(self):
+        cache.delete(SENTINEL_KEY_NAME)
+        cache.delete(SENTINEL_LOCK_NAME)
+
+    def tearDown(self):
+        cache.delete(SENTINEL_KEY_NAME)
+        cache.delete(SENTINEL_LOCK_NAME)
+
     @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.tz_now")
     def test__generate_build_path(self, mock_tz_now):
         mock_tz_now.return_value = datetime.datetime(
@@ -19,15 +36,23 @@ class TaskQueueBuildTests(TestCase):
         )
         self.assertEqual(
             _generate_build_path(),
-            "/path/to/build/dir/2001-12-25T01:23:45.123456+00:00",
+            f"{settings.BUILD_DIR}/2001-12-25T01:23:45.123456+00:00",
         )
 
     @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.call_command")
     @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.shutil.rmtree")
     @mock.patch("developerportal.apps.staticbuild.wagtail_hooks._generate_build_path")
-    def test_static_build_async__uses_specific_build_path(
-        self, mock_generate_build_path, mock_rmtree, mock_call_command
+    @mock.patch(
+        "developerportal.apps.staticbuild.wagtail_hooks._get_build_needed_sentinel"
+    )
+    def test__static_build_async(
+        self,
+        mock_get_build_needed_sentinel,
+        mock_generate_build_path,
+        mock_rmtree,
+        mock_call_command,
     ):
+        mock_get_build_needed_sentinel.return_value = True  # else the build is blocked
         mock_generate_build_path.return_value = "/build/subdir/"
 
         _static_build_async()
@@ -40,3 +65,123 @@ class TaskQueueBuildTests(TestCase):
         assert mock_call_command.call_args_list[1][1]["build_dir"] == "/build/subdir/"
 
         mock_rmtree.assert_called_once_with("/build/subdir/")
+
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.call_command")
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.shutil.rmtree")
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks._generate_build_path")
+    @mock.patch(
+        "developerportal.apps.staticbuild.wagtail_hooks._get_build_needed_sentinel"
+    )
+    @mock.patch(
+        "developerportal.apps.staticbuild.wagtail_hooks._set_build_needed_sentinel"
+    )
+    def test__static_build_async__not_requested(
+        self,
+        mock_set_build_needed_sentinel,
+        mock_get_build_needed_sentinel,
+        mock_generate_build_path,
+        mock_rmtree,
+        mock_call_command,
+    ):
+        mock_get_build_needed_sentinel.return_value = False
+
+        with self.assertLogs(
+            "developerportal.apps.staticbuild.wagtail_hooks", level="INFO"
+        ) as cm:
+            _static_build_async()
+
+        self.assertEqual(
+            cm.output,
+            [
+                (
+                    "INFO:developerportal.apps.staticbuild.wagtail_hooks:"
+                    "[Static-build-and-sync] No fresh static build requested."
+                )
+            ],
+        )
+
+        assert not mock_generate_build_path.called
+        assert not mock_call_command.called
+        assert not mock_rmtree.called
+        assert not mock_set_build_needed_sentinel.called
+
+    @mock.patch("developerportal.apps.staticbuild.context_managers.cache.add")
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.call_command")
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks.shutil.rmtree")
+    @mock.patch("developerportal.apps.staticbuild.wagtail_hooks._generate_build_path")
+    @mock.patch(
+        "developerportal.apps.staticbuild.wagtail_hooks._get_build_needed_sentinel"
+    )
+    @mock.patch(
+        "developerportal.apps.staticbuild.wagtail_hooks._set_build_needed_sentinel"
+    )
+    def test__static_build_async__locked_but_requested(
+        self,
+        mock_set_build_needed_sentinel,
+        mock_get_build_needed_sentinel,
+        mock_generate_build_path,
+        mock_rmtree,
+        mock_call_command,
+        mock_cache_add,
+    ):
+        mock_get_build_needed_sentinel.return_value = True  # else the build is blocked
+        mock_generate_build_path.return_value = "/build/subdir/"
+
+        mock_get_build_needed_sentinel.return_value = True  # else the build is blocked
+
+        # Necause we're faking the sentinel's presence we can also check that it's
+        # re-set by a lock-blocked _static_build_async()
+        assert cache.get(SENTINEL_KEY_NAME) is None  #  for comparison later
+
+        # Mimick the idea that the job couldn't get a lock because
+        mock_cache_add.return_value = False
+
+        assert not mock_set_build_needed_sentinel.called
+
+        _static_build_async()
+
+        assert not mock_generate_build_path.called
+        assert not mock_call_command.called
+        assert not mock_rmtree.called
+        assert mock_cache_add.call_count == 1
+
+        # The blocked job should have set a flag for a retry next CeleryBeat ping
+        assert mock_set_build_needed_sentinel.call_count == 1
+
+    def test__is_build_and_sync_job(self):
+        for config in [
+            {"name": "test", "expected_result": False},
+            {"name": EXPECTED_BUILD_AND_SYNC_JOB_FUNC_NAME, "expected_result": True},
+        ]:
+            with self.subTest(config=config):
+                job_details = {"name": config["name"]}
+                self.assertEqual(
+                    _is_build_and_sync_job(job_details), config["expected_result"]
+                )
+
+    def test__set_build_needed_sentinel(self):
+        assert cache.get(SENTINEL_KEY_NAME) is None
+        _set_build_needed_sentinel(oid="test")
+        assert cache.get(SENTINEL_KEY_NAME) is True
+
+    def test__get_build_needed_sentinel(self):
+        assert cache.get(SENTINEL_KEY_NAME) is None
+        assert _get_build_needed_sentinel(oid="test") is None
+        cache.set(SENTINEL_KEY_NAME, True)
+        assert _get_build_needed_sentinel(oid="test") is True
+
+    @mock.patch(
+        "developerportal.apps.staticbuild.wagtail_hooks._set_build_needed_sentinel"
+    )
+    def test__request_static_build(self, mock_set_build_needed_sentinel):
+        assert not mock_set_build_needed_sentinel.called
+        _request_static_build()
+        assert mock_set_build_needed_sentinel.call_count == 1
+
+    @mock.patch(
+        "developerportal.apps.staticbuild.wagtail_hooks._request_static_build.delay"
+    )
+    def test_static_build(self, mock_request_static_build_delay):
+        assert not mock_request_static_build_delay.called
+        static_build()
+        assert mock_request_static_build_delay.call_count == 1

--- a/developerportal/apps/staticbuild/wagtail_hooks.py
+++ b/developerportal/apps/staticbuild/wagtail_hooks.py
@@ -100,7 +100,7 @@ def _set_build_needed_sentinel(oid):
 
 @app.task(bind=True)
 def _request_static_build(self, **kwargs):
-    log_prefix = "[Static build requester]"
+    log_prefix = "[Static-build-and-sync requester]"
     logger.info(
         f"{log_prefix} Caching a sentinel marker to request a static build "
         f"within the next {STATIC_BUILD_JOB_ATTEMPT_FREQUENCY} seconds."
@@ -118,8 +118,8 @@ def _static_build_async(self, force=False, pipeline=settings.STATIC_BUILD_PIPELI
         force (optional): Boolean - used to run a build even when DEBUG is False
         pipeline (optional): tuple of strings that map to wagtail-bakery commands
     """
-    logger.info("Starting _static_build_async")
-    log_prefix = "[Static build]"
+    logger.debug("Entering _static_build_async")
+    log_prefix = "[Static-build-and-sync]"
     build_dir = None
 
     if not force:
@@ -128,12 +128,12 @@ def _static_build_async(self, force=False, pipeline=settings.STATIC_BUILD_PIPELI
             sentinel_val = cache.get(SENTINEL_KEY_NAME)
             cache.delete(SENTINEL_KEY_NAME)
             if sentinel_val is not True:
-                logger.info(f"{log_prefix} No static build requested.")
+                logger.info(f"{log_prefix} No fresh static build requested.")
                 return
 
     # If we reach here, an actual build is needed, but only if one is not
     # already in progress.
-    logger.info(f"{log_prefix} Starting fresh build")
+    logger.info(f"{log_prefix} Attempting fresh build")
     with redis_lock(lock_id=BUILD_LOCK_NAME, oid=self.app.oid) as lock_acquired:
         if lock_acquired:
 

--- a/developerportal/apps/staticbuild/wagtail_hooks.py
+++ b/developerportal/apps/staticbuild/wagtail_hooks.py
@@ -3,14 +3,19 @@ import os
 import shutil
 
 from django.conf import settings
+from django.core.cache import cache
 from django.core.management import call_command
 from django.utils.timezone import now as tz_now
 
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.core.signals import page_published, page_unpublished
 
-from developerportal.apps.staticbuild.celery import app
+from developerportal.apps.staticbuild.celery import (
+    STATIC_BUILD_JOB_ATTEMPT_FREQUENCY,
+    app,
+)
 
+from .context_managers import redis_lock
 from .models import StaticBuild
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", logging.INFO))
@@ -27,41 +32,124 @@ class ArticleAdmin(ModelAdmin):
 modeladmin_register(ArticleAdmin)
 
 
+# === TASK QUEUE / CELERY CODE ===
+
+# Concurrent builds, while wasteful, are possible when running Celery.
+# _request_static_build tries to deal with this.
+
+EXPECTED_BUILD_AND_SYNC_JOB_FUNC_NAME = (
+    "developerportal.apps.staticbuild.wagtail_hooks._static_build_async"
+)
+
+# Evaluate this now to avoid an awkward edge cause during concurrent builds where it
+# (somehow) an os.path.join()ed value involving settings.BUILD_DIR gets re-set with
+# the joined value...
+BUILD_ROOT_DIR = settings.BUILD_DIR
+
+SENTINEL_KEY_TIMEOUT = (
+    60 * 15
+)  # 15 mins - longer than a build-and-sync should be taking
+SENTINEL_KEY_NAME = "devportal-fresh-build-and-sync-needed"
+SENTINEL_LOCK_NAME = "deveportal-sentinel-lock"
+BUILD_LOCK_NAME = "deveportal-build-and-sync-lock"
+
+
 def _generate_build_path():
     """Generate a unique build path to avoid concurrent builds clashing"""
-    return os.path.join(settings.BUILD_DIR, tz_now().isoformat())
+    return os.path.join(BUILD_ROOT_DIR, tz_now().isoformat())
+
+
+def _is_build_and_sync_job(job_details):
+    return job_details["name"] == EXPECTED_BUILD_AND_SYNC_JOB_FUNC_NAME
+
+
+def _set_build_needed_sentinel():
+    """Idempotent flag that a static build should be attempted when next checked
+    (which is within STATIC_BUILD_JOB_ATTEMPT_FREQUENCY seconds)"""
+    with cache.lock(SENTINEL_LOCK_NAME):
+        cache.set(SENTINEL_KEY_NAME, True, SENTINEL_KEY_TIMEOUT)
+        print(cache.get(SENTINEL_KEY_NAME))
 
 
 @app.task
-def _static_build_async(force=False, pipeline=settings.STATIC_BUILD_PIPELINE):
-    """Calls each command in the static build pipeline in turn."""
-    log_prefix = "Static build task"
+def _request_static_build(**kwargs):
+    log_prefix = "[Static build requester]"
+    logger.info(
+        f"{log_prefix} Caching a sentinel marker to request a static build "
+        f"within the next {STATIC_BUILD_JOB_ATTEMPT_FREQUENCY} seconds."
+    )
+    _set_build_needed_sentinel()
+
+
+@app.task(bind=True)
+def _static_build_async(self, force=False, pipeline=settings.STATIC_BUILD_PIPELINE):
+    """Schedulable task that, if it gets the appropriate flag, calls each command
+    in the static build pipeline in turn.
+
+    See setup_periodic_tasks, above.
+
+        force (optional): Boolean - used to run a build even when DEBUG is False
+        pipeline (optional): tuple of strings that map to wagtail-bakery commands
+    """
+    logger.info("Starting _static_build_async")
+    log_prefix = "[Static build]"
     build_dir = None
 
-    if settings.DEBUG is False or force:
-        build_dir = _generate_build_path()
-        logger.info(f"{log_prefix} Created temporary build dir {build_dir}")
+    if not force:
+        # Check to see if a build has been requested, and if so, wipe they key.
+        with cache.lock(SENTINEL_LOCK_NAME):
+            print("BEFORE cache.get(SENTINEL_KEY_NAME)", cache.get(SENTINEL_KEY_NAME))
+            sentinel_val = cache.get(SENTINEL_KEY_NAME)
+            cache.delete(SENTINEL_KEY_NAME)
+            print("AFTER cache.get(SENTINEL_KEY_NAME)", cache.get(SENTINEL_KEY_NAME))
+            if sentinel_val is not True:
+                logger.info(f"{log_prefix} No static build requested.")
+                return
 
-    for name, command in pipeline:
-        if settings.DEBUG and not force:
-            logger.info(f"{log_prefix} (wagtail-bakery) command '{name}' skipped.")
+    # If we reach here, an actual build is needed, but only if one is not
+    # already in progress.
+    logger.info(f"{log_prefix}Starting fresh build")
+    with redis_lock(lock_id=BUILD_LOCK_NAME, oid=self.app.oid) as lock_acquired:
+        if lock_acquired:
+
+            build_dir = _generate_build_path()
+            logger.info(f"{log_prefix} Created temporary build dir {build_dir}")
+
+            for name, command in pipeline:
+                if settings.DEBUG and not force:
+                    logger.info(
+                        f"{log_prefix} (wagtail-bakery) command '{name}' skipped."
+                    )
+                else:
+                    logger.info(
+                        f"{log_prefix} (wagtail-bakery) command '{name}' started."
+                    )
+                    call_command(
+                        command,
+                        build_dir=build_dir,
+                        verbosity=0,  # Else stdout is output as logger.WARNING
+                    )
+                    logger.info(
+                        f"{log_prefix} (wagtail-bakery) command '{name}' finished."
+                    )
+
+            if build_dir:
+                shutil.rmtree(build_dir)
+                logger.info(f"{log_prefix} Deleted temporary build dir {build_dir}")
         else:
-            logger.info(f"{log_prefix} (wagtail-bakery) command '{name}' started.")
-            # We're passing in a specific output dir so that we don't risk
-            # concurrent builds clashing
-            call_command(command, build_dir=build_dir)
-            logger.info(f"{log_prefix} (wagtail-bakery) command '{name}' finished.")
-
-    if build_dir:
-        shutil.rmtree(build_dir)
-        logger.info(f"{log_prefix} Deleted temporary build dir {build_dir}")
+            # ie, we have no lock, so we give up and set a reminder to try again
+            logger.info(
+                f"{log_prefix} Skipping this build attempt: another is in progress. "
+                "Setting the sentinel so we'll try again later."
+            )
+            _set_build_needed_sentinel()
 
 
 def static_build(**kwargs):
     """Callback for Wagtail publish and unpublish signals to spawn a
-    task-queue job to do the actual build"""
+    task-queue job to do the actual build, if required"""
     force = kwargs.get("force", False)
-    _static_build_async.delay(force=force)
+    _request_static_build.delay(force=force)
 
 
 page_published.connect(static_build)

--- a/developerportal/apps/staticbuild/wagtail_hooks.py
+++ b/developerportal/apps/staticbuild/wagtail_hooks.py
@@ -106,7 +106,7 @@ def _get_build_needed_sentinel(oid):
 
 
 @app.task(bind=True)
-def _request_static_build(self, **kwargs):
+def _request_static_build(self):
     log_prefix = "[Static-build-and-sync requester]"
     logger.info(
         f"{log_prefix} Caching a sentinel marker to request a static build "
@@ -178,8 +178,7 @@ def _static_build_async(self, force=False, pipeline=settings.STATIC_BUILD_PIPELI
 def static_build(**kwargs):
     """Callback for Wagtail publish and unpublish signals to spawn a
     task-queue job to do the actual build, if required"""
-    force = kwargs.get("force", False)
-    _request_static_build.delay(force=force)
+    _request_static_build.delay()
 
 
 page_published.connect(static_build)

--- a/developerportal/regex.py
+++ b/developerportal/regex.py
@@ -1,0 +1,4 @@
+import re
+
+# Spot a REDIS_URL with a DB number associated with it
+REDIS_DB_URL_PATTERN = re.compile(r"redis\:\/\/.*\d{4,5}(\/\d{1,2})")

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -322,3 +322,16 @@ CELERY_RESULT_BACKEND = "django-db"  #  for django-celery-results
 CELERY_ACCEPT_CONTENT = ["application/json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
+CELERY_TIMEZONE = "UTC"
+CELERY_ENABLE_UTC = True
+
+_redis_cache_url = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+_redis_cache_url = _redis_cache_url.replace("/0", "/1")
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": _redis_cache_url,
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+    }
+}

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -16,6 +16,8 @@ from django.core.management.utils import get_random_secret_key
 
 from wagtail.embeds.oembed_providers import all_providers
 
+from developerportal.apps.common.settings_helpers import _get_redis_url_for_cache
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -317,7 +319,7 @@ MAPBOX_ACCESS_TOKEN = os.environ.get("MAPBOX_ACCESS_TOKEN")
 COUNTRIES_FIRST = ["US", "GB"]
 
 # Celery settings
-CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://redis:6379")
 CELERY_RESULT_BACKEND = "django-db"  #  for django-celery-results
 CELERY_ACCEPT_CONTENT = ["application/json"]
 CELERY_TASK_SERIALIZER = "json"
@@ -325,13 +327,12 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = "UTC"
 CELERY_ENABLE_UTC = True
 
-_redis_cache_url = os.environ.get("REDIS_URL", "redis://redis:6379/0")
-_redis_cache_url = _redis_cache_url.replace("/0", "/1")
+REDIS_CACHE_DB_NUMBER = os.environ.get("REDIS_CACHE_DB_NUMBER", "1")
 
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": _redis_cache_url,
+        "LOCATION": _get_redis_url_for_cache(REDIS_CACHE_DB_NUMBER),
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
     }
 }

--- a/developerportal/settings/dev.py
+++ b/developerportal/settings/dev.py
@@ -6,7 +6,7 @@ DEBUG = True
 # SECURITY WARNING: define the correct hosts in production!
 ALLOWED_HOSTS = ["*"]
 
-CELERY_BROKER_URL = "redis://redis:6379/0"
+CELERY_BROKER_URL = "redis://redis:6379"
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 

--- a/developerportal/settings/test.py
+++ b/developerportal/settings/test.py
@@ -1,0 +1,3 @@
+from .production import *
+
+CACHES["default"]["KEY_PREFIX"] = "test"

--- a/developerportal/settings/test_fast.py
+++ b/developerportal/settings/test_fast.py
@@ -1,3 +1,3 @@
-from .dev import *
+from .test import *
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,12 +36,17 @@ services:
     <<: *common
     command: gunicorn developerportal.wsgi:application --bind=0.0.0.0:8000 --reload --workers=3
     ports:
-      - "8000:8000"
+      - '8000:8000'
     user: ${UID:-1000}
 
   worker:
     <<: *common
     command: celery -A developerportal.apps.staticbuild worker -l info
+    user: ${UID:-1000}
+
+  scheduler:
+    <<: *common
+    command: celery -A developerportal.apps.staticbuild beat -l debug
     user: ${UID:-1000}
 
   static:

--- a/k8s/celery.yaml.j2
+++ b/k8s/celery.yaml.j2
@@ -37,4 +37,24 @@ spec:
             limits:
               cpu: {{ CELERY_WORKER_CPU_LIMIT }}
               memory: {{ CELERY_WORKER_MEMORY_LIMIT }}
+        - name: {{ CELERY_SCHEDULER_NAME }}
+          image: "{{ APP_IMAGE }}:{{ APP_IMAGE_TAG }}"
+          imagePullPolicy: {{ APP_IMAGE_PULL_POLICY }}
+          volumeMounts:
+            - name: developer-portal-fs
+              mountPath: {{ APP_MOUNT_PATH }}
+          command:
+            - "celery"
+          args:
+            - "--app=developerportal.apps.staticbuild"
+            - beat
+            - "--loglevel=INFO"
+            - "--concurrency={{ CELERY_SCHEDULER_CONCURRENCY }}"
+          resources:
+            requests:
+              cpu: {{ CELERY_SCHEDULER_CPU_REQUEST }}
+              memory: {{ CELERY_SCHEDULER_MEMORY_REQUEST }}
+            limits:
+              cpu: {{ CELERY_SCHEDULER_CPU_LIMIT }}
+              memory: {{ CELERY_SCHEDULER_MEMORY_LIMIT }}
 {% include 'app.env.yaml.j2' %}

--- a/k8s/celery.yaml.j2
+++ b/k8s/celery.yaml.j2
@@ -37,24 +37,4 @@ spec:
             limits:
               cpu: {{ CELERY_WORKER_CPU_LIMIT }}
               memory: {{ CELERY_WORKER_MEMORY_LIMIT }}
-        - name: {{ CELERY_SCHEDULER_NAME }}
-          image: "{{ APP_IMAGE }}:{{ APP_IMAGE_TAG }}"
-          imagePullPolicy: {{ APP_IMAGE_PULL_POLICY }}
-          volumeMounts:
-            - name: developer-portal-fs
-              mountPath: {{ APP_MOUNT_PATH }}
-          command:
-            - "celery"
-          args:
-            - "--app=developerportal.apps.staticbuild"
-            - beat
-            - "--loglevel=INFO"
-            - "--concurrency={{ CELERY_SCHEDULER_CONCURRENCY }}"
-          resources:
-            requests:
-              cpu: {{ CELERY_SCHEDULER_CPU_REQUEST }}
-              memory: {{ CELERY_SCHEDULER_MEMORY_REQUEST }}
-            limits:
-              cpu: {{ CELERY_SCHEDULER_CPU_LIMIT }}
-              memory: {{ CELERY_SCHEDULER_MEMORY_LIMIT }}
 {% include 'app.env.yaml.j2' %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 Django==2.2.6
 celery==4.3.0
 redis==3.3.11
+kombu==4.5.0  # This is not the latest, but see https://github.com/celery/kombu/issues/1087
 django-celery-results==1.1.2
+django-redis==4.10.0
 gunicorn==19.9.0
 meinheld==1.0.1
 django-storages==1.7.2

--- a/scripts/ci-tests
+++ b/scripts/ci-tests
@@ -3,5 +3,5 @@
 set -eo pipefail
 
 echo "Running tests"
-docker-compose exec -T app python manage.py test
+docker-compose exec -T app python manage.py test --settings=developerportal.settings.test
 docker-compose exec -T static npm run test


### PR DESCRIPTION
If merged, this changeset addresses the need to avoid concurrent and therefore conflicting builds being processed by the task queue.

It does this by switching from a pattern where builds are immediately enqueued (and picked up by workers) to one where builds are idempotently _requested_. A periodic task checks each minute if a build is needed and, if so, performs it.
 
(Resolves #279 - and goes beyond this, because it became clear it was necessary)

## Key changes:

-  Refactor how we enqueue jobs in Celery, to avoid concurrent builds and race conditions

    Prior to this commit, if a flurry of build requests were issued (eg multiple authors publishing)
this would put N jobs in the queue. Celery is configured by default to use the number of cores
on its worker node, so this would mean 4 (or more) builds taking place at once, and all targetting
the same output bucket in S3.

    IFF one could trust that the order of execution was stable, this would be tolerable (if wasteful)
but because it's async, there's no guarantee that Worker 4 will finish after Workers 1, 2 and 3.
Plus, this would cause four calls to invalidate the entire CDN, which itself is a bit of a black-box experience as it rolls from "InProgress" to "Complete".

    So, a new approach is needed.

    I've taken a few swings at this, most of which were just not satisfactory. (eg, in-task code that
checks for other running tasks of the same type is still prone to stale state and therefore bad
decisions about whether to terminate itself or carry on, etc). Running celery with `--pool=solo`
to only do one thing at a time would quickly cause problems as soon as we needed to do _other_
things with a task queue, or spin up multiple worker nodes, etc.

    So, instead, the approach has changed to one where builds are requested, and then that signal is checked frequently and exclusively actioned if it's neeeded.

    We do this using a sentinel value, stored in a shared (Redis-backed) cache that, when `True`,
signifies that a build is required. Separately from this, we have a regular scheduled task (via celery-beat) that calls the `_static_build_async` task every minute. That task function has been updated to:
a) check for the sentinel to decide whether to do a build or not, and - if it's set - to then un-set it before going ahead and start a build-and-sync to S3
b) use a distributed lock to ensure that no other builds can take place while this build is running
c) if a build is skipped because one _is_ running, ensure the sentinel is set again so that the next time the scheduler tries, it will still be clear that a fresh build is needed.

This means that for a flurry of, say, 8 requests, request 1 will trigger a build, while the rest will just (idempotently) set the sentinel to point out that someone else wanted a build while the current one was completing. If one or more fresh build requests come in while a build is in progress, that will be honoured as soon as the previous build completes.

- Update k8s config to spin up a celerybeat scheduler pod, too

- (implicit in the above) Start using Redis as a Django cache backend -- seemed appropriate given we already have it in place. Note we use DB `1`, not Celery's DB `0`

- Amend management command to call a more appropriate build-and-sync command, so that we don't risk concurrent builds

-  Add test settings based on production ones (not dev) and make the cache safe + ensure CI tests use the test settings

- Drop support for forced builds via this new approach (they are still possible in development, but they're not relevant to the production pattern anyway)

- Add tests

## How to test

- Ensure your .env has configuration for exporting a site to S3 in your `local.py` and that the bucket exists. *Do not use staging or production credentials/buckets here*.
```
# AWS_ACCESS_KEY_ID = "ADD_ME"
# AWS_SECRET_ACCESS_KEY = "ADD_ME"
# AWS_BUCKET_NAME = "BUCKET_NAME_HERE"  # Destination of baked site
# AWS_REGION = "REGION_NAME_HERE"  # eg eu-west-1
```
- Bring up the local docker stack: `docker-compose build && docker-compose up`
- Confirm you see `worker_1` and `scheduler_1` containers running
- Confirm you can see `scheduler_1` checking for the intent flag:

```
scheduler_1  | [2019-10-18 11:31:06,527: INFO/MainProcess] Scheduler: Sending due task add-every-minute (developerportal.apps.staticbuild.wagtail_hooks._static_build_async)
scheduler_1  | [2019-10-18 11:31:06,538: DEBUG/MainProcess] developerportal.apps.staticbuild.wagtail_hooks._static_build_async sent. id->921a5a92-8011-428b-a6b3-08c396ae11a6
scheduler_1  | [2019-10-18 11:31:06,541: DEBUG/MainProcess] beat: Waking up in 59.98 seconds.
worker_1     | [2019-10-18 11:31:06,542: INFO/MainProcess] Received task: developerportal.apps.staticbuild.wagtail_hooks._static_build_async[921a5a92-8011-428b-a6b3-08c396ae11a6]
worker_1     | [2019-10-18 11:31:06,549: INFO/ForkPoolWorker-1] [Static-build-and-sync] No fresh static build requested.
worker_1     | [2019-10-18 11:31:06,571: INFO/ForkPoolWorker-1] Task developerportal.apps.staticbuild.wagtail_hooks._static_build_async[921a5a92-8011-428b-a6b3-08c396ae11a6] succeeded in 0.02505229998496361s: None
```
- Open another terminal and shell into Django: `docker-compose exec app manage.py shell`
- `from developerportal.apps.staticbuild.wagtail_hooks import static_build`
- Now call `static_build()` to signal the intention for a static build, then wait to see the scheduler notice it and trigger a build-and-sync

```
worker_1     | [2019-10-18 11:33:23,953: INFO/MainProcess] Received task: developerportal.apps.staticbuild.wagtail_hooks._request_static_build[9485327f-de69-42fd-9a66-2e12759295dd]
worker_1     | [2019-10-18 11:33:23,954: INFO/ForkPoolWorker-1] [Static-build-and-sync requester] Caching a sentinel marker to request a static build within the next 60.0 seconds.
worker_1     | [2019-10-18 11:33:23,969: INFO/ForkPoolWorker-1] Task developerportal.apps.staticbuild.wagtail_hooks._request_static_build[9485327f-de69-42fd-9a66-2e12759295dd] succeeded in 0.014500599994789809s: None
scheduler_1  | [2019-10-18 11:33:24,533: INFO/MainProcess] Scheduler: Sending due task add-every-minute (developerportal.apps.staticbuild.wagtail_hooks._static_build_async)
scheduler_1  | [2019-10-18 11:33:24,536: DEBUG/MainProcess] developerportal.apps.staticbuild.wagtail_hooks._static_build_async sent. id->3dc85ce5-3436-4034-9977-c0d03a428e58
scheduler_1  | [2019-10-18 11:33:24,536: DEBUG/MainProcess] beat: Waking up in 59.99 seconds.
worker_1     | [2019-10-18 11:33:24,537: INFO/MainProcess] Received task: developerportal.apps.staticbuild.wagtail_hooks._static_build_async[3dc85ce5-3436-4034-9977-c0d03a428e58]
worker_1     | [2019-10-18 11:33:24,542: INFO/ForkPoolWorker-2] [Static-build-and-sync] Attempting fresh build
worker_1     | [2019-10-18 11:33:24,543: INFO/ForkPoolWorker-2] [Static-build-and-sync] Created temporary build dir /app/build/2019-10-18T11:33:24.543392+00:00
worker_1     | [2019-10-18 11:33:24,543: INFO/ForkPoolWorker-2] [Static-build-and-sync] (wagtail-bakery) command 'Build' started.
...
worker_1     | [2019-10-18 11:33:39,376: INFO/ForkPoolWorker-2] [Static-build-and-sync] (wagtail-bakery) command 'Publish' finished.
...
```

(Note that by default, the scheduler checks to see if a static build has been called once a minute, which makes it harder to see the locking in action. So, you can edit line 22 of `staticbuild/celery.py` to set the `"schedule": 3` - the build-and-sync takes more than 3 seconds, so we'll get to see the locking taking place)
- Now call `static_build()` to signal the intention for a static build, then wait to see the scheduler pick it up
- Immediately call `static_build()` again to signal the intention for a static build, then wait to see the scheduler come back a second or two later, spot the intention, but defer acting upon it because there's already a build in progress:

```
worker_1     | [2019-10-18 11:34:57,547: INFO/ForkPoolWorker-4] [Static-build-and-sync] Attempting fresh build
worker_1     | [2019-10-18 11:34:57,548: INFO/ForkPoolWorker-4] [Static-build-and-sync] Skipping this build attempt: another is in progress. Setting the sentinel so we'll try again later.
```

## MERGE BLOCKERS
- [x] need #422 sorting first, so that we can bring this up on k8s
