### PR TITLE
609: Fix incorrect solution to juggling absolute and relative URLs in OG tags

### DIFF
--- a/developerportal/templates/atoms/social-meta.html
+++ b/developerportal/templates/atoms/social-meta.html
@@ -32,7 +32,18 @@
   {% elif page.image %}
     {% image page.image width-1200 as image %}
   {% endif %}
-  <meta property="og:image" content="{{ base_url }}{% firstof image.url fallback_image_url %}">
+  {% if not image %}
+    {# Fallback images are hosted by Django, so need absolute URLs creating #}
+    <meta property="og:image" content="{{base_url}}{{fallback_image_url}}">
+  {% else %}
+    {% comment %}
+      There's no need to add the base URL if the image file exists as it's externally
+      hosted in production, so image.url is absolute.
+      Note: in local dev, if you use local file storage (not S3) the OG tags will
+      have relative URLs - but that hopefully shouldn't be a real problem.
+    {% endcomment %}
+    <meta property="og:image" content="{{ image.url }}">
+  {% endif %}
   <meta property="og:image:width" content="{% firstof image.width fallback_image_width %}">
   <meta property="og:image:height" content="{% firstof image.height fallback_image_height %}">
 {% endwith %}

--- a/developerportal/templatetags/app_tags.py
+++ b/developerportal/templatetags/app_tags.py
@@ -39,9 +39,6 @@ def render_gif(block_value):
 
 @register.simple_tag
 def get_scheme_and_host(request):
-    if settings.DEFAULT_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
-        # If we're using S3, we don't need to return a "base url" for assets
-        return ""
     return f"{request.scheme}://{request.get_host()}"
 
 


### PR DESCRIPTION
An earlier changeset introduced overly-simplistic behaviour when trying to create absolute URIs for images while also using S3 storage. Its logic was: "If we're using S3, we don't need to make the URLs for images in the OG tags absolute because they already will be absolute". 

This worked as long as there **was** a deliberately-associated image to use, but failed when there was not one set up and so a fallback image was used instead. This is because these fallback images are served by Django and have relative paths, not absolute ones.

This changeset addresses that with different, and clearer, conditional logic

Examples from `view-source`

### BROKEN with image associated with Page (ie, before this changeset's fix)
```
<meta property="og:title" content="Events">
<meta property="og:site_name" content="Mozilla Developer">
<meta property="og:image" content="https://<redacted>.s3.amazonaws.com/images/test.width-1200.jpg">  # ABSOLUTE BECAUSE IN CLOUD
<meta property="og:image:width" content="543">
<meta property="og:image:height" content="415">
<meta property="og:url" content="/events/">  # NOT ABSOLUTE
<meta name="twitter:card" content="summary_large_image">
```

### FIXED with image associated with Page

```
<meta property="og:title" content="Events">
<meta property="og:site_name" content="Mozilla Developer">
<meta property="og:image" content="https://<redacted>.s3.amazonaws.com/images/test.width-1200.jpg">
<meta property="og:image:width" content="543">
<meta property="og:image:height" content="415">
<meta property="og:url" content="http://testsite.example.com/events/">  # ABSOLUTE
<meta name="twitter:card" content="summary_large_image">
```

### BROKEN with fallback image in use

```
<meta property="og:title" content="Events">
<meta property="og:site_name" content="Mozilla Developer">
<meta property="og:image" content="/static/img/placeholders/article.jpg">  # NOT ABSOLUTE
<meta property="og:image:width" content="960">
<meta property="og:image:height" content="720">
<meta property="og:url" content="/events/">  # NOT ABSOLUTE
<meta name="twitter:card" content="summary_large_image">
```

### FIXED with fallback image in use

```
<meta property="og:title" content="Events">
<meta property="og:site_name" content="Mozilla Developer">
<meta property="og:image" content="http://testsite.example.com/static/img/placeholders/article.jpg"> # ABSOLUTE
<meta property="og:image:width" content="960">
<meta property="og:image:height" content="720">
<meta property="og:url" content="http://testsite.example.com/events/"> #ABSOLUTE
<meta name="twitter:card" content="summary_large_image">
```

(Resolves #609)

