### PR TITLE
550: Remove 'Featured' wording from the primary featured card

### DIFF
--- a/developerportal/templates/molecules/card-featured-primary.html
+++ b/developerportal/templates/molecules/card-featured-primary.html
@@ -16,7 +16,6 @@
     </div>
     <div class="card-featured-primary-body">
       <div class="card-featured-primary-content">
-        <div class="featured">Featured</div>
         <div>
           <h4 class="no-underline">
             {% firstof resource.card_title resource.title %}{% if external_page or resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}


### PR DESCRIPTION
This change alleviates repetition on pages where there's also a H2 saying "Featured" just above this card.

(Resolves #550)

## Before

<img width="1077" alt="Screenshot 2019-10-29 at 23 21 23" src="https://user-images.githubusercontent.com/101457/67816965-9e106a80-faa3-11e9-92d5-19d671a1920d.png">

## After

<img width="1069" alt="Screenshot 2019-10-29 at 23 27 34" src="https://user-images.githubusercontent.com/101457/67816988-b84a4880-faa3-11e9-9487-232dff425af3.png">
