### PR TITLE
669: Add docstring to make it easier to know how to solve broken new sidebar links

### DIFF
--- a/developerportal/apps/common/helpers.py
+++ b/developerportal/apps/common/helpers.py
@@ -11,6 +11,13 @@ logger = logging.getLogger(__name__)
 
 
 class ExplorerRedirectAdminURLHelper(AdminURLHelper):
+    """Make the sidebar link for the particular page type go to the
+    view of the page that lists their children, rather than the edit
+    view of the top-level page itself (Articles, Events, Topics or Videos)
+
+    eg: go to `/admin/pages/<id>/` rather than `/admin/videos/videos`
+    """
+
     def _get_action_url_pattern(self, action):
         if action == "index" and self.model.objects:
             try:

--- a/developerportal/apps/common/helpers.py
+++ b/developerportal/apps/common/helpers.py
@@ -1,9 +1,13 @@
+import logging
+
 from django.db.utils import ProgrammingError
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.contrib.modeladmin.helpers import PageButtonHelper
 from wagtail.contrib.modeladmin.helpers.url import AdminURLHelper
 from wagtail.contrib.modeladmin.options import ModelAdmin
+
+logger = logging.getLogger(__name__)
 
 
 class ExplorerRedirectAdminURLHelper(AdminURLHelper):
@@ -14,8 +18,9 @@ class ExplorerRedirectAdminURLHelper(AdminURLHelper):
                 if page:
                     return r"^pages/%s/$" % (page.pk)
                 action = "add"
-            except ProgrammingError:
-                pass
+            except ProgrammingError as e:
+                logger.exception(e)
+
         super()._get_action_url_pattern(action)
 
 


### PR DESCRIPTION
The ExplorerRedirectAdminURLHelper helper class is used via wagtail_hooks.py to send people
to a list of children for a given 'first-class' page (Articles, Videos, Events, Topics). 

However, the helper only checks the DB at the point of startup. So, if a page which uses this helper is added or recreated AFTER that point, the changes won't be reflected until server restart. The most likely manifestation of this is when setting up a new deployment from scratch and you see `/admin/None` for the sidebar links

This changeset adds this info as a docstring, where it would be have saved me an hour if it had existed already 😉 

It also adds some logging, to make it easier to catch this in Production if we roll out a new type of Page