### PR TITLE
757: Support recording deployments in monitoring tools

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,6 +122,7 @@ node {
     case 'dev-push':
       stage('Deploy') {
         deploy('dev', 'dev', 'mdn-apps-a')
+        record_rollout()
       }
       break
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,19 @@ def notify_slack(Map args, credential_id='slack-hook-devportal-notifications') {
     }
 }
 
+def record_rollout() {
+    /*
+     * Record the rollout in external services like New Relic and SpeedCurve.
+     *
+     * Kept separate from deploy() so we don't double-log when deploying to
+     * an experimental EKS cluster as well as the regular k8s setup.
+     */
+
+      sh """
+        make k8s-record-deployment-job
+      """
+}
+
 def deploy(config, environment, cluster) {
   /*
    * Start a rolling update of the K8s deployments.
@@ -115,12 +128,14 @@ node {
     case 'stage-push':
       stage('Deploy') {
         deploy('stage', 'stage', 'mdn-apps-a')
+        record_rollout()
       }
       break
 
     case 'prod-push':
       stage('Deploy') {
         deploy('prod', 'prod', 'mdn-apps-a')
+        record_rollout()
       }
       break
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -155,6 +155,19 @@ k8s-jenkins-create-rbac:
 k8s-jenkins-delete-rbac:
 	kubectl delete -f jenkins-rbac.yaml
 
+k8s-record-deployment-job: k8s-delete-record-deployment-job
+	env APP_NAME=wagtail \
+		FROM_REVISION_HASH=${FROM_REVISION_HASH} \
+		TO_REVISION_HASH=$(shell make k8s-get-developerportal-revision-hash) \
+		j2 record-deployment-job.yaml.j2 | ${KC} apply -n ${K8S_NAMESPACE} -f -
+	env JOB_NAME=developerportal-record-deployment ./wait_for_job.sh
+
+k8s-delete-record-deployment-job:
+	${KC} delete -n ${K8S_NAMESPACE} --ignore-not-found job developerportal-record-deployment
+
+k8s-get-developerportal-revision-hash:
+	@ ${KC} -n ${K8S_NAMESPACE} exec $(shell ${KC} -n ${K8S_NAMESPACE} get pods --selector app=${WEB_SERVICE_NAME} -o jsonpath='{.items[0].metadata.name}') -- printenv REVISION_HASH
+
 ### end core tasks
 ###############################
 
@@ -164,4 +177,7 @@ k8s-jenkins-delete-rbac:
 		k8s-wagtail-deployments k8s-celery-deployments \
 		k8s-delete-wagtail-deployments k8s-delete-celery-deployments \
 		k8s-rollback k8s-history k8s-db-migration-job \
-		k8s-delete-db-migration-job
+		k8s-delete-db-migration-job \
+    k8s-record-deployment-job \
+    k8s-delete-record-deployment-job \
+    k8s-get-developerportal-revision-hash

--- a/k8s/record-deployment-job.yaml.j2
+++ b/k8s/record-deployment-job.yaml.j2
@@ -1,0 +1,49 @@
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: developerportal-{{ APP_NAME }}-record-deployment
+spec:
+  template:
+    metadata:
+      name: developerportal-{{ APP_NAME }}-record-deployment
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: developerportal-{{ APP_NAME }}-record-deployment
+          image: {{ APP_IMAGE }}:{{ APP_IMAGE_TAG }}
+          imagePullPolicy: {{ APP_IMAGE_PULL_POLICY }}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          env:
+            - name: NEW_RELIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: newrelic-secrets
+                  key: NEW_RELIC_API_KEY
+            - name: NEW_RELIC_APP_IDS
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: {{ APP_NAME }}-new-relic-app-ids
+            - name: SPEEDCURVE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: speedcurve-secrets
+                  key: SPEEDCURVE_API_KEY
+            - name: SPEEDCURVE_SITE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: speedcurve-site-id
+          command:
+            - "./scripts/record_deployments.py"
+          args:
+            - "--app={{ APP_NAME }}"
+            - "--from={{ FROM_REVISION_HASH }}"
+            - "--to={{ TO_REVISION_HASH }}"
+            - "--verbose"

--- a/k8s/record-deployment-job.yaml.j2
+++ b/k8s/record-deployment-job.yaml.j2
@@ -17,23 +17,18 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 256m
+              memory: 512Mi
           env:
             - name: NEW_RELIC_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: newrelic-secrets
                   key: NEW_RELIC_API_KEY
-            - name: NEW_RELIC_APP_IDS
-              valueFrom:
-                secretKeyRef:
-                  name: dev-portal-secrets
-                  key: {{ APP_NAME }}-new-relic-app-ids
             - name: SPEEDCURVE_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: speedcurve-secrets
+                  name: dev-portal-secrets
                   key: SPEEDCURVE_API_KEY
             - name: SPEEDCURVE_SITE_ID
               valueFrom:

--- a/k8s/record-deployment-job.yaml.j2
+++ b/k8s/record-deployment-job.yaml.j2
@@ -28,13 +28,13 @@ spec:
             - name: SPEEDCURVE_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: dev-portal-secrets
+                  name: speedcurve-secrets
                   key: SPEEDCURVE_API_KEY
             - name: SPEEDCURVE_SITE_ID
               valueFrom:
                 secretKeyRef:
                   name: dev-portal-secrets
-                  key: speedcurve-site-id
+                  key: SPEEDCURVE_SITE_ID
           command:
             - "./scripts/record_deployments.py"
           args:

--- a/scripts/record_deployments.py
+++ b/scripts/record_deployments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/scripts/record_deployments.py
+++ b/scripts/record_deployments.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python
+
+import os
+import sys
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from datetime import datetime
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+# API keys and IDs are set with environment variables rather than on the
+# command line, to avoid displaying the key in logs
+NR_API_KEY_NAME = "NEW_RELIC_API_KEY"
+NR_APP_IDS_NAME = "NEW_RELIC_APP_IDS"
+SC_API_KEY_NAME = "SPEEDCURVE_API_KEY"
+SC_SIDE_ID_NAME = "SPEEDCURVE_SITE_ID"
+
+APP_NAME = os.getenv("APP_NAME")  # "wagtail" is APP_NAME -- see Makefile's constants
+
+
+# URL pattern to compare two commits
+app_compare = {APP_NAME: "https://github.com/mdn/developer-portal/compare/%s...%s"}
+
+
+def deploy_all(
+    app,
+    nr_api_key=None,
+    nr_app_ids=None,
+    sc_api_key=None,
+    sc_site_id=None,
+    from_tag=None,
+    to_tag=None,
+    verbose=False,
+):
+    """
+    Send deployments to New Relic and SpeedCurve as specified.
+
+    Return is True for success, False for errors.
+
+    Keyword Arguments:
+    app: The name of the app
+    nr_api_key: A New Relic Admin API key, or None
+    nr_app_ids: A list of New Relic application IDs (can be empty)
+    sc_api_key: A SpeedCurve API key, or None
+    sc_site_id: A SpeedCurve site ID, or None
+    from_tag: Commit hash for what was deployed, or None
+    to_tag: Commit hash for what is now deployed, or None
+    verbose: Print status and responses
+    """
+    # Create deployment parameters
+    if to_tag:
+        revision = to_tag
+    else:
+        ts = datetime.now().replace(microsecond=0)
+        revision = ts.isoformat()
+
+    if to_tag and from_tag:
+        from_sub_tag = from_tag[:7]
+        to_sub_tag = to_tag[:7]
+        compare_url = app_compare[app] % (from_sub_tag, to_sub_tag)
+        description = compare_url
+    else:
+        description = None
+
+    # Send New Relic deployments
+    passed = True
+    count = 0
+    nr_app_ids = nr_app_ids or []
+    for app_num, app_id in enumerate(nr_app_ids):
+        response = deploy_newrelic(app_id, nr_api_key, revision, description)
+        if response.status_code == 201:
+            success = "SUCCESS"
+            count += 1
+        else:
+            success = "FAILURE"
+            passed = False
+        if verbose:
+            safer_id = "%s_APP_ID_%d" % (app.upper(), app_num)
+            content = response.text.replace(app_id, safer_id)
+            print(
+                "%s (%s): Deployment to New Relic application %s %d: %s"
+                % (success, response.status_code, app, app_num, content)
+            )
+
+    # Send SpeedCurve deployments
+    if sc_api_key and sc_site_id and app == APP_NAME:
+        response = deploy_speedcurve(sc_site_id, sc_api_key, revision, description)
+        in_progress = "Deploy already in progress"
+        if response.status_code == 200:
+            success = "SUCCESS"
+            count += 1
+        elif response.status_code == 403 and in_progress in response.text:
+            # Ignore this error
+            success = "IN PROGRESS"
+            count += 1
+        else:
+            success = "FAILURE"
+            passed = False
+        if verbose:
+            safer_id = "SITE_ID_0"
+            content = response.text.replace(sc_site_id, safer_id)
+            print(
+                "%s (%s): Deployment to SpeedCurve site ID %s: %s"
+                % (success, response.status_code, sc_site_id, content)
+            )
+
+    return bool(count and passed)
+
+
+def deploy_newrelic(app_id, api_key, revision, description=None):
+    """
+    Create a deployment in New Relic, categorizing performance.
+
+    https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/record-deployments
+
+    Keyword Arguments:
+    app_id - The application ID, a 8-digit number
+    api_key - A New Relic admin API key
+    revision - The commit hash or deployment timestamp
+    description - A description such as a GitHub comparison URL, or None
+    """
+    assert app_id, "New Relic Application ID is empty."
+    assert api_key, "New Relic API Key is empty."
+    url = "https://api.newrelic.com/v2/applications/%s/deployments.json" % app_id
+    deployment = {"revision": revision}
+    if description:
+        deployment["description"] = description
+
+    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
+    payload = {"deployment": deployment}
+    response = requests.post(url, json=payload, headers=headers)
+    return response
+
+
+def deploy_speedcurve(site_id, api_key, note, detail=None):
+    """
+    Create a deployment in SpeedCurve, kicking off testing.
+
+    https://api.speedcurve.com/#add-a-deploy
+
+    Keyword Arguments:
+    site_id - The site ID, a 3- to 6-digit number
+    api_key - A SpeedCurve admin API key
+    note - The commit hash or deployment timestamp
+    detail - A description such as a GitHub comparison URL, or None
+    """
+    assert site_id, "SpeedCurve Site ID is empty."
+    assert api_key, "SpeedCurve API Key is empty."
+    url = "https://api.speedcurve.com/v1/deploys"
+    payload = {"site_id": site_id, "note": note}
+    if detail:
+        payload["detail"] = detail
+
+    auth = HTTPBasicAuth(api_key, "x")
+    response = requests.post(url, data=payload, auth=auth)
+    return response
+
+
+def get_parser():
+    """Create an argument parser."""
+    epilog = (
+        "Sensitve parameters are read from environment variables, to avoid\n"
+        "appearing in logs:\n\n"
+        "%s: New Relic API Key\n"
+        "%s: New Relic Application ID(s) (8-digit number(s), space separated)\n"
+        "%s: SpeedCurve API Key\n"
+        "%s: SpeedCurve Site ID (5-digit number)\n"
+    ) % (NR_API_KEY_NAME, NR_APP_IDS_NAME, SC_API_KEY_NAME, SC_SIDE_ID_NAME)
+    parser = ArgumentParser(
+        description="Record a deployment in New Relic",
+        formatter_class=RawDescriptionHelpFormatter,
+        epilog=epilog,
+    )
+    parser.add_argument(
+        "-f", "--from", dest="from_tag", help="Existing commit at start of deployment"
+    )
+    parser.add_argument("-t", "--to", help="Commit at the end of deployment")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="store_false",
+        help="Print responses (obfuscating IDs)",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+    from_tag = args.from_tag
+    to_tag = args.to
+    verbose = args.verbose
+    app = APP_NAME  # There is only one thing to deploy, so no need to get from args
+    nr_api_key = os.environ.get(NR_API_KEY_NAME)
+    raw_nr_app_ids = os.environ.get(NR_APP_IDS_NAME, "")
+    sc_api_key = os.environ.get(SC_API_KEY_NAME)
+    sc_site_id = os.environ.get(SC_SIDE_ID_NAME)
+
+    # Split by commas or whitespace
+    nr_app_ids = raw_nr_app_ids.replace(",", " ").split()
+
+    show_help = False
+    if nr_app_ids and not nr_api_key:
+        show_help = True
+        print("*** The environment variable %s is not set. ***" % NR_API_KEY_NAME)
+    if sc_site_id and not sc_api_key:
+        show_help = True
+        print("*** The environment variable %s is not set. ***" % SC_API_KEY_NAME)
+
+    if not (nr_app_ids or sc_site_id):
+        show_help = True
+        print(
+            "*** Neither New Relic application IDs %s or a SpeedCuve"
+            "site ID %s is set. ***" % (NR_APP_IDS_NAME, SC_SIDE_ID_NAME)
+        )
+    if show_help:
+        print("")
+        parser.print_help()
+        sys.exit(1)
+
+    success = deploy_all(
+        app,
+        nr_api_key,
+        nr_app_ids,
+        sc_api_key,
+        sc_site_id,
+        from_tag,
+        to_tag,
+        verbose=verbose,
+    )
+    if not success:
+        sys.exit(1)


### PR DESCRIPTION
This changeset repurposes code from mdn/kuma to add rollout tracking to developerportal.

It will ping New Relic and Speedcurve when a deployment has taken place.

Note that because a deployment doesn't automatically trigger a rebuild of the static site (but this does happen automatically every 30 mins) it's possible/likely that speedcurve will profile the previous static build. This isn't a massive problem, but is something to think about. We could instead trigger Speedcurve from the static build pipeline

(Related issue #757)

## How to test

- the only real way to test this is to deploy it, so we should give it a REALLY close look-over before we do, and be prepared to tweak/fix when getting `master` onto staging once this is merged