### PR TITLE
Fix up minor static-pipeline bug in local development when DEBUG=True

### DIFF
--- a/developerportal/apps/staticbuild/wagtail_hooks.py
+++ b/developerportal/apps/staticbuild/wagtail_hooks.py
@@ -142,8 +142,9 @@ def _static_build_async(self, force=False, pipeline=settings.STATIC_BUILD_PIPELI
     with redis_lock(lock_id=BUILD_LOCK_NAME, oid=self.app.oid) as lock_acquired:
         if lock_acquired:
 
-            build_dir = _generate_build_path()
-            logger.info(f"{log_prefix} Created temporary build dir {build_dir}")
+            if not settings.DEBUG:
+                build_dir = _generate_build_path()
+                logger.info(f"{log_prefix} Created temporary build dir {build_dir}")
 
             for name, command in pipeline:
                 if settings.DEBUG and not force:


### PR DESCRIPTION
When DEBUG=True, the static build is always skipped, but - in this case - the worker was still making a temporary build path (even though it wasn't being used to make a directory). 
In turn, the presence of the build_path var, but no actual directory of that name, was then
causing `shutil.rmtree` to error out, understandably.

This changeset addresses that by only generating the build path if we're not in debug mode.
(The default value for the build path is None.)

Example output:

## BROKEN with DEBUG=True

```
worker_1     |   File "/usr/local/lib/python3.7/site-packages/celery/app/trace.py", line 385, in trace_task
worker_1     |     R = retval = fun(*args, **kwargs)
worker_1     |   File "/usr/local/lib/python3.7/site-packages/celery/app/trace.py", line 648, in __protected_call__
worker_1     |     return self.run(*args, **kwargs)
worker_1     |   File "/app/developerportal/apps/staticbuild/wagtail_hooks.py", line 167, in _static_build_async
worker_1     |     shutil.rmtree(build_dir)
worker_1     |   File "/usr/local/lib/python3.7/shutil.py", line 485, in rmtree
worker_1     |     onerror(os.lstat, path, sys.exc_info())
worker_1     |   File "/usr/local/lib/python3.7/shutil.py", line 483, in rmtree
worker_1     |     orig_st = os.lstat(path)
worker_1     | FileNotFoundError: [Errno 2] No such file or directory: '/app/build/2019-11-05T12:18:14.911949+00:00'
```

## FIXED with DEBUG=True

```
worker_1     | [2019-11-05 15:36:19,807: INFO/ForkPoolWorker-4] [Static-build-and-sync] Attempting fresh build
worker_1     | [2019-11-05 15:36:19,810: INFO/ForkPoolWorker-4] [Static-build-and-sync] (wagtail-bakery) command 'Build' skipped.
worker_1     | [2019-11-05 15:36:19,810: INFO/ForkPoolWorker-4] [Static-build-and-sync] (wagtail-bakery) command 'Publish' skipped.
worker_1     | [2019-11-05 15:36:19,839: INFO/ForkPoolWorker-4] Task developerportal.apps.staticbuild.wagtail_hooks._static_build_async[43c6088a-1445-45f8-aa40-80b1e336dae5] succeeded in 0.03938060000655241s: None
```

## STILL WORKING AS NORMAL with DEBUG=False

```
worker_1     | [2019-11-05 15:43:10,259: INFO/ForkPoolWorker-3] [Static-build-and-sync] Attempting fresh build
worker_1     | [2019-11-05 15:43:10,260: INFO/ForkPoolWorker-3] [Static-build-and-sync] Created temporary build dir /app/build/2019-11-05T15:43:10.260895+00:00
worker_1     | [2019-11-05 15:43:10,261: INFO/ForkPoolWorker-3] [Static-build-and-sync] (wagtail-bakery) command 'Build' started.
worker_1     | [2019-11-05 15:43:10,374: INFO/ForkPoolWorker-3] Build started
worker_1     | [2019-11-05 15:43:20,421: INFO/ForkPoolWorker-3] Build finished
worker_1     | [2019-11-05 15:43:20,422: INFO/ForkPoolWorker-3] [Static-build-and-sync] (wagtail-bakery) command 'Build' finished.
worker_1     | [2019-11-05 15:43:20,422: INFO/ForkPoolWorker-3] [Static-build-and-sync] (wagtail-bakery) command 'Publish' started.
worker_1     | [2019-11-05 15:43:26,258: INFO/ForkPoolWorker-3] No Wagtail Redirects detected, so no S3 Website Redirects to create
worker_1     | [2019-11-05 15:43:26,544: INFO/ForkPoolWorker-3] Purging Cloudfront distribtion ID [REDACTED].
worker_1     | [2019-11-05 15:43:27,090: INFO/ForkPoolWorker-3] Got a positive response from Cloudfront. Invalidation status: InProgress
worker_1     | [2019-11-05 15:43:27,093: INFO/ForkPoolWorker-3] Publish completed, 39 uploaded and 0 deleted files in 6.67 seconds
worker_1     | [2019-11-05 15:43:27,098: INFO/ForkPoolWorker-3] [Static-build-and-sync] (wagtail-bakery) command 'Publish' finished.
worker_1     | [2019-11-05 15:43:27,170: INFO/ForkPoolWorker-3] [Static-build-and-sync] Deleted temporary build dir /app/build/2019-11-05T15:43:10.260895+00:00
worker_1     | [2019-11-05 15:43:27,178: INFO/ForkPoolWorker-3] Task developerportal.apps.staticbuild.wagtail_hooks._static_build_async[e12670b9-bebd-4607-bd8b-ac0a37c488de] succeeded in 16.95883160000085s: None
```