### PR TITLE
825: Address SVG-related validation errors due to invalid hashes as ids

### DIFF
--- a/developerportal/templatetags/app_tags.py
+++ b/developerportal/templatetags/app_tags.py
@@ -21,8 +21,12 @@ def mime_type(file_name):
 
 
 @register.simple_tag
-def random_hash():
-    return binascii.hexlify(os.urandom(16)).decode("utf-8")
+def random_hash(start_with_letter=True):
+    val = binascii.hexlify(os.urandom(15)).decode("utf-8")
+    if start_with_letter:
+        # If used as an XML or SVG `id` attribute, it has to start with a letter
+        val = f"a{val}"
+    return val
 
 
 @register.simple_tag


### PR DESCRIPTION
This changeset ensures all randomly generated hashes start with an `a` and are still 16 chars long.

There's no risk of collision because we're extending the original hash, rather than swapping out the
first (random) char for a fixed on.

This avoids validator.w3.org/nu reporting an error such as:
`Bad value 72644ef3cd99e4c20245b864b1ff1cb2-a for attribute id on element path: Not a valid XML 1.0 name.`

In addition to this change, we'll need to manually edit the WebAssembly SVG icon to fix duplicate IDs in the SVG markup (which isn't in this codebase)

No unit tests, but manually tested

(Related issue #825)

