### PR TITLE
604: Enable HSTS by default

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -206,13 +206,16 @@ CSRF_COOKIE_SECURE = True
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-SECURE_SSL_REDIRECT = True
 SECURE_SSL_REDIRECT = bool(os.environ.get("SECURE_SSL_REDIRECT", False))
 SESSION_COOKIE_SECURE = True
 X_FRAME_OPTIONS = "DENY"
 
-# Wagtail settings
+# Set header Strict-Transport-Security header
+SECURE_HSTS_SECONDS = int(os.environ.get("SECURE_HSTS_SECONDS", 3600))
+# Start with an hour, move to a year once we're settled.
+# Set to 0 via env to disable BEFORE deployment (!)
 
+# Wagtail settings
 WAGTAIL_SITE_NAME = "Mozilla Developer"
 
 # Add support for CodePen oEmbed

--- a/developerportal/settings/dev.py
+++ b/developerportal/settings/dev.py
@@ -14,6 +14,7 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 SECURE_SSL_REDIRECT = False
 CSRF_COOKIE_SECURE = False
 SESSION_COOKIE_SECURE = False
+SECURE_HSTS_SECONDS = 0
 
 # Swap out the default use of S3 for user media to instead use local machine
 DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"


### PR DESCRIPTION
This changeset enables HSTS by setting a default time of 1 hour for the Strict-Transport-Security
header, which we can upgrade to a year (31536000 seconds) once we're happy.

(Resolves #604)

Note that the default behaviour for ALL non-local-development mode is to
have HSTS **ENABLED**, so staging WILL be affected, too.

Also, note that the SECURE_HSTS_INCLUDE_SUBDOMAINS setting is NOT set, so it
remains its [default value](https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SECURE_HSTS_INCLUDE_SUBDOMAINS) of `False`. This is because Django warned (via
`manage.py check --deploy`) to: 
> ...only set this to True if you are certain that all subdomains of your domain should be served exclusively via SSL. 

and I don't know what else goes on `mozit.cloud` or `mozilla.com` so am playing it safe. 

*Please be sure you agree/that this makes sense before approving this PR* 😄 

(Kuma doesn't appear to include HSTS subdomains in its config, either: https://github.com/mdn/kuma/blob/master/kuma/settings/common.py#L1726)

--

This changeset also removes a duplicated definition of SECURE_SSL_REDIRECT in settings.base


