### PR TITLE
651 Fix glitches with topic filters

### DIFF
--- a/developerportal/apps/common/tests/test_app_tags.py
+++ b/developerportal/apps/common/tests/test_app_tags.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+
+from wagtail.core.models import Page
+
+from developerportal.templatetags.app_tags import has_at_least_two_filters
+
+
+class AppTagsTestCase(TestCase):
+    def test_has_at_least_two_filters(self):
+
+        case_data = [
+            # One item
+            ({"foos": Page.objects.none()}, False),
+            ({"foos": Page.objects.all()}, False),
+            # Two items
+            ({"foos": Page.objects.none(), "bars": True}, False),
+            ({"foos": Page.objects.none(), "bars": False}, False),
+            ({"foos": Page.objects.all(), "bars": True}, True),
+            ({"foos": Page.objects.all(), "bars": False}, False),
+            # Three items
+            ({"foos": Page.objects.none(), "bars": True, "bams": True}, True),
+            ({"foos": Page.objects.none(), "bars": False, "bams": True}, False),
+            ({"foos": Page.objects.none(), "bars": False, "bams": False}, False),
+            ({"foos": Page.objects.all(), "bars": True, "bams": True}, True),
+            ({"foos": Page.objects.all(), "bars": False, "bams": True}, True),
+            ({"foos": Page.objects.all(), "bars": False, "bams": False}, False),
+        ]
+        for data, expected_outcome in case_data:
+            with self.subTest(data=data, expected_outcome=expected_outcome):
+                self.assertEqual(has_at_least_two_filters(data), expected_outcome)

--- a/developerportal/templates/molecules/filter-form.html
+++ b/developerportal/templates/molecules/filter-form.html
@@ -1,9 +1,12 @@
+{% load app_tags %}
+
 <form
   class="filter-form js-filter-form"
   data-controls="{{ type }}-cards"
   {% if initial_resources %}data-initial-resources="{{ initial_resources }}"{% endif %}
   {% if resources_per_page %}data-resources-per-page="{{ resources_per_page }}"{% endif %}
 >
+  {% if filters|has_at_least_two_filters %}
   <header class="filter-form-section js-filter-form-clear-section">
     <a href="#" class="filter-form-clear js-filter-clear">
       <span class="icon">
@@ -12,6 +15,7 @@
       Clear all
     </a>
   </header>
+  {% endif %}
 
   {% if filters.months %}
     <fieldset class="filter-form-section">

--- a/developerportal/templatetags/app_tags.py
+++ b/developerportal/templatetags/app_tags.py
@@ -45,3 +45,11 @@ def get_scheme_and_host(request):
 @register.simple_tag
 def use_conventional_auth():
     return settings.USE_CONVENTIONAL_AUTH
+
+
+@register.filter
+def has_at_least_two_filters(filters):
+    # For the given dictionary of `filters`, return True if at
+    # least two of its keys' values are truthy, else False
+    result = len([val for val in filters.values() if bool(val)]) >= 2
+    return result

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -23,9 +23,9 @@ exports.parseQueryParams = () => {
  *
  * @returns {object}
  */
-exports.parseForm = () => {
+exports.parseForm = form => {
   const filter = {};
-  const elements = document.querySelectorAll('input[type="checkbox"]:checked');
+  const elements = form.querySelectorAll('input[type="checkbox"]:checked');
   Array.from(elements).forEach(element => {
     if (!filter[element.name]) {
       filter[element.name] = [];


### PR DESCRIPTION
This changeset addresses two small niggles with the filter form:

1) Only show a Clear All option when there is more than one group of filters available on the page
2) Fix an issue to do with form filter state set up from querystring parameters.

(Resolves #651)

## Key changes:

- **Fix showing the 'X Clear all'  trigger when there is only one filter to clear**

**"Clear all" present when multiple filter groups exist**
![Screenshot 2019-11-08 at 15 58 30](https://user-images.githubusercontent.com/101457/68500025-8f1f7a00-0252-11ea-9165-ef100cd5a9c7.png)
----

**"Clear all" absent when just one filter group exists**
![Screenshot 2019-11-08 at 15 58 39](https://user-images.githubusercontent.com/101457/68500026-8f1f7a00-0252-11ea-971a-a26543895f4b.png)

----
----


-  **Fix issue with JS filter-form**

    Prior to this changeset, when pages were loaded with a querystring for selected filters (eg a user back-arrows from a page, or gets sent a URL), there was a bug where unselecting one of the checkboxes would actually add it to the querystring again (eg `?topic=foo,bar` --> `?topic=foo,bar,foo`) and then unticking it would retain one of the `foo` entries and continue to filter by it, even tho the UI looked like the option had been deselected. (In this case, the querystring would be `?topic=foo,bar` again, further confusing the user.)

    The root cause of this was in a change to how parseForm stopped using a target form element, despite being given it. It's [this commit](https://github.com/mdn/developer-portal/commit/85d822b0dcdc78478c631834dda700eb3710da5d) that stoppped taking the triggering form as the base node for the data and instead grabbed all the relevant-seeming checkboxes.

    Why did this matter? The change seems sensible enough. The sutble gotcha here is that there are actually _two_ forms in the page, but only one displayed (one is for mobile filtering, the other is for desktop). When a page was loaded without querystring params, everything was working fine. When a page is loaded WITH querystring params, BOTH forms get initialised to have some fields ticked, but only one of them is visible and so can have its fields unticked by a user. However, because document.querySelectorAll() was scanning _all_ checkboxes in the page, not just those for the form that was amended, it would return "false" for the just-unticked checkbox but still a "true" for the hidden one that was populated on page load -- and _then_ it would re-update the querystring with this incorrect data.

    The fix is simply to ensure the parseFrom function now again accepts a form element being passed to it, and to use that form to reduce the scope of the querySelectorAll to only its form fields.
