### PR TITLE
906: Switch from Google Tag Manager to regular GA; add in Mozilla DNT support

### DIFF
--- a/developerportal/templates/base.html
+++ b/developerportal/templates/base.html
@@ -51,6 +51,9 @@
         {% include "atoms/social-meta.html" with fallback_description=home.search_description %}
       {% endif %}
     {% endwith %}
+
+    {% include "base_includes/google_analytics.html"%}
+
     {% block head %}
     {% endblock %}
   </head>
@@ -65,14 +68,5 @@
     {% endblock %}
     <script>window.Mzp = {}</script>
     <script src="{% static 'js/bundle.js' %}"></script>
-    {% if GOOGLE_ANALYTICS %}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS }}"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', '{{ GOOGLE_ANALYTICS }}');
-    </script>
-    {% endif %}
   </body>
 </html>

--- a/developerportal/templates/base_includes/google_analytics.html
+++ b/developerportal/templates/base_includes/google_analytics.html
@@ -1,0 +1,30 @@
+{% load static %}
+{% if GOOGLE_ANALYTICS %}
+
+  <!-- Mozilla DNT Helper -->
+  <script src="{% static 'js/head.js' %}"></script>
+
+  <!-- Only load GA if DNT is not enabled -->
+  <script>
+  if (window.Mozilla && !window.Mozilla.dntEnabled()) {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/{{ GA_FILE|default:"analytics" }}.js','ga');
+
+      ga('create', '{{ GOOGLE_ANALYTICS }}', 'mozilla.com');
+      ga('set', 'anonymizeIp', true);
+      (function() {
+          // Remove analytics clutter from campaign URLs
+          var win = window;
+          var removeUtms = function(){
+              var location = win.location;
+              if (location.href.indexOf('utm') != -1 && win.history.replaceState) {
+                  win.history.replaceState({}, '', location.pathname);
+              }
+          };
+          ga('send', 'pageview', {'hitCallback': removeUtms});
+      })();
+  }
+  </script>
+{% endif %}

--- a/src/js/head-includes.js
+++ b/src/js/head-includes.js
@@ -1,0 +1,3 @@
+/* eslint-disable import/no-unresolved */
+
+require('./mozilla-dnthelper');

--- a/src/js/mozilla-dnthelper.js
+++ b/src/js/mozilla-dnthelper.js
@@ -1,0 +1,65 @@
+/* eslint-disable no-octal-escape */
+/* eslint-disable func-names */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof window.Mozilla === 'undefined') {
+  window.Mozilla = {};
+}
+
+/*
+ * Returns true or false based on whether doNotTack is enabled. It also takes into account the
+ * anomalies, such as !bugzilla 887703, which effect versions of Fx 31 and lower. It also handles
+ * IE versions on Windows 7, 8 and 8.1, where the DNT implementation does not honor the spec.
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1217896 for more details
+ * @params {string} [dnt] - An optional mock doNotTrack string to ease unit testing.
+ * @params {string} [ua] - An optional mock userAgent string to ease unit testing.
+ * @returns {boolean} true if enabled else false
+ */
+window.Mozilla.dntEnabled = function(dnt, ua) {
+  // for old version of IE we need to use the msDoNotTrack property of navigator
+  // on newer versions, and newer platforms, this is doNotTrack but, on the window object
+  // Safari also exposes the property on the window object.
+  let dntStatus =
+    dnt || navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
+  const userAgent = ua || navigator.userAgent;
+
+  // List of Windows versions known to not implement DNT according to the standard.
+  const anomalousWinVersions = [
+    'Windows NT 6.1',
+    'Windows NT 6.2',
+    'Windows NT 6.3',
+  ];
+
+  const fxMatch = userAgent.match(/Firefox\/(\d+)/);
+  const ieRegEx = /MSIE|Trident/i;
+  const isIE = ieRegEx.test(userAgent);
+  // Matches from Windows up to the first occurance of ; un-greedily
+  // http://www.regexr.com/3c2el
+  const platform = userAgent.match(/Windows.+?(?=;)/g);
+
+  // With old versions of IE, DNT did not exist so we simply return false;
+  if (isIE && typeof Array.prototype.indexOf !== 'function') {
+    return false;
+  }
+  if (fxMatch && parseInt(fxMatch[1], 10) < 32) {
+    // Can't say for sure if it is 1 or 0, due to Fx bug 887703
+    dntStatus = 'Unspecified';
+  } else if (
+    isIE &&
+    platform &&
+    anomalousWinVersions.indexOf(platform.toString()) !== -1
+  ) {
+    // default is on, which does not honor the specification
+    dntStatus = 'Unspecified';
+  } else {
+    // sets dntStatus to Disabled or Enabled based on the value returned by the browser.
+    // If dntStatus is undefined, it will be set to Unspecified
+    dntStatus = { '0': 'Disabled', '1': 'Enabled' }[dntStatus] || 'Unspecified';
+  }
+
+  return dntStatus === 'Enabled';
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,12 +4,15 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
 const config = {
-  entry: './src/js/index.js',
-  target: 'web',
+  entry: {
+    bundle: './src/js/index.js',
+    head: './src/js/head-includes.js',
+  },
   output: {
-    filename: 'js/bundle.js',
+    filename: 'js/[name].js',
     path: resolve(__dirname, 'dist'),
   },
+  target: 'web',
   mode: process.env.NODE_ENV,
   module: {
     rules: [
@@ -47,10 +50,7 @@ const config = {
 };
 
 if (process.env.NODE_ENV === 'production') {
-  config.plugins = [
-    ...config.plugins,
-    new OptimizeCssAssetsPlugin(),
-  ];
+  config.plugins = [...config.plugins, new OptimizeCssAssetsPlugin()];
 }
 
 module.exports = config;


### PR DESCRIPTION
This changeset moves away from using GTM and instead drops in GA code in the head of the document, as per mdn/kuma

At the same time it also uses the same Do Not Track lib [that kuma uses](https://github.com/mdn/kuma/blob/master/kuma/static/js/libs/mozilla.dnthelper.js) - thanks @sneethling!

Note that the DNT lib lifted from kuma is slighty changed to pin a `Mozilla` object on the DOM's `window` so that it's within reachable scope within the page. The way Kuma integrates the same code is to inline it into the HTML (ie, render it as a template) but that behaviour isn't currently supported by the Developer Portal codebase, and switching to it seemed more disruptive than just updating webpack to output a new bundle.

As before, if there is no `GOOGLE_ANALYTICS` code present via settings, the relevant JS code block is not included. If it is present, the block is rendered. As such, only `settings.worker` will, by default, try to get `GOOGLE_ANALYTICS` from the env vars, so only the static site should render it out.

Example of included HTML/JS when GA is meant to be rendered (fake code here is `TestTestTest`

```
  <!-- Mozilla DNT Helper -->
  <script src="/static/js/head.4da485bfc790.js"></script>

  <!-- Only load GA if DNT is not enabled -->
  <script>
  if (window.Mozilla && !window.Mozilla.dntEnabled()) {
      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');

      ga('create', 'TestTestTest', 'mozilla.com');
      ga('set', 'anonymizeIp', true);
      (function() {
          // Remove analytics clutter from campaign URLs
          var win = window;
          var removeUtms = function(){
              var location = win.location;
              if (location.href.indexOf('utm') != -1 && win.history.replaceState) {
                  win.history.replaceState({}, '', location.pathname);
              }
          };
          ga('send', 'pageview', {'hitCallback': removeUtms});
      })();
  }
  </script>
```

(Resolves #906)

# Testing
Requires a local version of the stack and an S3 bucket configured appropriately. If you lack these things, a code-only review is fine. 

If you do have devportal running locally:
* ensure `GOOGLE_ANALYTICS` is defined in your `.env` but not your `local.py` 
* View source on `localhost:8000` and confirm there is no GA code/JS rendered 
* Run `docker-compose exec app python manage.py request_static_build` and view source on the index.html that ends up in your S3 bucket - that _will_ show the GA code/JS