### PR TITLE
Set settings.ADMIN

### DIFF
--- a/developerportal/settings/production.py
+++ b/developerportal/settings/production.py
@@ -2,6 +2,8 @@ from urllib.parse import urlparse
 
 from .base import *  # noqa
 
+ADMINS = [ ("Developer-Portal Errors", "dev-portal-errors@mozilla.com") ]
+
 DEBUG = False
 DEBUG_PROPAGATE_EXCEPTIONS = True
 


### PR DESCRIPTION
Sets `settings.ADMIN` to receive any django errors

(Resolves #622)

## Key changes:

- Sets `settings.ADMIN`
