### PR TITLE
Remove port 80 from nginx service, sneeaked in some cleanup as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,7 @@ RUN apk add --no-cache \
   libmemcached-dev \
   libxslt-dev \
   postgresql-libs \
-  zlib-dev \
-  bash \
-  openssl \
-  openssl-dev
+  zlib-dev
 
 COPY requirements.txt /app/
 RUN pip install -U pip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       - ./developerportal:/app/developerportal
       - ./media:/app/media
       - ./src:/app/src
-      - ./etc/nginx/ssl:/etc/nginx/ssl
     depends_on:
       - db
       - redis
@@ -71,13 +70,14 @@ services:
       - ./etc/nginx/ssl:/ssl
     entrypoint: ./gen-cert.sh
 
+  # NOTE: Used to have port 80 but its being used by our jenkins
+  # instance
   nginx:
     image: nginx
     volumes:
       - ./etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./etc/nginx/ssl:/etc/nginx/ssl
     ports:
-      - '80:80'
       - '443:443'
     depends_on:
       - cfssl


### PR DESCRIPTION
Currently our CI server uses port 80 to do a reverse proxy to the jenkins (we do ELB SSL termination at the ELB level). However for local development we started exposing port `80` and port `443` (see PR #424) which causes jenkins to fail so this change removes port `80` from the nginx container since realistically we only want to test SSL anyway. 

Sneaked in a couple of cleanup changes that came from PR #424, we no longer need openssl and bash installed on the `app` container


## Key changes:

- Remove port `80` from `nginx` container
- Cleanup packages we don't need

## How to test

- Run `docker-compose up -d --build` locally, and test `https://developer-portal-127-0-0-1.nip.io` responds
- Chicken and egg situation where this PR needs to be merged to ensure that jenkins actually completes a build