### PR TITLE
475: Disable the migration that drops the social-auth tables

### DIFF
--- a/developerportal/apps/common/migrations/0001_drop_social_auth_app_tables.py
+++ b/developerportal/apps/common/migrations/0001_drop_social_auth_app_tables.py
@@ -34,5 +34,7 @@ class Migration(migrations.Migration):
     dependencies = []
 
     operations = [
-        migrations.RunPython(drop_social_auth_tables, migrations.RunPython.noop)
+        # DISABLED BECAUSE WE NO LONGER NEED IT, BUT KEPT FOR REFERENCE
+        # migrations.RunPython(drop_social_auth_tables, migrations.RunPython.noop)
+        # migrations.RunPython(drop_social_auth_tables, migrations.RunPython.noop)
     ]


### PR DESCRIPTION
...now that it has reached (and been run on) production.

If someone happens to still have the social-auth tables locally, that's not a great concern.
A fresh install will match the state of stage/prod.

It's good to tidy this up now in case we re-add python-social-auth (or its family members) to the project and wonder where our DB tables went during CI 😄 

Run locally to check that it can be applied forwards and backwards with no effect:
```
Operations to perform:
  Unapply all migrations: common
Running migrations:
  Rendering model states... DONE
  Unapplying common.0001_drop_social_auth_app_tables... OK
/app $ python manage.py migrate common
Operations to perform:
  Apply all migrations: common
Running migrations:
  Applying common.0001_drop_social_auth_app_tables... OK
```

(Resolves #475)
