### PR TITLE
Deploy to 2 clusters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,11 +105,13 @@ node {
     case 'stage-push':
       stage('Deploy') {
         deploy('stage-oregon', 'stage')
+        deploy('stage', 'stage')
       }
       break
 
     case 'prod-push':
       stage('Deploy') {
+        deploy('prod', 'prod')
         deploy('prod', 'prod')
       }
       break

--- a/k8s/config/prod.sh
+++ b/k8s/config/prod.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-echo '--> Setting environment to developer-portal STAGE on mdn-apps-a cluster'
+echo '--> Setting environment to developer-portal PROD on mdn-apps-a cluster'
 
 export KUBECONFIG=${HOME}/.kube/mdn-apps-a.config
 
 # Define defaults for environment variables that personalize the commands.
-export TARGET_ENVIRONMENT=stage
+export TARGET_ENVIRONMENT=prod
 export K8S_NAMESPACE=dev-portal-${TARGET_ENVIRONMENT}
 
 # Define an alias for the namespaced kubectl for convenience.
 alias kc="kubectl -n ${K8S_NAMESPACE}"
 
-export APP_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/ccc148ae-2a73-4551-84d4-f785f0d5e67e
-export APP_BUCKET_ROLE_ARN=arn:aws:iam::178589013767:role/developer-portal-stage-us-west-2-role
+export APP_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/03cedb62-c36d-4e9e-b5a1-716ca6bdd7c4
+export APP_BUCKET_ROLE_ARN=arn:aws:iam::178589013767:role/developer-portal-prod-us-west-2-role
 
 export APP_REPLICAS=2
 export APP_CPU_LIMIT=2
@@ -19,10 +19,10 @@ export APP_CPU_REQUEST=500m
 export APP_MEMORY_LIMIT=4Gi
 export APP_MEMORY_REQUEST=2Gi
 export APP_GUNICORN_WORKERS=2
-export APP_HOST=developer-portal-stage.mdn.mozit.cloud
-export APP_EXPORTED_SITE_HOST=developer-portal-published.stage.mdn.mozit.cloud
-export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
-export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-stage
+export APP_HOST=developer-portal.prod.mdn.mozit.cloud
+export APP_EXPORTED_SITE_HOST=developer-portal-published.prod.mdn.mozit.cloud
+export APP_AWS_BUCKET_NAME=developer-portal-prod-178589013767
+export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-prod
 export APP_AWS_BUCKET_REGION=us-west-2
 
 export CELERY_SCHEDULER_REPLICAS=0


### PR DESCRIPTION
This PR deploys developer-portal to 2 clusters (our existing KOPS cluster and an EKS cluster), however the only difference is that one of the cluster will not have any `celery-beat` and `celery-worker` pods running.

(Resolves #453)

## Key changes:

- Create config for a second cluster
- Update `Jenkinsfile` to deploy to another cluster

