### PR TITLE
691: Enable gzip compression for HTML pages

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -236,8 +236,11 @@ WAGTAILIMAGES_IMAGE_MODEL = "mozimages.MozImage"
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 BASE_URL = os.environ.get("BASE_URL")
 
+# Django-Bakery settings
+# https://django-bakery.readthedocs.io/en/latest/settingsvariables.html#bakery-gzip
+BAKERY_GZIP = True
 
-# Wagtail Bakery Settings
+# Wagtail-Bakery Settings
 
 # This is a handy default for local building, but note that when we build in production
 # we're actually using this as a root of a build path, to prevent concurrent builds
@@ -253,8 +256,8 @@ BAKERY_VIEWS = (
     "developerportal.apps.bakery.views.S3RedirectManagementView",
     "developerportal.apps.bakery.views.CloudfrontInvalidationView",
 )
-AWS_REGION = os.environ.get("AWS_REGION")
 
+AWS_REGION = os.environ.get("AWS_REGION")
 # This bucket is where the static site will be baked to
 AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")


### PR DESCRIPTION
This changeset addresses the desire for smaller page loads, by implementing gzip compression for the pages generated by `wagtail-bakery`

It's simple configuration tweak, plus some tidying up of nearby settings.

HOWEVER, before we merge this, we need to be 100% happy that it's not going to be at risk of [BREACH](http://breachattack.com/) or similar attacks. (For now the site is entirely inert/GET-only, but we shouldn't assume this makes it automaticall OK - a check in with MozInfoSec is worthwhile.)

UPDATE: checked MozInfoSec and got a 👍 

(Resolves #691)

<img width="401" alt="Screenshot 2019-11-10 at 22 02 35" src="https://user-images.githubusercontent.com/101457/68551725-cdaa6580-0407-11ea-8d94-09004c62e3f2.png">


