### PR TITLE
Start celery and gunicorn using newrelic-admin

### DIFF
--- a/k8s/app.deploy.yaml.j2
+++ b/k8s/app.deploy.yaml.j2
@@ -19,8 +19,10 @@ spec:
           image: "{{ APP_IMAGE }}:{{ APP_IMAGE_TAG }}"
           imagePullPolicy: {{ APP_IMAGE_PULL_POLICY }}
           command:
-            - "gunicorn"
+            - "/usr/local/bin/newrelic-admin"
           args:
+            - "run-program"
+            - "gunicorn"
             - "--workers={{ APP_GUNICORN_WORKERS }}"
             - "--worker-class=meinheld.gmeinheld.MeinheldWorker"
             - "--bind=0.0.0.0:{{ APP_PORT }}"

--- a/k8s/celery.yaml.j2
+++ b/k8s/celery.yaml.j2
@@ -17,8 +17,10 @@ spec:
           image: "{{ APP_IMAGE }}:{{ APP_IMAGE_TAG }}"
           imagePullPolicy: {{ APP_IMAGE_PULL_POLICY }}
           command:
-            - "celery"
+            - "/usr/local/bin/newrelic-admin"
           args:
+            - "run-program"
+            - "celery"
             - "--app=developerportal.apps.staticbuild"
             - worker
             - "--loglevel=INFO"


### PR DESCRIPTION
Start `gunicorn` and `celery` using `newrelic-admin` this will allow them to start sending metrics over to New Relic

(Resolves #758)

## Key changes:

- Start up app using `newrelic-admin`
