### PR TITLE
Make DJANGO_SETTINGS_MODULE configurable

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -8,6 +8,9 @@ export K8S_CLUSTER_SHORT_NAME ?= eks-oregon
 # Define an alias for the namespaced kubectl for convenience.
 export KC=kubectl -n ${K8S_NAMESPACE}
 
+# Configure default django settings to prod
+export DJANGO_SETTINGS_MODULE ?= developerportal.settings.production
+
 export APP_SERVICE_NAME ?= wagtail
 export APP_SERVICE_IDLE_TIMEOUT ?= 120
 
@@ -72,6 +75,7 @@ k8s-wagtail-deployments:
 	j2 app.deploy.yaml.j2 | ${KC} apply -f -
 
 k8s-celery-deployments:
+	env DJANGO_SETTINGS_MODULE=developerportal.settings.worker \
 	j2 celery.yaml.j2 | ${KC} apply -f -
 
 k8s-celery-beat-deployments:

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -15,7 +15,7 @@
                   name: dev-portal-secrets
                   key: DJANGO_SECRET_KEY
             - name: DJANGO_SETTINGS_MODULE
-              value: "developerportal.settings.production"
+              value: "{{ DJANGO_SETTINGS_MODULE }}"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/k8s/celery.yaml.j2
+++ b/k8s/celery.yaml.j2
@@ -31,7 +31,3 @@ spec:
               cpu: {{ CELERY_WORKER_CPU_LIMIT }}
               memory: {{ CELERY_WORKER_MEMORY_LIMIT }}
 {% include 'app.env.yaml.j2' %}
-            # Ensure we have the right settings available for the worker
-            # (the indentation here is the right depth to be in the `env:` key)
-            - name: DJANGO_SETTINGS_MODULE
-              value: "developerportal.settings.worker"


### PR DESCRIPTION
This changeset allows `DJANGO_SETTINGS_MODULE` to be a configurable value, this is a companion PR of https://github.com/mdn/developer-portal/pull/684

## Key changes:

- Set a default value `DJANGO_SETTINGS_MODULE` in the `Makefile`
- Export `DJANGO_SETTINGS_MODULE` in the `Makefile` target of your choice to select the value you want


