### PR TITLE
777: Disable gzip of content by django-bakery

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -238,7 +238,7 @@ BASE_URL = os.environ.get("BASE_URL")
 
 # Django-Bakery settings
 # https://django-bakery.readthedocs.io/en/latest/settingsvariables.html#bakery-gzip
-BAKERY_GZIP = True
+BAKERY_GZIP = False  # NB: *Not* enabled here, because it's done at the CDN level
 
 # Wagtail-Bakery Settings
 


### PR DESCRIPTION
An earlier changeset (for #691) enabled gzip compression during the wagtail-bakery build process. However we now have that as part of the CDN configuration so only enabling it in ONE place makes sense.


(Resolves #777)

