### PR TITLE
676: Add SERVER_EMAIL configuration

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -161,6 +161,7 @@ EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
 EMAIL_PORT = int(os.environ.get("EMAIL_PORT", 587))
 EMAIL_USE_TLS = bool(os.environ.get("EMAIL_USE_TLS", True))
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
+SERVER_EMAIL = os.environ.get("SERVER_EMAIL", DEFAULT_FROM_EMAIL)
 
 
 # Internationalization


### PR DESCRIPTION
Uses a sensible default of the DEFAULT_FROM_EMAIL, but can be explicitly set if need be.


(Resolves #672)
