### PR TITLE
615: Enable HTTP-only cookies for CSRF

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -203,6 +203,7 @@ STATIC_URL = "/static/"
 # Django security settings (see `manage.py check --deploy`)
 
 CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_HTTPONLY = True
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")


### PR DESCRIPTION
This changeset addresses a request from MozInfoSec to try enabling HTTP-only CSRF cookies.

Talking with `@gasmanic` (Lead Wagtail dev), it sounds like Wagtail doesn't do
anything that should be affected by enabling this, but we should still keep
an eye open.

A light test-drive locally seemed fine and the content-entry phase we're entering will be a good shakedown.

(Resolves #615)
