### PR TITLE
Update docker-compose.yml to not make and run a redundant 'common' container 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,20 @@
 version: '3.4'
 
+x-common: &common
+  build:
+    context: .
+    target: app_base
+  depends_on:
+    - db
+    - redis
+  env_file: .env
+  tty: true
+  volumes:
+    - dist:/app/dist
+    - ./developerportal:/app/developerportal
+    - ./media:/app/media
+    - ./src:/app/src
+
 services:
   db:
     env_file: .env
@@ -17,26 +32,11 @@ services:
     image: redis:5.0.6-alpine
     tty: true
 
-  common: &common
-    build:
-      context: .
-      target: app_base
-    depends_on:
-      - db
-      - redis
-    env_file: .env
-    tty: true
-    volumes:
-      - dist:/app/dist
-      - ./developerportal:/app/developerportal
-      - ./media:/app/media
-      - ./src:/app/src
-
   app:
     <<: *common
     command: gunicorn developerportal.wsgi:application --bind=0.0.0.0:8000 --reload --workers=3
     ports:
-      - "8000:8000"
+      - '8000:8000'
     user: ${UID:-1000}
 
   worker:


### PR DESCRIPTION
(Resolves #370)

## Key changes:

- Improve syntax of docker-compose.yml to define `common` outside of the `services` node so that it doesn't get built and run as a container

## How to test

* `docker-compose build && docker-compose up` and then `docker-compose ps`


**Before:**

```
$ docker-compose ps
          Name                         Command               State           Ports
-------------------------------------------------------------------------------------------
developer-portal_app_1      gunicorn developerportal.w ...   Up      0.0.0.0:8000->8000/tcp
developer-portal_common_1   python3                          Up      8000/tcp
developer-portal_db_1       docker-entrypoint.sh postgres    Up      5432/tcp
developer-portal_redis_1    docker-entrypoint.sh redis ...   Up      6379/tcp
developer-portal_static_1   docker-entrypoint.sh npm r ...   Up
developer-portal_worker_1   celery -A developerportal. ...   Up      8000/tcp
```

**After:**
```
$ docker-compose ps
          Name                         Command               State           Ports
-------------------------------------------------------------------------------------------
developer-portal_app_1      gunicorn developerportal.w ...   Up      0.0.0.0:8000->8000/tcp
developer-portal_db_1       docker-entrypoint.sh postgres    Up      5432/tcp
developer-portal_redis_1    docker-entrypoint.sh redis ...   Up      6379/tcp
developer-portal_static_1   docker-entrypoint.sh npm r ...   Up
developer-portal_worker_1   celery -A developerportal. ...   Up      8000/tcp
```

