### PR TITLE
864: Fix regression with static-site generation

### DIFF
--- a/developerportal/apps/bakery/views.py
+++ b/developerportal/apps/bakery/views.py
@@ -34,7 +34,7 @@ class AllPublishedPagesViewAllowingSecureRedirect(AllPublishedPagesView):
         Build wagtail page and set SERVER_NAME to retrieve corresponding site
         object.
         """
-        site = obj.get_site()
+        site = obj.specific.get_site()
         logger.debug("Building %s" % obj)
         secure_request = site.port == 443 or getattr(
             settings, "SECURE_SSL_REDIRECT", False

--- a/developerportal/apps/externalcontent/models.py
+++ b/developerportal/apps/externalcontent/models.py
@@ -99,7 +99,7 @@ class ExternalContent(BasePage):
         return self.external_url
 
     def get_site(self):
-        """Due to modelling/config (which will be changed soon), it's possiblethat
+        """Due to modelling/config (which will be changed soon), it's possible that
         ExternalContent subclasses end up a children of Wagtail's hidden root page,
         rather than the Homepage, which means that the default get_site() will not
         work for them and instead will return None. This addresses that

--- a/developerportal/apps/externalcontent/models.py
+++ b/developerportal/apps/externalcontent/models.py
@@ -100,7 +100,7 @@ class ExternalContent(BasePage):
 
     def get_site(self):
         """Due to modelling/config (which will be changed soon), it's possiblethat
-        ExternalContent subclasses end up being children of Wagtail's root page,
+        ExternalContent subclasses end up a children of Wagtail's hidden root page,
         rather than the Homepage, which means that the default get_site() will not
         work for them and instead will return None. This addresses that
         shortcoming by fetching the default Site instead, if needed."""

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -11,3 +11,8 @@ As a result, the changes done were all kept (as part of ticket 624) at surface l
 Streamfield blocks have been renamed from 'article' to 'post' to keep the UI consistent, but the internal use of a `type` or `resource_type` attribute on a Page instance has been left with the value 'article', not changed to 'post' because that would have been a non-visible-to-humans change.
 
 However, in the future, we may decide that we definitely want to stick with "Posts", in which case a proper model-renaming exercise is worth it, along with CSS and template-name changes, too.
+
+## General assumption about there being just one Site
+
+Sometimes in the custom views that inform the 'baking' process for wagtail-bakery, we've had to get hold of a Site object from the database instead of via a relation from a Page we're processing.
+In this case, we've had no option but to use the default Site -- which is fine because was only one at the genesis of this project. HOWEVER, if this changes and - for example - we add i18n and l10n, this assumption will no longer be reliable/safe and any ORM query that uses `is_default_site=` must be refactored out of the codebase.

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -15,4 +15,4 @@ However, in the future, we may decide that we definitely want to stick with "Pos
 ## General assumption about there being just one Site
 
 Sometimes in the custom views that inform the 'baking' process for wagtail-bakery, we've had to get hold of a Site object from the database instead of via a relation from a Page we're processing.
-In this case, we've had no option but to use the default Site -- which is fine because was only one at the genesis of this project. HOWEVER, if this changes and - for example - we add i18n and l10n, this assumption will no longer be reliable/safe and any ORM query that uses `is_default_site=` must be refactored out of the codebase.
+In this case, we've had no option but to use the default Site -- which was initially fine because there was only one at the genesis of this project. HOWEVER, if this changes and - for example - we add i18n and l10n, this assumption will no longer be reliable/safe and any ORM query that uses `is_default_site=` must be refactored out of the codebase.

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ botocore==1.13.26
 certifi==2019.9.11
 chardet==3.0.4
 cssselect==1.1.0
-django-bakery==0.12.3
+django-bakery==0.12.7
 django-countries==5.5
 django-modelcluster==4.4
 django-taggit==0.24

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -21,6 +21,7 @@ exports.parseQueryParams = () => {
 /**
  * Creates an object based on a form's current input values.
  *
+ * @param {object} form
  * @returns {object}
  */
 exports.parseForm = form => {


### PR DESCRIPTION
Somewhere between wagtail-bakery 0.3 and 0.4 (which was recently bumped as a dependency) a change took place that surfaces a shortcoming in our code: ExternalContent subclasses return None for .get_site() because they are not saved as children of Articles, Videos or Events, respectively.

The workaround for now is to just get the default Site for these Pages. A fuller fixup has been ticketed as #865.

Note that bumping django-bakery in this changeset didn't cause the regression - it was happening before that, and this change is just to bring it up to date, now that wagtail-bakery==0.4.0 allows a higher version of django-bakery.

I've also added a reminder to the developer notes about the downside of assuming we can always use the default Site if we lack a route to a Page's actual Site.

Manually checked a static build (all the way to S3) and seems fine:  http://devportalstatictestabc.s3-website-eu-west-1.amazonaws.com

Python tests pass; JS tests/linting checks pass

(Resolves #864)
