### PR TITLE
622: Enable settings.ADMINS so we get basic error-report emails

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -27,10 +27,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", get_random_secret_key())
 
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
-
+ADMINS = [("DevPortal Admins", "dev-portal-errors@mozilla.com")]
 
 # Application definition
 INSTALLED_APPS = [


### PR DESCRIPTION
This changeset configures who should be emailed if if ERROR or above is raised within Django.

* the `mail_admins` option is in the default config (which we are extending, not overwriting) - see [here](https://github.com/django/django/blob/stable/2.2.x/django/utils/log.py#L55)
* @limed has set up an email group (`dev-portal-errors@mozilla.com`) in #621, which is set as the only address in `settings.ADMINS`

This is hard to test, so I rigged a the homepage to `raise Exception("test")` then loaded it. So here's an example of this working (locally, with the `console` `EmailBackend`):

```
app_1        | Content-Type: text/plain; charset="utf-8"
app_1        | MIME-Version: 1.0
app_1        | Content-Transfer-Encoding: quoted-printable
app_1        | Subject: [Django] ERROR (EXTERNAL IP): Internal Server Error: /
app_1        | From: root@localhost
app_1        | To: dev-portal-errors@mozilla.com
app_1        | Date: Thu, 31 Oct 2019 21:38:11 -0000
app_1        | Message-ID: <157255789166.133.757682793205071768@61198020639a>
app_1        |
app_1        | Internal Server Error: /
app_1        |
app_1        | Exception at /
app_1        | test
app_1        | ..... [ REST  OF TRACEBACK FOLLOWS ] ....
```


(Resolves #622)

