### PR TITLE
567: Remove 'Latest authors' section from top of People page

### DIFF
--- a/developerportal/apps/people/models.py
+++ b/developerportal/apps/people/models.py
@@ -107,23 +107,6 @@ class People(BasePage):
             "topics": Topic.published_objects.order_by("title"),
         }
 
-    def latest_authors(self, limit=3):
-        """
-        Returns a list of authors from the most recently published articles.
-        """
-        from ..articles.models import Article
-
-        authors = []
-        articles = Article.published_objects.order_by("last_published_at").specific()
-        for article in articles:
-            if article.has_author:
-                for author in article.authors:  # pylint: disable=not-an-iterable
-                    if author.block_type == "author" and author.value not in authors:
-                        authors.append(author.value)
-                        if len(authors) >= limit:
-                            return authors  # Limit reached, return early
-        return authors
-
 
 class PersonTag(TaggedItemBase):
     content_object = ParentalKey(

--- a/developerportal/apps/people/templates/people.html
+++ b/developerportal/apps/people/templates/people.html
@@ -8,12 +8,12 @@
 {% block content %}
   <main>
     {% if page.people %}
-      <section class="section{% if not page.latest_authors %} section-pattern{% endif %}">
-        {% include "organisms/people-section.html" with people=page.latest_authors title="Latest authors" %}
-        {% if page.latest_authors %}
-          </section>
-          <section class="section section-pattern">
-        {% endif %}
+      <section class="section section-pattern">
+        <div class="container">
+          <div class="section-header">
+            <h2>People</h2>
+          </div>
+        </div>
         {% include "organisms/filter-list.html" with type="person" resources=page.people initial_resources=10 resources_per_page=4 no_resources_message="No people found" %}
       </section>
     {% endif %}


### PR DESCRIPTION
This changeset removes the unit at the top of the People page that showed the three authors with most recently published things.

**BEFORE:**

![88dda333-40d2-4464-aee8-caf8788d5ad3](https://user-images.githubusercontent.com/101457/67991009-a1d0f800-fc2f-11e9-8648-4a30d865d5a1.jpg)


**AFTER** (different data, because rendered locally, and using fallback/placeholder images, which are all unrelated to the changes made here)

<img width="1126" alt="Screenshot 2019-10-31 at 22 39 53" src="https://user-images.githubusercontent.com/101457/67991081-e492d000-fc2f-11e9-89a2-ee2791fdf6e7.png">


The unit is gone, and we've added in a new 'People' `h2`, in the same position as the `h2` on 'Articles'. 

This changeset also drops now-rendant code from People page model that generated that list of latest authors.

(Resolves #567)

