### PR TITLE
Expose SENTRY_DSN

### DIFF
--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -93,7 +93,6 @@
               value: "{{ NEW_RELIC_LABELS }}"
             - name: NEW_RELIC_MONITOR_MODE
               value: "{{ NEW_RELIC_MONITOR_MODE }}"
-
             - name: OIDC_RP_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -104,3 +103,8 @@
                 secretKeyRef:
                   name: dev-portal-secrets
                   key: OIDC_RP_CLIENT_SECRET
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: dev-portal-secrets
+                  key: SENTRY_DSN


### PR DESCRIPTION
Exposes the `SENTRY_DSN` to kubernetes, the sentry dsn is the public dsn
only so if the secret key is needed we can change that in the secrets.

(Related issue #803)

## Key changes:

- Set `SENTRY_DSN` in pod envvars