### PR TITLE
Automatically request a fresh static-site rebuild each hour

### DIFF
--- a/developerportal/apps/staticbuild/celery.py
+++ b/developerportal/apps/staticbuild/celery.py
@@ -3,6 +3,7 @@ import os
 from django.conf import settings
 
 from celery import Celery
+from celery.schedules import crontab
 
 STATIC_BUILD_JOB_ATTEMPT_FREQUENCY = 60.0 * 1  # Check each minute
 
@@ -17,10 +18,15 @@ app.autodiscover_tasks()
 
 # Set up a Celery Beat task to try to build the static site every minute
 app.conf.beat_schedule = {
-    "add-every-minute": {
+    "check-for-build-desire": {
         "task": "developerportal.apps.staticbuild.wagtail_hooks._static_build_async",
         "schedule": STATIC_BUILD_JOB_ATTEMPT_FREQUENCY,
         "args": (),
-    }
+    },
+    "fresh-static-build-every-hour": {
+        "task": "developerportal.apps.staticbuild.wagtail_hooks._request_static_build",
+        "schedule": crontab(minute=30),  # Half past past each hour
+        "args": (),
+    },
 }
 app.conf.timezone = "UTC"

--- a/docs/automatic-publishing-to-s3.md
+++ b/docs/automatic-publishing-to-s3.md
@@ -4,24 +4,18 @@
 
 _Note that "Publish" and "Unpublish" here refer to the Wagtail sense of making a page live / not live. Emitting a version of the site to S3 will be referred to as "build-and-sync"._
 
-In production, this "build-and-sync" process will run at a few points:
+In production, this "build-and-sync" process will be requested at a few points:
 
-1. It will be run whenever a Page is Published or Unpublished from the Wagtail admin. (Note: this means if two Pages are published, the "build-and-sync" process is run twice...)
+1. Whenever a Page is Published or Unpublished from the Wagtail admin. (Note: this means if two Pages are published, the "build-and-sync" process is called twice, but requesting a build is idempotent: a flag is set, but a separate periodic task checks for this flag and does a build, so we don't end up with concurrent builds.)
 
-2. Hourly, on a schedule, we'll check for any Wagtail Pages due to be automaticaly Published or Unpublished, and if any are found, that will be done. This action will then trigger the "build-and-sync" step mentioned in 1 for each page being automatically Published or Unpublished.
+2. Hourly, on a schedule, we'll check for any Wagtail Pages due to be automaticaly Published or Unpublished, and if any are found, that will be done. This is done via the [`publish_scheduled_pages`](https://docs.wagtail.io/en/v2.0/reference/management_commands.html#publish-scheduled-pages) management command. This action will automatically then trigger the "build-and-sync" step mentioned in 1 for each page being automatically Published or Unpublished.
 
 3. Hourly, on a schedule, the whole site needs to republished, so that listings of upcoming Events, for instance, don't become too stale (especially if it's a weekend, for instance).
 
-**Case 1** will be performed asynchronously, via a task queue. Publishing/Unpublishing a Page immediately puts a task in the queue. A worker process picks it up and runs the "build-and-sync" process. This process will sync new HTML for **every Page within the site** as well as any new/changed assets (CSS, JS, images and user media) to the S3 bucket.
+All builds are performed asynchronously, via a task queue.
 
-**Case 2** will be triggered by a scheduler/cron job running Wagtail's [`publish_scheduled_pages`](https://docs.wagtail.io/en/v2.0/reference/management_commands.html#publish-scheduled-pages) management command. This implicitly then triggers `Case 1`.
-
-**Case 3** will be triggered by a different scheduler/cron job. The cleanest way to implement this is to add a new management command that emits the post-Publish Django Signal that starts **Case 1**, so we simply end up with a new enqueued task, which the worker picks up.)
-
-## A note about queue load
-
-There is a risk that the various ways of triggering an async build, plus the fact that each Publish/Unpublish action for each page will trigger a new static build, means there may be a lot of "build-and-sync" tasks in the queue, and all but the most recent one will be redundant. (We might want to look at a way to purge outmoded "build-and-sync" tasks and just use the newest one.)
+Note that the build-and-sync process will sync new HTML for **every Page within the site** as well as any new/changed assets (CSS, JS, images and user media) to the S3 bucket.
 
 # CDN invalidation
 
-We can't lean on Wagtail for frontend/CDN cache invalidation because the build-and-sync process happens asynchronously, so we'll be handling that with a post-publish API call to the CDN
+We can't lean on Wagtail for frontend/CDN cache invalidation because the build-and-sync process happens asynchronously, on the whole site, while Wagtail FE cache invalidation works on individually-published pages only. So,we handle that with a post-publish API call to the CDN with a wildcard invalidation for `/*`


### PR DESCRIPTION
This changset adds a regular task to the Celery Beat scheduler that requests a fresh static build at 30 mins past each hour.

Note that it only requests a build, rather than starts one, so that this doesn't risk causing concurrent builds. It slots neatly into the existing pattern.

At startup can see the job being registered:

```
scheduler_1  | <ScheduleEntry: fresh-static-build-every-hour developerportal.apps.staticbuild.wagtail_hooks._request_static_build() <crontab: 30 * * * * (m/h/d/dM/MY)>
```
And at that point in time you can see the job requesting a new static build:

```
scheduler_1  | [2019-10-22 12:46:00,000: INFO/MainProcess] Scheduler: Sending due task fresh-static-build-every-hour (developerportal.apps.staticbuild.wagtail_hooks._request_static_build)
```
...which gets handled as per a regular publish-triggered request

(Resolves #235)
