### PR TITLE
Support filename hashing for S3 uploads

### DIFF
--- a/developerportal/apps/mozimages/models.py
+++ b/developerportal/apps/mozimages/models.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from django.db import models
 
 from wagtail.images.models import AbstractImage, AbstractRendition, Image
@@ -8,6 +10,31 @@ class MozImage(AbstractImage):
     caption = models.CharField(max_length=255, blank=True)
 
     admin_form_fields = Image.admin_form_fields + ("caption",)
+
+    def _extract_suffix(self, filename, delimiter="."):
+        parts = filename.split(delimiter)
+        if len(parts) == 1:
+            return ""
+        return f"{delimiter}{parts[-1]}"
+
+    def get_upload_to(self, filename):
+        """Custom filename-setting code that will scrub original filenames and
+        use a SHA1 of them instead."""
+
+        hashed_filename = hashlib.sha1(filename.encode("utf-8")).hexdigest()[:32]
+        # Reducing the hash to 32 chars gives us more scope for padding if two files
+        # with the same original filename are uploaded and get extra chars added
+        # to their name (because settings.AWS_S3_FILE_OVERWRITE is False)
+
+        file_suffix = self._extract_suffix(filename)
+        _filename = f"{hashed_filename}{file_suffix}"
+
+        # Make sure we use the rest of Wagtail's logic to benefit from
+        # edge-case contingencies – see AbstractImage.get_upload_to in
+        # https://github.com/wagtail/wagtail/blob/master/wagtail/images/models.py
+        _upload_to = super().get_upload_to(_filename)
+
+        return _upload_to
 
 
 class Rendition(AbstractRendition):

--- a/developerportal/apps/mozimages/tests/test_models.py
+++ b/developerportal/apps/mozimages/tests/test_models.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+
+from developerportal.apps.mozimages.models import MozImage
+
+
+class MozImageTests(TestCase):
+    def test_extract_suffix(self):
+        cases = (
+            ("example.jpg", ".", ".jpg"),
+            ("example.file.jpeg", ".", ".jpeg"),
+            ("example.jpg", None, ".jpg"),
+            ("example.file.png", None, ".png"),
+            ("example_file", ".", ""),
+            ("example_tiff", "_", "_tiff"),
+        )
+        image = MozImage()
+
+        for input_, delimiter, expected in cases:
+            with self.subTest(input_=input_, delimiter=delimiter, expected=expected):
+                if delimiter:
+                    self.assertEqual(
+                        image._extract_suffix(filename=input_, delimiter=delimiter),
+                        expected,
+                    )
+                else:
+                    self.assertEqual(image._extract_suffix(filename=input_), expected)
+
+    def test_get_image_upload_to(self):
+        image = MozImage()
+        cases = (
+            ("example.jpg", "original_images/f3b0002ea58a851a514fec772d8ab7eb.jpg"),
+            ("Amélie.png", "original_images/b464cdb73f309351707ec74dd36867ca.png"),
+        )
+
+        for input_, expected_result in cases:
+            with self.subTest(input_=input_, expected_result=expected_result):
+                upload_to = image.get_upload_to(input_)
+                self.assertEqual(upload_to, expected_result)
+
+        # This test also acts as a canary, implicitly checking that `original_images`
+        #  is still what Wagtail is using internally

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -261,6 +261,7 @@ AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME")
 AWS_S3_CUSTOM_DOMAIN = "%s.s3.amazonaws.com" % AWS_STORAGE_BUCKET_NAME
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_DEFAULT_ACL = "public-read"
+AWS_S3_FILE_OVERWRITE = False  #  so that two files with the same name don't clash
 
 MEDIA_URL = "https://%s/" % AWS_S3_CUSTOM_DOMAIN
 # This is critical for django-bakery NOT to try to do a filesystem copy on a URI in S3


### PR DESCRIPTION
This changeset adds a custom `get_upload_to` method on `mozimages'` `MozImage` that takes the original filename and instead uses a slightly truncated SHA1 hash of it instead. This hashed filename is then respected in Renditions of the original image, too.

This change does NOT break existing files hosted on S3 but it may well break any image links on a local dev build that is not using S3.

Note that settings.AWS_S3_FILE_OVERWRITE is set to True to overcome django-storages default - see https://github.com/wagtail/wagtail/issues/1686

(Partiallt deals with #369)

Tested locally against my own S3 bucket. 