### PR TITLE
680: Try another approach to get GA codes rendereed out in static build only

### DIFF
--- a/developerportal/context_processors.py
+++ b/developerportal/context_processors.py
@@ -2,7 +2,12 @@ from django.conf import settings
 
 
 def google_analytics(request):
-    return {"GOOGLE_ANALYTICS": settings.GOOGLE_ANALYTICS}
+    DEFAULT_GA_PLACEHOLDER_VAL = "0"  # from the k8s Makefile
+    output = {}
+    ga_code = settings.GOOGLE_ANALYTICS
+    if ga_code and ga_code != DEFAULT_GA_PLACEHOLDER_VAL:
+        output.update({"GOOGLE_ANALYTICS": ga_code})
+    return output
 
 
 def mapbox_access_token(request):

--- a/k8s/celery.yaml.j2
+++ b/k8s/celery.yaml.j2
@@ -31,3 +31,7 @@ spec:
               cpu: {{ CELERY_WORKER_CPU_LIMIT }}
               memory: {{ CELERY_WORKER_MEMORY_LIMIT }}
 {% include 'app.env.yaml.j2' %}
+            # Ensure we have the right settings available for the worker
+            # (the indentation here is the right depth to be in the `env:` key)
+            - name: DJANGO_SETTINGS_MODULE
+              value: "developerportal.settings.worker"


### PR DESCRIPTION
Locally, when the celery worker runs with `developerportal.settings.worker` (which is the only settings file that tries to read `GOOGLE_ANALYTICS` from the environment), it correctly exports a static site that features the GA code, while Wagtail still leaves the GA code out of the static site.

However, this doesn't appear to be working when deployed to k8s. (And now that staging doesn't have the GA code available in it, we can only see this issue arising in the prod env.)

So, this changeset is assuming that something is stopping the right settings from being used.

By being extra-explicit about which DJANGO_SETTINGS_MODULE to use for the celery worker, we should hopefully make it use the correct settings, without affecting other pods which use the same env-var template

(Resolves #680)
