### PR TITLE
781: Minor CSS changes to Topic blocks to better align the rich text

### DIFF
--- a/src/css/molecules/item-topic-link.scss
+++ b/src/css/molecules/item-topic-link.scss
@@ -47,6 +47,8 @@
   font-size: 0; // Prevent spacing below icon.
   margin-right: 16px;
   padding-top: 4px;
+  width: 50px;
+  text-align: center;
 
   img {
     width: 24px;
@@ -55,8 +57,8 @@
 
 .item-topic-link-content {
   max-width: 672px;
-
   @media #{$mq-md} {
+    padding-right: 6px;
     flex-grow: 1;
   }
 


### PR DESCRIPTION
While this isn't a perfect fix, it makes the content less susceptible to reflow issues triggered by differing widths of the SVG icons for each Topic. Note that the existing SVG icons do not need to be changed for this to be "good enough" (See comments in #781), but standardising them will also help.

Checked locally and/or in Browserstack across Edge, FF, Safari and Chrome

## Before
<img width="1082" alt="Screenshot 2019-11-18 at 11 24 28" src="https://user-images.githubusercontent.com/101457/69048847-6176c580-09f6-11ea-867e-c5a75a9156a3.png">


## After
<img width="1068" alt="Screenshot 2019-11-18 at 11 24 10" src="https://user-images.githubusercontent.com/101457/69048846-60de2f00-09f6-11ea-89f0-99faac54c0db.png">


(Resolves #718)
