### PR TITLE
Set NEW_RELIC_APP_NAME to emptry string in migration job

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -111,6 +111,7 @@ k8s-history:
 	${KC} rollout history deploy ${APP_NAME}
 
 k8s-db-migration-job: k8s-delete-db-migration-job
+	env NEW_RELIC_APP_NAME="" \
 	j2 db-migration-job.yaml.j2 | ${KC} apply -f -
 	env JOB_NAME=db-migration ./wait_for_job.sh
 


### PR DESCRIPTION
Set `NEW_RELIC_APP_NAME` to emptry string for db migration job since it doesn't need it.