### PR TITLE
747: Cleanup static build process to remove `force` keyword

### DIFF
--- a/developerportal/apps/staticbuild/models.py
+++ b/developerportal/apps/staticbuild/models.py
@@ -18,4 +18,4 @@ def trigger_build(sender, instance, created=False, **kwargs):
     if created:
         from .wagtail_hooks import static_build
 
-        static_build(force=True)
+        static_build()


### PR DESCRIPTION
The `force` keyword hasn't been supported for a few weeks (since the refactor to the 'request a build' pattern from the 'start a build' one). This changeset removes the keyword and adds a clearer message hinting at how to get a statid build running locally:

```
worker_1     | [2019-11-11 16:30:30,265: INFO/ForkPoolWorker-3] [Static-build-and-sync] Attempting fresh build
worker_1     | [2019-11-11 16:30:30,266: INFO/ForkPoolWorker-3] [Static-build-and-sync] (wagtail-bakery) command 'Build' skipped because DEBUG=True.
worker_1     | [2019-11-11 16:30:30,267: INFO/ForkPoolWorker-3] [Static-build-and-sync] (wagtail-bakery) command 'Publish' skipped because DEBUG=True.
```

It also rephrases the Admin menu item from 'trigger' a static build to 'request' one

While manually QAing this, I confirmed the 'Request a static build' feature in the Admin is working.

(Resolves #747)

