### PR TITLE
726 Surface hidden slug clashes for external content

### DIFF
--- a/developerportal/apps/common/forms.py
+++ b/developerportal/apps/common/forms.py
@@ -1,17 +1,34 @@
 from wagtail.admin.forms import WagtailAdminPageForm
 from wagtail.core.models import Site
 
+EXTERNAL_ENTITY_NAMES = [
+    # Done as strings to avoid cross-module imports
+    "ExternalArticle",
+    "ExternalContent",
+    "ExternalEvent",
+    "ExternalVideo",
+]
 
-def _custom_slug_help_text():
-    # Generate slug help_text that uses the default site’s real URL, falling
-    # back to example.com instead of the Wagtail default.
-    default_site = Site.objects.filter(is_default_site=True).first()
-    base_url = default_site.root_url if default_site else "https://example.com"
 
-    return (
-        f"The name of the page as it will appear in URLs. For example, "
-        f"for a post: {base_url}/posts/your-slug-here/"
-    )
+def _custom_slug_help_text(model):
+    """Helper to generate entity-appropriate help text without also triggering
+    migration creation (which monkeypatching the models will do)"""
+
+    if model.__class__.__name__ in EXTERNAL_ENTITY_NAMES:
+        return (
+            "Because you are adding External content, this slug will NOT be "
+            "visible to the end user, but still needs to be unique within the CMS."
+        )
+    else:
+        # Generate slug help_text that uses the default site’s real URL, falling
+        # back to example.com instead of the Wagtail default.
+        default_site = Site.objects.filter(is_default_site=True).first()
+        base_url = default_site.root_url if default_site else "https://example.com"
+
+        return (
+            f"The name of the page as it will appear in URLs. For example, "
+            f"for a post: {base_url}/posts/your-slug-here/"
+        )
 
 
 class BasePageForm(WagtailAdminPageForm):
@@ -25,8 +42,7 @@ class BasePageForm(WagtailAdminPageForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
         # Find the default slug field, if possible, and patch it
         slug_field = self.fields.get(self.SLUGFIELD_NAME)
         if slug_field:
-            slug_field.help_text = _custom_slug_help_text()
+            slug_field.help_text = _custom_slug_help_text(self.instance)

--- a/developerportal/apps/common/tests/test_common.py
+++ b/developerportal/apps/common/tests/test_common.py
@@ -83,3 +83,28 @@ class BasePageFormTestCase(TestCase):
                 "for a post: http://localhost/posts/your-slug-here/"
             ),
         )
+
+    def test_help_text_patching_for_external_content(self):
+        # Inline import because we need to use a subclass of Page and don't
+        # want to pollute this module more than we have to
+        from developerportal.apps.externalcontent.models import (
+            ExternalEvent,
+            ExternalContent,
+            ExternalVideo,
+            ExternalArticle,
+        )
+
+        for model in [ExternalEvent, ExternalContent, ExternalVideo, ExternalArticle]:
+            assert model.base_form_class == BasePageForm
+
+            FormClass = get_form_for_model(model, form_class=BasePageForm)
+            form = FormClass()
+
+            self.assertEqual(
+                form.fields["slug"].help_text,
+                (
+                    "Because you are adding External content, "
+                    "this slug will NOT be visible to the end user, "
+                    "but still needs to be unique within the CMS."
+                ),
+            )

--- a/developerportal/apps/externalcontent/models.py
+++ b/developerportal/apps/externalcontent/models.py
@@ -74,12 +74,12 @@ class ExternalContent(BasePage):
         FieldPanel("external_url"),
     ]
 
+    settings_panels = BasePage.settings_panels + [FieldPanel("slug")]
+
     edit_handler = TabbedInterface(
         [
             ObjectList(card_panels, heading="Card"),
-            ObjectList(
-                BasePage.settings_panels, heading="Settings", classname="settings"
-            ),
+            ObjectList(settings_panels, heading="Settings", classname="settings"),
         ]
     )
 
@@ -158,13 +158,13 @@ class ExternalArticle(ExternalContent):
         FieldPanel("read_time"),
     ]
 
+    settings_panels = BasePage.settings_panels + [FieldPanel("slug")]
+
     edit_handler = TabbedInterface(
         [
             ObjectList(ExternalContent.card_panels, heading="Card"),
             ObjectList(meta_panels, heading="Meta"),
-            ObjectList(
-                BasePage.settings_panels, heading="Settings", classname="settings"
-            ),
+            ObjectList(settings_panels, heading="Settings", classname="settings"),
         ]
     )
 
@@ -239,13 +239,13 @@ class ExternalEvent(ExternalContent):
         ),
     ]
 
+    settings_panels = BasePage.settings_panels + [FieldPanel("slug")]
+
     edit_handler = TabbedInterface(
         [
             ObjectList(ExternalContent.card_panels, heading="Card"),
             ObjectList(meta_panels, heading="Meta"),
-            ObjectList(
-                BasePage.settings_panels, heading="Settings", classname="settings"
-            ),
+            ObjectList(settings_panels, heading="Settings", classname="settings"),
         ]
     )
 
@@ -339,13 +339,13 @@ class ExternalVideo(ExternalContent):
         FieldPanel("duration"),
     ]
 
+    settings_panels = BasePage.settings_panels + [FieldPanel("slug")]
+
     edit_handler = TabbedInterface(
         [
             ObjectList(ExternalContent.card_panels, heading="Card"),
             ObjectList(meta_panels, heading="Meta"),
-            ObjectList(
-                BasePage.settings_panels, heading="Settings", classname="settings"
-            ),
+            ObjectList(settings_panels, heading="Settings", classname="settings"),
         ]
     )
 


### PR DESCRIPTION
This changeset addresses a blow-up when adding External entities (any subtype) that has a name that auto-creates a slug that matches an existing slug for another piece of `External[Content|Video|Article|Event]`.

(For context an `External[Content|Video|Article|Event]` is still a subclass of a Wagtail `Page`, but when it is used we never render it as a regular Wagtail page: we just use it as a way of holding data about an external URL to load.) 

Prior to this changeset, because the `slug` field for the entity was not surfaced in Wagtail's Admin UI, there was no way to catch and report a slug-field clash as a `ValidationError`, so the conflict would cause an integrity-related blow-up during `save()`. (The slug field was probably not shown, because an `External*` item isn't meant to be used as a browsable page in the rendered site.)

The fix has been to reveal the `slug` in the Admin UI, to be able to catch and fix the clashes, while also adding useful help-text (for `External*` only) for editors.

(Resolves #726)

## Screenshots

**Note the presence of the `slug` field, the error messaging and also the help text (to the right)**
<img width="1063" alt="Screenshot 2019-11-08 at 11 53 33" src="https://user-images.githubusercontent.com/101457/68482614-dcd7ba80-0231-11ea-97e5-8094b66057ed.png">

**Note that non-`External*` entities still get the existing, dynamic, help text**
<img width="1027" alt="Screenshot 2019-11-08 at 11 55 28" src="https://user-images.githubusercontent.com/101457/68482615-dcd7ba80-0231-11ea-81d0-c82752f77ca3.png">


