### PR TITLE
803: Add Sentry support

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -71,6 +71,8 @@ INSTALLED_APPS = [
     "django_celery_results",
     "mozilla_django_oidc",  # needs to be loaded after auth
 ]
+# Note that "raven.contrib.django.raven_compat" is added to INSTALLED_APPS
+# if Sentry is enabled -- see later in this file
 
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -370,6 +372,16 @@ WAGTAIL_PASSWORD_RESET_ENABLED = False
 # Don't require a password when creating a user,
 # and blank password means cannot log in unless SSO
 WAGTAILUSERS_PASSWORD_ENABLED = False
+
+# Sentry logging
+REVISION_HASH = os.environ.get("REVISION_HASH", "undefined")
+SENTRY_DSN = os.environ.get("SENTRY_DSN")
+
+if SENTRY_DSN:
+    RAVEN_CONFIG = {"dsn": SENTRY_DSN}
+    if REVISION_HASH and REVISION_HASH != "undefined":
+        RAVEN_CONFIG["release"] = REVISION_HASH
+    INSTALLED_APPS += ["raven.contrib.django.raven_compat"]
 
 # Based on DEFAULT_LOGGING with some tweaks
 LOGGING = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ django-storages==1.8
 boto3==1.10.28
 psycopg2==2.8.4
 Pygments==2.4.2
+raven==6.10.0
 readtime==1.1.1
 wagtail==2.6.3
 wagtail-bakery==0.3.0


### PR DESCRIPTION
Automatically enabled when SENTRY_DSN is available as an env var

Supoprts the idea of a REVISION_HASH as per Kuma, but I don't know if it's available (but it would be nice to add)

(Resolves #803)

Tested locally using staging credentials, sending from both the test management command and by raising an exception in a Celery task (to prove we'll get alerts from the worker, too):

![Screenshot 2019-11-28 at 16 54 26](https://user-images.githubusercontent.com/101457/69823626-547d8180-1201-11ea-9c71-a7bfdb44a7aa.png)


