### PR TITLE
548: Disable filtering of articles by month

### DIFF
--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -109,7 +109,7 @@ class Articles(BasePage):
     def get_filters(self):
         from ..topics.models import Topic
 
-        return {"months": True, "topics": Topic.published_objects.order_by("title")}
+        return {"topics": Topic.published_objects.order_by("title")}
 
 
 class ArticleTag(TaggedItemBase):


### PR DESCRIPTION
This changeset addresses the risk of an over-long and messy filter list on the articles page by removing the option to filter articles by month

(Resolves #548)

----

## Before (using dummy content in local dev)

<img width="844" alt="Screenshot 2019-10-29 at 23 07 02" src="https://user-images.githubusercontent.com/101457/67816582-4f160580-faa2-11e9-8aeb-9960e1575f5b.png">

----

## After

<img width="854" alt="Screenshot 2019-10-29 at 23 14 46" src="https://user-images.githubusercontent.com/101457/67816583-4fae9c00-faa2-11e9-8930-f8643959d52c.png">

----