### PR TITLE
Add auth0 client id and client secret

### DIFF
--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -80,3 +80,13 @@
                 secretKeyRef:
                   name: dev-portal-secrets
                   key: CLOUDFRONT_DISTRIBUTION_ID
+            - name: OIDC_RP_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: OIDC_RP_CLIENT_ID
+            - name: OIDC_RP_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: OIDC_RP_CLIENT_SECRET


### PR DESCRIPTION
This is a counter part PR for #401 in which we expose the auth0 `client_id` and `client_secret` for SSO integration.

(Partiall Resolves #474)

## Key changes:

- Expose auth0 `client_id` and `client_secret`