### PR TITLE
Increase number of pods for prod

### DIFF
--- a/k8s/config/prod-oregon.sh
+++ b/k8s/config/prod-oregon.sh
@@ -13,7 +13,7 @@ alias kc="kubectl -n ${K8S_NAMESPACE}"
 export APP_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/03cedb62-c36d-4e9e-b5a1-716ca6bdd7c4
 export APP_BUCKET_ROLE_ARN=arn:aws:iam::178589013767:role/developer-portal-prod-us-west-2-role
 
-export APP_REPLICAS=2
+export APP_REPLICAS=4
 export APP_CPU_LIMIT=2
 export APP_CPU_REQUEST=500m
 export APP_MEMORY_LIMIT=4Gi
@@ -24,5 +24,7 @@ export APP_EXPORTED_SITE_HOST=developer-portal-published.prod.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-prod-178589013767
 export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-prod
 export APP_AWS_BUCKET_REGION=us-west-2
+
+export CELERY_WORKER_REPLICAS=2
 
 export GOOGLE_ANALYTICS=UA-49796218-59

--- a/k8s/config/prod-oregon.sh
+++ b/k8s/config/prod-oregon.sh
@@ -25,6 +25,4 @@ export APP_AWS_BUCKET_NAME=developer-portal-prod-178589013767
 export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-prod
 export APP_AWS_BUCKET_REGION=us-west-2
 
-export CELERY_WORKER_REPLICAS=2
-
 export GOOGLE_ANALYTICS=UA-49796218-59

--- a/k8s/config/prod.sh
+++ b/k8s/config/prod.sh
@@ -13,7 +13,7 @@ alias kc="kubectl -n ${K8S_NAMESPACE}"
 export APP_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/03cedb62-c36d-4e9e-b5a1-716ca6bdd7c4
 export APP_BUCKET_ROLE_ARN=arn:aws:iam::178589013767:role/developer-portal-prod-us-west-2-role
 
-export APP_REPLICAS=2
+export APP_REPLICAS=4
 export APP_CPU_LIMIT=2
 export APP_CPU_REQUEST=500m
 export APP_MEMORY_LIMIT=4Gi


### PR DESCRIPTION
Increases the number of `celery-workers` and `web` nodes for the prod
environment.

(Resolves #523)

## Key changes:

- Increase number of pods for celery and web pods