### PR TITLE
648: Drop 'Featured' wording from inside cards that are featured

### DIFF
--- a/developerportal/templates/molecules/card-featured.html
+++ b/developerportal/templates/molecules/card-featured.html
@@ -12,9 +12,6 @@
 {% endif %}
   <div class="card-featured">
     <div class="card-featured-image" style="background-image: url('{% firstof card_image.url image.url fallback_image_url %}')"></div>
-    <div class="card-featured-content">
-      <span class="highlighted featured">Featured</span>
-    </div>
     <div class="card-featured-caption">
       <h5 class="no-underline">
         {% firstof resource.card_title resource.title %}{% if external_page or resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}


### PR DESCRIPTION
(Because there's a h2 saying the same word just above)

## Before


![Screenshot 2019-11-01 at 17 08 57](https://user-images.githubusercontent.com/101457/68042660-5704be00-fccb-11e9-8325-88467c7d4ede.png)


## After

![Screenshot 2019-11-01 at 17 14 07](https://user-images.githubusercontent.com/101457/68042659-566c2780-fccb-11e9-9bc2-6fe357440b81.png)


Resolves #648