### PR TITLE
551: Make the privacy policy link in the footer more prominent

### DIFF
--- a/developerportal/templates/organisms/newsletter-signup.html
+++ b/developerportal/templates/organisms/newsletter-signup.html
@@ -12,7 +12,7 @@
       <p>
         <label for="newsletter-privacy" class="mzp-u-inline">
           <input type="checkbox" name="privacy" id="newsletter-privacy" required aria-required="true">
-          I'm okay with Mozilla handling my info as explained in this <a href="https://www.mozilla.org/en-US/privacy/websites/" target="_blank" rel="noopener noreferrer">Privacy Notice</a>.
+          I'm okay with Mozilla handling my info as explained in this <a class="privacy-link" href="https://www.mozilla.org/en-US/privacy/websites/" target="_blank" rel="noopener noreferrer">Privacy Notice</a>.
         </label>
       </p>
       <p>

--- a/src/css/organisms/newsletter-signup.scss
+++ b/src/css/organisms/newsletter-signup.scss
@@ -16,6 +16,10 @@
     margin-right: 4px;
   }
 
+  a.privacy-link {
+    color: $color-blue-10;
+  }
+
   input[type='email'] {
     display: inline-block;
   }


### PR DESCRIPTION
This changeset addresses poor visibility of the privacy-policy link in the footer. By using a light blye from Mozilla Protocol's colour options, it now 

(Resolves #551)

## Before

<img width="482" alt="Screenshot 2019-10-29 at 21 54 40" src="https://user-images.githubusercontent.com/101457/67814587-52a68e00-fa9c-11e9-8bbb-889aa6184c61.png">

## After

<img width="513" alt="Screenshot 2019-10-29 at 22 28 28" src="https://user-images.githubusercontent.com/101457/67814588-52a68e00-fa9c-11e9-9ded-25a178ae343e.png">
