### PR TITLE
Set GID and UID for cfssl container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,9 @@ node {
         }
       }
       stage ('Test') {
+        // Set UID and GID
+        env['UID'] = sh(returnStdout: true, script: 'id -u jenkins').trim()
+        env['GID'] = sh(returnStdout: true, script: 'id -g jenkins').trim()
         try {
             sh "scripts/ci-setup --build"
             sh "scripts/ci-tests"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
   cfssl:
     image: cfssl/cfssl
     working_dir: /ssl
+    user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - ./etc/nginx/ssl:/ssl
     entrypoint: ./gen-cert.sh


### PR DESCRIPTION
Ensures that GID and UID is set for the `cfssl` container, this ensure that Jenkins eventually owns the cert files

(Resolves #753)

## Key changes:

- Sets `GID` and `UID`

