### PR TITLE
746: Add sitemap support to static site

### DIFF
--- a/developerportal/apps/bakery/tests/test_views.py
+++ b/developerportal/apps/bakery/tests/test_views.py
@@ -267,3 +267,13 @@ class CloudfrontInvalidationViewTests(TestCase):
                 )
             ],
         )
+
+
+class SitemapViewTests(TestCase):
+    def test_reminder(self):
+        self.fail("WRITE ME")
+
+
+class HelpersTests(TestCase):
+    def test_is_secure_request(self):
+        self.fail("WRITE ME")

--- a/developerportal/apps/bakery/views.py
+++ b/developerportal/apps/bakery/views.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from http import HTTPStatus
+from http.client import HTTPS_PORT
 
 from django.conf import settings
 from django.db.models import Q
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def is_secure_request(site):
-    return site.port == 443 or getattr(settings, "SECURE_SSL_REDIRECT", False)
+    return site.port == HTTPS_PORT or getattr(settings, "SECURE_SSL_REDIRECT", False)
 
 
 class AllPublishedPagesViewAllowingSecureRedirect(AllPublishedPagesView):

--- a/developerportal/apps/bakery/views.py
+++ b/developerportal/apps/bakery/views.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from http import HTTPStatus
 
 from django.conf import settings
@@ -8,12 +9,18 @@ from django.utils.timezone import now as tz_now
 
 import boto3
 from wagtail.contrib.redirects.models import Redirect
+from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.core.models import Site
 
 from bakery.management.commands import get_s3_client
+from bakery.views import BuildableMixin
 from wagtailbakery.views import AllPublishedPagesView, WagtailBakeryView
 
 logger = logging.getLogger(__name__)
+
+
+def is_secure_request(site):
+    return site.port == 443 or getattr(settings, "SECURE_SSL_REDIRECT", False)
 
 
 class AllPublishedPagesViewAllowingSecureRedirect(AllPublishedPagesView):
@@ -36,9 +43,7 @@ class AllPublishedPagesViewAllowingSecureRedirect(AllPublishedPagesView):
         """
         site = obj.get_site()
         logger.debug("Building %s" % obj)
-        secure_request = site.port == 443 or getattr(
-            settings, "SECURE_SSL_REDIRECT", False
-        )
+        secure_request = is_secure_request(site)
         self.request = RequestFactory(SERVER_NAME=site.hostname).get(
             self.get_url(obj), secure=secure_request
         )
@@ -169,3 +174,31 @@ class CloudfrontInvalidationView(PostPublishOnlyWagtailBakeryView):
                 logger.warning(
                     "Got an unexpected response from Cloudfront: {}".format(response)
                 )
+
+
+class SitemapBuildableView(BuildableMixin):
+    # Note that this code is based on https://github.com/wagtail/wagtail-bakery/pull/38
+    # and ONLY builds out the default site (which is fine for our current needs
+    # but may change over time). Ideally wagtail-bakery will soon get this behaviour
+    # and we can switch to its own implementation
+
+    build_path = "sitemap.xml"
+
+    def build(self):
+        logger.info("Building out XML sitemap.")
+        default_site = Site.objects.filter(is_default_site=True).first()
+        secure_request = is_secure_request(default_site)
+        self.request = RequestFactory(SERVER_NAME=default_site.hostname).get(
+            self.build_path, secure=secure_request
+        )
+        path = os.path.join(settings.BUILD_DIR, self.build_path)
+        self.prep_directory(self.build_path)
+        self.build_file(path, self.get_content())
+        logger.info("Sitemap building complete.")
+
+    @property
+    def build_method(self):
+        return self.build
+
+    def get_content(self):
+        return sitemap(self.request).render().content

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -67,6 +67,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sitemaps",
     "django_celery_results",
     "mozilla_django_oidc",  # needs to be loaded after auth
 ]
@@ -253,6 +254,7 @@ BAKERY_VIEWS = (
     # to run last of all
     "developerportal.apps.bakery.views.AllPublishedPagesViewAllowingSecureRedirect",
     "bakery.views.Buildable404View",
+    "developerportal.apps.bakery.views.SitemapBuildableView",
     "developerportal.apps.bakery.views.S3RedirectManagementView",
     "developerportal.apps.bakery.views.CloudfrontInvalidationView",
 )

--- a/developerportal/templates/base.html
+++ b/developerportal/templates/base.html
@@ -43,6 +43,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <link rel="stylesheet" type="text/css" href="{% static 'css/bundle.css' %}">
       <link rel="shortcut icon" href="{% static 'img/icons/favicon.ico' %}">
+      <link rel="sitemap" type="application/xml" href="/sitemap.xml"/>
       {% comment "DISABLED FOR NOW UNTIL WE CAN EXPORT IT TO THE STATIC SITE %}
       <link rel="alternate" type="application/rss+xml" href="/posts-feed/">
       {% endcomment %}

--- a/developerportal/urls.py
+++ b/developerportal/urls.py
@@ -6,6 +6,7 @@ from django.views.defaults import page_not_found, server_error
 from django.views.generic import TemplateView
 
 from wagtail.admin import urls as wagtailadmin_urls
+from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
@@ -16,6 +17,7 @@ urlpatterns = [
     url(r"^django-admin/", admin.site.urls),
     url(r"^admin/", include(wagtailadmin_urls)),
     url(r"^documents/", include(wagtaildocs_urls)),
+    url(r"^sitemap\.xml$", sitemap),
     url(r"^posts-feed/", RssFeeds()),
     url(r"^auth/", include("mozilla_django_oidc.urls")),
     url(


### PR DESCRIPTION
This changeset adds an XML sitemap to the rendered site and also includes it in the static site exported to S3

(Addresses #746)

## How to test

- locally, run `docker-compose exec app manage.py build` to "bake out" the static site to `/app/build/` in your `app_1` container
- shell in with `docker-compose exec app sh` 
- `less /app/build/index.html` to see the link to `sitemap.xml` in the `<head>` of the document
- `less /app/build/sitemap.xml` to see the sitemap content itself.

For convenience, I've temporarily exposed my own dev S3 bucket in website mode, so you can check for yourself. The content is dummy, but the sitemap is still correct. (Note that there is no HTTPS on this example bucket)

- View source on http://devportalstatictestxyz.s3-website-eu-west-1.amazonaws.com/ - see that the sitemap is linked from the `head`
- Browse the sitemap itself at http://devportalstatictestxyz.s3-website-eu-west-1.amazonaws.com/sitemap.xml and confirm it works fine


## To check on staging after merge:

- [ ] Ensure HTTPS links are correctly included in the sitemap