### PR TITLE
718: Make it possible to see draft ExternalContent in the Admin

### DIFF
--- a/developerportal/apps/externalcontent/wagtail_hooks.py
+++ b/developerportal/apps/externalcontent/wagtail_hooks.py
@@ -35,7 +35,32 @@ class ExternalContentButtonHelper(PageButtonHelper):
         return btns
 
 
-class ExternalContentAdmin(ModelAdmin):
+class BaseExternalEntityAdmin(ModelAdmin):
+    """We want all the ExternalContent Pages to show in the list,
+    not just the live ones. And we want to make it easy to see which
+    of them is live and which is draft."""
+
+    list_display = ("title", "show_draft_status")
+
+    def show_draft_status(self, obj):
+        if obj.live:
+            return "Published"
+        else:
+            return "Draft"
+
+    show_draft_status.short_description = "Published state?"
+
+    def get_queryset(self, request):
+        # super().get_queryset() uses the default manager, which only gets
+        # live Pages, but here we want to see drafts, too
+        qs = self.model.objects.all()
+        ordering = self.get_ordering(request)
+        if ordering:
+            qs = qs.order_by(*ordering)
+        return qs
+
+
+class ExternalContentAdmin(BaseExternalEntityAdmin):
     model = ExternalContent
     menu_icon = "link"
     menu_label = "All content"
@@ -43,7 +68,7 @@ class ExternalContentAdmin(ModelAdmin):
     button_helper_class = ExternalContentButtonHelper
 
 
-class ExternalArticleAdmin(ModelAdmin):
+class ExternalArticleAdmin(BaseExternalEntityAdmin):
     model = ExternalArticle
     menu_icon = "doc-full-inverse"
     menu_label = "Posts"
@@ -51,7 +76,7 @@ class ExternalArticleAdmin(ModelAdmin):
     button_helper_class = ExternalContentButtonHelper
 
 
-class ExternalEventAdmin(ModelAdmin):
+class ExternalEventAdmin(BaseExternalEntityAdmin):
     model = ExternalEvent
     menu_icon = "date"
     menu_label = "Events"
@@ -59,7 +84,7 @@ class ExternalEventAdmin(ModelAdmin):
     button_helper_class = ExternalContentButtonHelper
 
 
-class ExternalVideoAdmin(ModelAdmin):
+class ExternalVideoAdmin(BaseExternalEntityAdmin):
     model = ExternalVideo
     menu_icon = "media"
     menu_label = "Videos"


### PR DESCRIPTION
This changeset fixes an issue where draft pieces of ExternalContent were not visible in the Admin, which then can cause a server error when the user tries to add the same information again (with the same resulting slug, which causes a 500).

By ensuring the ExternalContent views show both live and draft states, we can avoid this.

Examples of the updated UI:

<img width="1063" alt="Screenshot 2019-11-06 at 21 51 12" src="https://user-images.githubusercontent.com/101457/68341680-e1408e00-00e0-11ea-88ce-e37a783a9ca4.png">

<img width="1071" alt="Screenshot 2019-11-06 at 21 51 20" src="https://user-images.githubusercontent.com/101457/68341681-e1408e00-00e0-11ea-91e6-052b8f626d3f.png">


(Resolves #718)
