### PR TITLE
436: Support Wagtail's scheduled publishing behaviour via periodic task

### DIFF
--- a/developerportal/apps/staticbuild/celery.py
+++ b/developerportal/apps/staticbuild/celery.py
@@ -28,5 +28,12 @@ app.conf.beat_schedule = {
         "schedule": crontab(minute=30),  # Half past past each hour
         "args": (),
     },
+    "run-publish-scheduled-command-every-hour": {
+        "task": (
+            "developerportal.apps.staticbuild.wagtail_hooks._publish_scheduled_pages"
+        ),
+        "schedule": crontab(minute=55),  # Five minutes to each hour
+        "args": (),
+    },
 }
 app.conf.timezone = "UTC"

--- a/developerportal/apps/staticbuild/wagtail_hooks.py
+++ b/developerportal/apps/staticbuild/wagtail_hooks.py
@@ -175,6 +175,13 @@ def _static_build_async(self, force=False, pipeline=settings.STATIC_BUILD_PIPELI
             _set_build_needed_sentinel(oid=self.app.oid)
 
 
+@app.task
+def _publish_scheduled_pages():
+    log_prefix = "[Static-build-and-sync requester]"
+    logger.info(f"{log_prefix} Trying to publish/unpublish scheduled pages")
+    call_command("publish_scheduled_pages")
+
+
 def static_build(**kwargs):
     """Callback for Wagtail publish and unpublish signals to spawn a
     task-queue job to do the actual build, if required"""

--- a/developerportal/apps/staticbuild/wagtail_hooks.py
+++ b/developerportal/apps/staticbuild/wagtail_hooks.py
@@ -177,7 +177,7 @@ def _static_build_async(self, force=False, pipeline=settings.STATIC_BUILD_PIPELI
 
 @app.task
 def _publish_scheduled_pages():
-    log_prefix = "[Static-build-and-sync requester]"
+    log_prefix = "[Publish scheduled pages]"
     logger.info(f"{log_prefix} Trying to publish/unpublish scheduled pages")
     call_command("publish_scheduled_pages")
 


### PR DESCRIPTION
While not all of the publishable objects in the CMS use Wagtail's go-live/de-publish
dates, some of them do (the External* entities, basically).

We should support this behaviour in case editors expect something to happen based
on the options available to them.

This changeset adds a periodic celerybeat task that calls Wagtail's
`publish_scheduled_pages` management command once an hour, at five mins before
the hour.

(Resolves #436)


Here's an example of it running at a (test) 29 mins past the hour:

```
worker_1     | [2019-10-28 17:29:00,039: INFO/MainProcess] Received task: developerportal.apps.staticbuild.wagtail_hooks._publish_scheduled_pages[333407c9-9f7a-4427-8ed0-00d3fb908fce]
worker_1     | [2019-10-28 17:29:00,043: INFO/ForkPoolWorker-4] [Static-build-and-sync requester] Trying to publish/unpublish scheduled pages
worker_1     | [2019-10-28 17:29:00,182: INFO/ForkPoolWorker-4] Page published: "test external event updated" id=39 revision_id=12
worker_1     | [2019-10-28 17:29:00,184: INFO/MainProcess] Received task: developerportal.apps.staticbuild.wagtail_hooks._request_static_build[492ae869-0d92-458e-b227-28c4acd158f8]
worker_1     | [2019-10-28 17:29:00,188: INFO/ForkPoolWorker-4] Task developerportal.apps.staticbuild.wagtail_hooks._publish_scheduled_pages[333407c9-9f7a-4427-8ed0-00d3fb908fce] succeeded in 0.14506990000154474s: None
worker_1     | [2019-10-28 17:29:00,188: INFO/ForkPoolWorker-3] [Static-build-and-sync requester] Caching a sentinel marker to request a static build within the next 60.0 seconds.
worker_1     | [2019-10-28 17:29:00,236: INFO/ForkPoolWorker-3] Task developerportal.apps.staticbuild.wagtail_hooks._request_static_build[492ae869-0d92-458e-b227-28c4acd158f8] succeeded in 0.0482981999994081s: None
scheduler_1  | [2019-10-28 17:29:44,880: DEBUG/MainProcess] beat: Waking up now.
scheduler_1  | [2019-10-28 17:29:44,914: INFO/MainProcess] Scheduler: Sending due task check-for-build-desire (developerportal.apps.staticbuild.wagtail_hooks._static_build_async)
scheduler_1  | [2019-10-28 17:29:44,918: DEBUG/MainProcess] developerportal.apps.staticbuild.wagtail_hooks._static_build_async sent. id->85f283ba-c9bf-49fe-9df8-f72742ea044a
scheduler_1  | [2019-10-28 17:29:44,918: DEBUG/MainProcess] beat: Waking up in 15.07 seconds.
worker_1     | [2019-10-28 17:29:44,918: INFO/MainProcess] Received task: developerportal.apps.staticbuild.wagtail_hooks._static_build_async[85f283ba-c9bf-49fe-9df8-f72742ea044a]
worker_1     | [2019-10-28 17:29:44,932: INFO/ForkPoolWorker-4] [Static-build-and-sync] Attempting fresh build
...etc...
```


## How to test

- boot up the stack locally
- add S3 credentials OR set DEBUG=False in local.py to disable actual build-and-sync
- the scheduler is set to publish at 55 mins past the hour, so add an ExternalEvent and in the Settings tab set it to be published at the current full hour, assuming it's before XX:55 (eg if it's 16:24 now, set the page's publish time to 16:00) 
- wait for it to be auto-published - look for `_publish_scheduled_pages` in the logs in your console.
(if you'd prefer, temporarily change the `55` in the relevant part of celery.py to be a time that'll happen sooner!)