### PR TITLE
Ensure that files uploaded to S3 that have the same filename do not clash

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -264,6 +264,9 @@ AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME")
 AWS_S3_CUSTOM_DOMAIN = "%s.s3.amazonaws.com" % AWS_STORAGE_BUCKET_NAME
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_DEFAULT_ACL = "public-read"
+# Ensure two files with the same name don't clash - see
+# https://docs.wagtail.io/en/v2.6.3/advanced_topics/deploying.html#cloud-storage
+AWS_S3_FILE_OVERWRITE = False
 
 MEDIA_URL = "https://%s/" % AWS_S3_CUSTOM_DOMAIN
 # This is critical for django-bakery NOT to try to do a filesystem copy on a URI in S3


### PR DESCRIPTION
This changeset addresses the problem of non-unique filenames overwriting an existing file of the same name when uploaded to S3 via `django-storages`.

Enabling `AWS_S3_FILE_OVERWRITE=False` means that filenames that would otherwise clash are renamed with a unique suffix.

See https://docs.wagtail.io/en/v2.6.3/advanced_topics/deploying.html#cloud-storage for the background

## Example screenshots, uploading the same file three times
(Check out the resulting filename, not the image's name) 

![Screenshot 2019-10-30 at 14 39 22](https://user-images.githubusercontent.com/101457/67868382-d22b7000-fb23-11e9-854e-9915447ac146.png)
-----
![Screenshot 2019-10-30 at 14 46 59](https://user-images.githubusercontent.com/101457/67868650-29c9db80-fb24-11e9-893d-dfac1e8ef275.png)

-----
![Screenshot 2019-10-30 at 14 39 27](https://user-images.githubusercontent.com/101457/67868383-d22b7000-fb23-11e9-9173-6c97efb6357b.png)

