### PR TITLE
642: Only insert the Google Analytics code into the static site

### DIFF
--- a/developerportal/apps/staticbuild/celery.py
+++ b/developerportal/apps/staticbuild/celery.py
@@ -7,7 +7,7 @@ from celery.schedules import crontab
 
 STATIC_BUILD_JOB_ATTEMPT_FREQUENCY = 60.0 * 1  # Check each minute
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "developerportal.settings.production")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "developerportal.settings.worker")
 
 app = Celery("developerportal.apps.staticbuild", broker=settings.CELERY_BROKER_URL)
 

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -294,8 +294,9 @@ LOGIN_ERROR_URL = "/admin/"
 LOGIN_REDIRECT_URL = "/admin/"
 LOGOUT_REDIRECT_URL = "/admin/"
 
-# GOOGLE_ANALYTICS
-GOOGLE_ANALYTICS = os.environ.get("GOOGLE_ANALYTICS")
+GOOGLE_ANALYTICS = ""
+# GOOGLE_ANALYTICS is _only_ set in settings.worker, because we ONLY want it
+# to appear in the static site, not the live-rendered site.
 
 # Mapbox
 MAPBOX_ACCESS_TOKEN = os.environ.get("MAPBOX_ACCESS_TOKEN")

--- a/developerportal/settings/build.py
+++ b/developerportal/settings/build.py
@@ -1,4 +1,0 @@
-from .production import *
-
-STATIC_URL = "/portal" + STATIC_URL
-BUILD_DIR = BUILD_DIR + "/portal"

--- a/developerportal/settings/worker.py
+++ b/developerportal/settings/worker.py
@@ -1,0 +1,7 @@
+# Extra settings that ONLY apply to the Celery workers/schedulers
+
+from .production import *
+
+# GOOGLE_ANALYTICS is _only_ set in this file, because we ONLY want it
+# to appear in the static site, not the live-rendered site.
+GOOGLE_ANALYTICS = os.environ.get("GOOGLE_ANALYTICS")


### PR DESCRIPTION
This changeset catches a subtle one: we don't want the live-rendered pages (eg someone previewing a draft page or viewing a live page on the CMS domain) to show up in Google Analytics.

Happily, because we now omit the GA JS if we have no GA ID available via settings, we can address this easily enough:
* Remove code from `settings.base` that gets the GA code from the env
* Add a new `settings.worker` module, which DOES try to get the GA code from the env
* Ensure Celery is using that new `settings.worker` module, so that it's the only place where the GA code is obtained and, therefore, used.

GA code present in ENV but page live-rendered by CMS:

```
</footer>
    <script>window.Mzp = {}</script>
    <script src="/static/js/bundle.js"></script>
  </body>
</html>
```

GA code present in ENV and page baked out to static site:

```
</footer>
    <script>window.Mzp = {}</script>
    <script src="/static/js/bundle.e035d308bbe9.js"></script>
    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-[REDACTED]-1"></script>
    <script>
      window.dataLayer = window.dataLayer || [];
      function gtag(){dataLayer.push(arguments);}
      gtag('js', new Date());
      gtag('config', 'UA-[REDACTED]-1');
    </script>

  </body>
</html>
```


(Resolves #642)

