### PR TITLE
625: Allow posts/articles page to also show videos

### DIFF
--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -267,8 +267,8 @@ class Article(BasePage):
         ]
     )
 
-    # Rss feed
     def get_absolute_url(self):
+        # For the RSS feed
         return self.full_url
 
     @property

--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -32,7 +32,7 @@ from ..common.blocks import ExternalAuthorBlock, ExternalLinkBlock
 from ..common.constants import RICH_TEXT_FEATURES_SIMPLE
 from ..common.fields import CustomStreamField
 from ..common.models import BasePage
-from ..common.utils import get_combined_articles, get_combined_articles_and_videos
+from ..common.utils import get_combined_articles_and_videos
 
 
 class ArticlesTag(TaggedItemBase):
@@ -105,8 +105,9 @@ class Articles(BasePage):
         return context
 
     @property
-    def articles(self):
-        return get_combined_articles(self)
+    def resources(self):
+        # This Page class will show both Articles/Posts and Videos in its listing
+        return get_combined_articles_and_videos(self)
 
     def get_filters(self):
         from ..topics.models import Topic

--- a/developerportal/apps/articles/templates/articles.html
+++ b/developerportal/apps/articles/templates/articles.html
@@ -19,7 +19,7 @@
           </div>
         </div>
       </div>
-      {% include "organisms/filter-list.html" with type="article" resources=page.articles initial_resources=6 resources_per_page=4 no_resources_message="No posts found" %}
+      {% include "organisms/filter-list.html" with type="article_or_video" resources=page.resources initial_resources=6 resources_per_page=4 no_resources_message="No posts found" %}
     </section>
     {% include "organisms/newsletter-signup.html" %}
   </main>

--- a/developerportal/apps/common/feed.py
+++ b/developerportal/apps/common/feed.py
@@ -1,15 +1,35 @@
+from itertools import chain
+
+from django.conf import settings
 from django.contrib.syndication.views import Feed
 
 from developerportal.apps.articles.models import Article
+from developerportal.apps.videos.models import Video
 
 
 class RssFeeds(Feed):
     title = "Mozilla Developer posts feed"
     link = "/posts-feed/"
-    description = "Posts published"
+    description = "Posts and Videos published"
 
     def items(self):
-        return Article.published_objects.all().order_by("-date")[:20]
+        items = sorted(
+            chain(
+                # Order here matters because we want Articles to come ahead of Videos.
+                # Also, we sort by -date here BEFORE reversing so we can
+                # appropriately truncate the queryset (and get newer ones
+                # rather than older ones) instead of pull all of the items.
+                Article.published_objects.all().order_by("-date")[
+                    : settings.RSS_MAX_ITEMS
+                ],
+                Video.published_objects.all().order_by("-date")[
+                    : settings.RSS_MAX_ITEMS
+                ],
+            ),
+            key=lambda instance: instance.date,
+            reverse=True,
+        )
+        return items[: settings.RSS_MAX_ITEMS]
 
     def item_title(self, item):
         return item.title

--- a/developerportal/apps/common/tests/test_feed.py
+++ b/developerportal/apps/common/tests/test_feed.py
@@ -1,0 +1,68 @@
+import datetime
+
+from django.test import TestCase, override_settings
+
+from developerportal.apps.articles.models import Article
+from developerportal.apps.common.feed import RssFeeds
+from developerportal.apps.videos.models import Video
+
+
+class RSSFeedsTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.video_newer = Video.objects.create(
+            title="Video Newer",
+            path="000100010004",
+            depth=6,
+            date=datetime.date(2019, 10, 1),
+        )
+        cls.video_older = Video.objects.create(
+            title="Video Older",
+            path="000100010002",
+            depth=6,
+            date=datetime.date(2019, 6, 1),
+        )
+        cls.video_oldest = Video.objects.create(
+            title="Video Oldest",
+            path="000100010001",
+            depth=6,
+            date=datetime.date(2019, 1, 1),
+        )
+
+        cls.article_newer = Article.objects.create(
+            title="Article Newer",
+            path="000100010007",
+            depth=6,
+            date=datetime.date(2019, 10, 1),
+        )
+        cls.article_older = Article.objects.create(
+            title="Article Older",
+            path="000100010005",
+            depth=6,
+            date=datetime.date(2019, 6, 1),
+        )
+        cls.article_oldest = Article.objects.create(
+            title="Article Oldest",
+            path="000100010003",
+            depth=6,
+            date=datetime.date(2019, 1, 1),
+        )
+
+    def test_feed_ordering(self):
+        # Show newer comes ahead of older ones, and that Articles come ahead of Videos
+        assert RssFeeds().items() == [
+            self.article_newer,
+            self.video_newer,
+            self.article_older,
+            self.video_older,
+            self.article_oldest,
+            self.video_oldest,
+        ]
+
+    @override_settings(RSS_MAX_ITEMS=3)
+    def test_limit_to_feed(self):
+        assert RssFeeds().items() == [
+            self.article_newer,
+            self.video_newer,
+            self.article_older,
+        ]

--- a/developerportal/apps/videos/models.py
+++ b/developerportal/apps/videos/models.py
@@ -249,6 +249,10 @@ class Video(BasePage):
         ]
     )
 
+    def get_absolute_url(self):
+        # For the RSS feed
+        return self.full_url
+
     @property
     def primary_topic(self):
         """Return the first (primary) topic specified for the video."""

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -299,6 +299,10 @@ GOOGLE_ANALYTICS = ""
 # GOOGLE_ANALYTICS is _only_ set in settings.worker, because we ONLY want it
 # to appear in the static site, not the live-rendered site.
 
+# RSS Feed
+RSS_MAX_ITEMS = 20
+
+
 # Mapbox
 MAPBOX_ACCESS_TOKEN = os.environ.get("MAPBOX_ACCESS_TOKEN")
 

--- a/developerportal/templates/base.html
+++ b/developerportal/templates/base.html
@@ -43,7 +43,9 @@
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <link rel="stylesheet" type="text/css" href="{% static 'css/bundle.css' %}">
       <link rel="shortcut icon" href="{% static 'img/icons/favicon.ico' %}">
+      {% comment "DISABLED FOR NOW UNTIL WE CAN EXPORT IT TO THE STATIC SITE %}
       <link rel="alternate" type="application/rss+xml" href="/posts-feed/">
+      {% endcomment %}
       {% if page %}
         {% include "atoms/social-meta.html" with fallback_description=home.search_description %}
       {% endif %}

--- a/developerportal/templates/molecules/cards/card-video.html
+++ b/developerportal/templates/molecules/cards/card-video.html
@@ -8,11 +8,16 @@
 
 <a
   href="{% pageurl resource %}"
-  class="card-link {% if resource.is_external %}js-modal-trigger{% endif %}"
-  data-type="{{ resource.resource_type }}"
+  class="card-link {% if filter_target %}js-filter-target{% endif %} {% if resource.is_external %}js-modal-trigger{% endif %}"
   {% if resource.is_external %}
     data-class-name="mzp-has-media"
     data-title="{{ resource.title }}"
+  {% endif %}
+  data-type="{{ resource.resource_type }}"
+  {% if filter_target %}
+    data-topics="{% for topic in resource.topics.all %}{{ topic.topic.slug }} {% endfor %}"
+    data-month="{{ resource.month_group|date:'Y-m' }}"
+    hidden
   {% endif %}
 >
   <div class="card {% if full_width %}card-full{% endif %}">

--- a/developerportal/templates/molecules/cards/card.html
+++ b/developerportal/templates/molecules/cards/card.html
@@ -5,5 +5,5 @@
 {% elif resource.resource_type == "person" %}
   {% include "molecules/cards/card-person.html" with resource=resource filter_target=filter_target %}
 {% elif resource.resource_type == "video" %}
-  {% include "molecules/cards/card-video.html" with resource=resource %}
+  {% include "molecules/cards/card-video.html" with resource=resource filter_target=filter_target %}
 {% endif %}

--- a/developerportal/templates/organisms/filter-list.html
+++ b/developerportal/templates/organisms/filter-list.html
@@ -29,6 +29,12 @@
               {% for resource in resources %}
                 {% if type == "article" %}
                   {% include "molecules/cards/card.html" with resource=resource.article filter_target=True show_author=True %}
+                {% elif type == "article_or_video" %}
+                  {% if resource.video %}
+                    {% include "molecules/cards/card.html" with resource=resource.video filter_target=True %}
+                  {% else %}
+                    {% include "molecules/cards/card.html" with resource=resource.article filter_target=True show_author=True %}
+                  {% endif %}
                 {% elif type == "person" %}
                   {% include "molecules/cards/card.html" with resource=resource.person filter_target=True %}
                 {% elif type == "event" %}


### PR DESCRIPTION
This changeset slightly changes the direction of what will soon (via #624) be the Posts page.

It will contain data from Article Pages and also Video Pages. The retrieval of those
was already handled by a helper function, but the HTML templating and JS form-filter
code needed a small update.

Note that while I think this change has no adverse side-effects, there may be a regression somewhere due to the various ways some of the molecule templates are re-used - we should keep a close eye open during content entry.

(Resolves #625)

## Screenshots

![Screenshot 2019-11-01 at 15 59 40](https://user-images.githubusercontent.com/101457/68038930-f2ddfc00-fcc2-11e9-812e-966c5a51d53c.png)
![Screenshot 2019-11-01 at 15 59 49](https://user-images.githubusercontent.com/101457/68038931-f3769280-fcc2-11e9-81c4-6c9317c1556e.png)
![Screenshot 2019-11-01 at 15 59 55](https://user-images.githubusercontent.com/101457/68038932-f3769280-fcc2-11e9-97fa-043cfd355f7e.png)
![Screenshot 2019-11-01 at 16 00 50](https://user-images.githubusercontent.com/101457/68038935-f40f2900-fcc2-11e9-89e1-7f044ad384f9.png)
![Screenshot 2019-11-01 at 16 00 43](https://user-images.githubusercontent.com/101457/68038934-f3769280-fcc2-11e9-99e3-661bdd2ea373.png)



## How to test

- add some videos
- give at least some of them topics (via the meta tab)
- view the /articles/ page (soon to be /posts/) and confirm you can see the videos in with the articles
- confirm the filtering works as expected to show/hide the videos and related articles