### PR TITLE
Hotfix/downgrade bakeries

### DIFF
--- a/developerportal/apps/bakery/views.py
+++ b/developerportal/apps/bakery/views.py
@@ -34,7 +34,7 @@ class AllPublishedPagesViewAllowingSecureRedirect(AllPublishedPagesView):
         Build wagtail page and set SERVER_NAME to retrieve corresponding site
         object.
         """
-        site = obj.specific.get_site()
+        site = obj.get_site()
         logger.debug("Building %s" % obj)
         secure_request = site.port == 443 or getattr(
             settings, "SECURE_SSL_REDIRECT", False

--- a/developerportal/apps/externalcontent/models.py
+++ b/developerportal/apps/externalcontent/models.py
@@ -1,6 +1,5 @@
 # pylint: disable=no-member
 import datetime
-import logging
 
 from django.db.models import (
     CASCADE,
@@ -24,14 +23,12 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core.blocks import PageChooserBlock
 from wagtail.core.fields import RichTextField, StreamBlock, StreamField
-from wagtail.core.models import Orderable, Site
+from wagtail.core.models import Orderable
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from ..common.blocks import ExternalAuthorBlock
 from ..common.constants import RICH_TEXT_FEATURES_SIMPLE
 from ..common.models import BasePage
-
-logger = logging.getLogger(__name__)
 
 
 class ExternalContent(BasePage):
@@ -97,19 +94,6 @@ class ExternalContent(BasePage):
 
     def relative_url(self, current_site, request=None):
         return self.external_url
-
-    def get_site(self):
-        """Due to modelling/config (which will be changed soon), it's possible that
-        ExternalContent subclasses end up a children of Wagtail's hidden root page,
-        rather than the Homepage, which means that the default get_site() will not
-        work for them and instead will return None. This addresses that
-        shortcoming by fetching the default Site instead, if needed."""
-
-        site = super().get_site()
-        if not site:
-            logger.info(f"Page {self} lacks a Site. Using default Site...")
-            site = Site.objects.get(is_default_site=True)
-        return site
 
     @property
     def url(self):

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -11,8 +11,3 @@ As a result, the changes done were all kept (as part of ticket 624) at surface l
 Streamfield blocks have been renamed from 'article' to 'post' to keep the UI consistent, but the internal use of a `type` or `resource_type` attribute on a Page instance has been left with the value 'article', not changed to 'post' because that would have been a non-visible-to-humans change.
 
 However, in the future, we may decide that we definitely want to stick with "Posts", in which case a proper model-renaming exercise is worth it, along with CSS and template-name changes, too.
-
-## General assumption about there being just one Site
-
-Sometimes in the custom views that inform the 'baking' process for wagtail-bakery, we've had to get hold of a Site object from the database instead of via a relation from a Page we're processing.
-In this case, we've had no option but to use the default Site -- which was initially fine because there was only one at the genesis of this project. HOWEVER, if this changes and - for example - we add i18n and l10n, this assumption will no longer be reliable/safe and any ORM query that uses `is_default_site=` must be refactored out of the codebase.

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ botocore==1.13.26
 certifi==2019.9.11
 chardet==3.0.4
 cssselect==1.1.0
-django-bakery==0.12.7
+django-bakery==0.12.3
 django-countries==5.5
 django-modelcluster==4.4
 django-taggit==0.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ psycopg2==2.8.4
 Pygments==2.4.2
 readtime==1.1.1
 wagtail==2.6.3
-wagtail-bakery==0.4.0
+wagtail-bakery==0.3.0
 whitenoise==4.1.4
 urlwait==0.4
 newrelic==5.2.3.131

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -21,6 +21,7 @@ exports.parseQueryParams = () => {
 /**
  * Creates an object based on a form's current input values.
  *
+ * @param {object} form
  * @returns {object}
  */
 exports.parseForm = form => {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -21,7 +21,6 @@ exports.parseQueryParams = () => {
 /**
  * Creates an object based on a form's current input values.
  *
- * @param {object} form
  * @returns {object}
  */
 exports.parseForm = form => {


### PR DESCRIPTION
This changeset backs out the upgrade to `wagtail-bakery==0.4.0` because it breaks the static build. It also backs out the changes I introduced for #864 to try to work around them, because the while the workaround did "work", other unexpected behaviour appeared (#868) that needs investigating before I'm happy to go ahead with 0.4.0

It also contains a one-line fix for some eslint-jsdoc linting



