### PR TITLE
885: Ensure that if an Event has no Venue address specified, don't show an empty location row

### DIFF
--- a/developerportal/templates/molecules/event-details.html
+++ b/developerportal/templates/molecules/event-details.html
@@ -8,15 +8,17 @@
       </span>
       <span>{{ resource.event_dates_full|safe }}</span>
     </div>
+    {% make_list_from_args resource.venue_name resource.address_line_1 resource.address_line_2 resource.address_line_3 resource.city resource.zip_code resource.country as address %}
+    {% if address %}
     <div class="event-details-venue">
       <span class="icon">
         {% include "atoms/icons/location.svg" %}
       </span>
       <address>
-        {% make_list_from_args resource.address_line_1 resource.address_line_2 resource.address_line_3 resource.city resource.zip_code resource.country as address %}
         {{ address | join:', ' }}
       </address>
     </div>
+    {% endif %}
   </div>
   {% if resource.register_url %}
   <div class="event-details-register">


### PR DESCRIPTION
The use-case here is an Event in multiple places, where a single country cannot be configured. If there is no Venue address specified (eg for a multi-country roadshow) then prior to this changeset an empty UI element with a Location icon but no data would be rendered.

This changeset now makes that conditional: we only show the Location icon and row if there is data to populate it.

This changeset also includes showing the name of the venue in the location bar - it was previously only shown around the map box 

(Resolves #885 )

## Before
![Screenshot 2019-11-28 at 13 50 38](https://user-images.githubusercontent.com/101457/69813292-cea20c00-11e9-11ea-9db2-ea63b7aa4ff5.png)

## After - no location info
![Screenshot 2019-11-28 at 14 07 30](https://user-images.githubusercontent.com/101457/69813293-cf3aa280-11e9-11ea-8faa-7dc77cc7a8ac.png)

## After - only country specified
![Screenshot 2019-11-28 at 14 07 51](https://user-images.githubusercontent.com/101457/69813296-cf3aa280-11e9-11ea-93bb-bb82513a2f47.png)

## After - full address for a Venue specified
![Screenshot 2019-11-28 at 14 20 52](https://user-images.githubusercontent.com/101457/69813528-512acb80-11ea-11ea-973b-851a8d4b293c.png)
