### PR TITLE
Rename media bucket

### DIFF
--- a/k8s/config/stage-oregon.sh
+++ b/k8s/config/stage-oregon.sh
@@ -22,7 +22,7 @@ export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-stage.mdn.mozit.cloud
 export APP_EXPORTED_SITE_HOST=developer-portal-published.stage.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
-export APP_AWS_STORAGE_BUCKET_NAME=developer-portal-stage-media-178589013767
+export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-stage
 export APP_AWS_BUCKET_REGION=us-west-2
 export APP_MOUNT_PATH=/app/media
 

--- a/k8s/config/stage.sh
+++ b/k8s/config/stage.sh
@@ -22,7 +22,7 @@ export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal-dev.mdn.mozit.cloud
 export APP_EXPORTED_SITE_HOST=developer-portal-published.dev.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
-export APP_AWS_STORAGE_BUCKET_NAME=developer-portal-stage-media-178589013767
+export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-stage
 export APP_AWS_BUCKET_REGION=us-west-2
 export APP_MOUNT_PATH=/app/media
 


### PR DESCRIPTION
Simplifies the name of the s3 bucket, currently its using the convention of `developer-portal-<environment>-<account id>`, this PR moves the media bucket to a different bucket that has a shorter name

(Partially Resolves #318)

## Key changes:

- Rename media bucket

