### PR TITLE
Add celery results backend environment variable

### DIFF
--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -75,6 +75,11 @@
                 secretKeyRef:
                   name: dev-portal-secrets
                   key: REDIS_URL
+            - name: REDIS_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: REDIS_BASE
             - name: AWS_CLOUDFRONT_DISTRIBUTION_ID
               valueFrom:
                 secretKeyRef:

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -80,3 +80,8 @@
                 secretKeyRef:
                   name: dev-portal-secrets
                   key: CLOUDFRONT_DISTRIBUTION_ID
+            - name: CELERY_RESULT_BACKEND
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: REDIS_URL_1


### PR DESCRIPTION
Exposes `CELERY_RESULTS_BACKEND` to environment variables

(Partially Resolves #430)

## Key changes:

- Exposes  `CELERY_RESULTS_BACKEND` environment variables

