### PR TITLE
591: only load GA code if Google Analytics ID is available

### DIFF
--- a/developerportal/templates/base.html
+++ b/developerportal/templates/base.html
@@ -62,6 +62,7 @@
     {% endblock %}
     <script>window.Mzp = {}</script>
     <script src="{% static 'js/bundle.js' %}"></script>
+    {% if GOOGLE_ANALYTICS %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -69,5 +70,6 @@
       gtag('js', new Date());
       gtag('config', '{{ GOOGLE_ANALYTICS }}');
     </script>
+    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
This changeset prepares the ground for switching the Google Analytics ID from staging to production, so there will (normally) be no GA ID configured. In that situation, we want to avoid including any GA code, rather than risk it complaining in the console. 

(Resolves #591)

## Key changes:

- Only load GA code if Google Analytics ID is available

## No GOOGLE_ANALYTICS code configured in environment

```
...
  </footer>

    <script>window.Mzp = {}</script>
    <script src="/static/js/bundle.js"></script>

  </body>
</html>
```

## With a GOOGLE_ANALYTICS code configured in environment

```
...
  </footer>

    <script>window.Mzp = {}</script>
    <script src="/static/js/bundle.js"></script>

    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-[REDACTED]-1"></script>
    <script>
      window.dataLayer = window.dataLayer || [];
      function gtag(){dataLayer.push(arguments);}
      gtag('js', new Date());
      gtag('config', 'UA-[REDACTED]-1');
    </script>

  </body>
</html>
```