### PR TITLE
Add db backup cron

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -59,6 +59,15 @@ export NEW_RELIC_LABELS ?= Project:developer-portal;Namespace:${K8S_NAMESPACE};E
 
 export GOOGLE_ANALYTICS ?= 0
 
+# Backup config
+export RDS_BACKUP_DBTYPE ?= 'PGSQL'
+export RDS_BACKUP_SCHEDULE ?= '@daily'
+export RDS_BACKUP_IMAGE ?= mdnwebdocs/mdn-rds-backup
+export RDS_BACKUP_IMAGE_TAG ?= 6197650
+export RDS_BACKUP_DIR ?= '/backup'
+export RDS_BACKUP_BUCKET ?= 's3://developer-portal-backups-178589013767/backups'
+export RDS_BACKUP_DEBUG_MODE ?= 'false'
+
 ###############################
 ### core tasks
 
@@ -118,6 +127,11 @@ k8s-db-migration-job: k8s-delete-db-migration-job
 k8s-delete-db-migration-job:
 	${KC} delete --ignore-not-found job db-migration
 
+k8s-rds-backup-cronjob:
+	j2 db-backups-cron.yaml.j2 | ${KC} apply -f -
+
+k8s-delete-rds-backup-cronjob:
+	${KC} delete --ignore-not-found cronjob dev-portal-rds-backup
 
 k8s-jenkins-create-rbac:
 	kubectl apply -f jenkins-rbac.yaml

--- a/k8s/db-backups-cron.yaml.j2
+++ b/k8s/db-backups-cron.yaml.j2
@@ -1,0 +1,73 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: dev-portal-rds-backup
+spec:
+  schedule: {{ RDS_BACKUP_SCHEDULE }}
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: dev-portal-rds-backup
+              image: {{ RDS_BACKUP_IMAGE }}:{{ RDS_BACKUP_IMAGE_TAG }}
+              {%- if RDS_BACKUP_DEBUG_MODE == 'true' %}
+              command: [ "/bin/bash", "-c", "--" ]
+              args: [ "while true; do sleep 30; done;" ]
+              {%- endif %}
+              env:
+                - name: DBTYPE
+                  value: {{ RDS_BACKUP_DBTYPE }}
+                - name: BACKUP_DIR
+                  value: {{ RDS_BACKUP_DIR }}
+                - name: BACKUP_BUCKET
+                  value: {{ RDS_BACKUP_BUCKET }}
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: dev-portal-backups
+                      key: AWS_ACCESS_KEY_ID
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: dev-portal-backups
+                      key: AWS_SECRET_ACCESS_KEY
+                - name: BACKUP_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: dev-portal-backups
+                      key: BACKUP_PASSWORD
+                - name: DBHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: dev-portal-backups
+                      key: DBHOST
+                - name: DBNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: dev-portal-backups
+                      key: DBNAME
+                - name: DBPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: dev-portal-backups
+                      key: DBPASSWORD
+                - name: DBPORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: dev-portal-backups
+                      key: DBPORT
+                - name: DBUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: dev-portal-backups
+                      key: DBUSER
+                - name: DEADMANSSNITCH_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: dev-portal-backups
+                      key: DEADMANSSNITCH_URL


### PR DESCRIPTION
This changeset creates a cronjob that runs daily and creates a daily db dump of the database. The db dump is encrypted using a passphrase and then uploaded to `s3`

(Resolves #802 )

## Key changes:

- Create k8s cronjob to run a nightly db dump on the prod database

