### PR TITLE
Remove concurrency option for celery beat

### DIFF
--- a/k8s/celery-beat.yaml.j2
+++ b/k8s/celery-beat.yaml.j2
@@ -29,7 +29,6 @@ spec:
             - "--app=developerportal.apps.staticbuild"
             - beat
             - "--loglevel=INFO"
-            - "--concurrency={{ CELERY_SCHEDULER_CONCURRENCY }}"
           resources:
             requests:
               cpu: {{ CELERY_SCHEDULER_CPU_REQUEST }}


### PR DESCRIPTION
celery-beat doesn't like the `--concurrency` option, removing this to allow celery-beat to start up


## Key changes:

- Remove `--concurrency` option
