### PR TITLE
784: improve padding for the filter-list open/close trigger on mobile

### DIFF
--- a/src/css/organisms/filter-list.scss
+++ b/src/css/organisms/filter-list.scss
@@ -49,6 +49,14 @@
   @media #{$mq-md} {
     display: none;
   }
+  padding-top: 5px;
+  padding-bottom: 5px;
+  padding-right: 8px;
+  summary {
+    &:before {
+      margin-top: -10px;
+    }
+  }
 }
 
 .filter-list-sidebar-content-desktop {


### PR DESCRIPTION
The `+` and `X` no longer feels offset vertically. Also tried to equalise the space towards the right box border, too.


(Resolves #784)

# BEFORE

![Screenshot 2019-11-15 at 12 58 04](https://user-images.githubusercontent.com/101457/68993411-d8ce1d00-086f-11ea-8850-155de70cc92f.png)
![Screenshot 2019-11-15 at 13 01 10](https://user-images.githubusercontent.com/101457/68993413-d8ce1d00-086f-11ea-84ed-17bace8738f3.png)
![Screenshot 2019-11-15 at 13 01 15](https://user-images.githubusercontent.com/101457/68993414-d966b380-086f-11ea-90da-422050e36ecd.png)


# AFTER

<img width="463" alt="Screenshot 2019-11-16 at 12 33 39" src="https://user-images.githubusercontent.com/101457/68993423-e8e5fc80-086f-11ea-915c-f31064fff364.png">
<img width="401" alt="Screenshot 2019-11-16 at 12 51 26" src="https://user-images.githubusercontent.com/101457/68993425-f26f6480-086f-11ea-8b43-5a389443eecf.png">
<img width="830" alt="Screenshot 2019-11-16 at 12 47 59" src="https://user-images.githubusercontent.com/101457/68993426-f26f6480-086f-11ea-8b5d-e32b86daff00.png">
<img width="724" alt="Screenshot 2019-11-16 at 12 47 54" src="https://user-images.githubusercontent.com/101457/68993427-f26f6480-086f-11ea-8070-420a4b1909b4.png">
<img width="420" alt="Screenshot 2019-11-16 at 12 53 45" src="https://user-images.githubusercontent.com/101457/68993445-29de1100-0870-11ea-91d3-573c61df7ce8.png">
