### PR TITLE
882: Increase HSTS lease time to 1 year, via env vars

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -33,6 +33,7 @@ export APP_MOUNT_PATH ?= /app/media
 export APP_EMAIL_HOST ?= email-smtp.us-west-2.amazonaws.com
 export APP_EMAIL_PORT ?= 587
 export APP_EMAIL_USE_TLS ?= True
+export APP_SECURE_HSTS_SECONDS = 31536000
 
 export CELERY_WORKER_NAME ?= celery-worker
 export CELERY_WORKER_REPLICAS ?= 1

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -55,6 +55,8 @@
               value: "{{ APP_EMAIL_PORT }}"
             - name: EMAIL_USE_TLS
               value: "{{ APP_EMAIL_USE_TLS }}"
+            - name: SECURE_HSTS_SECONDS
+              value: "{{ APP_SECURE_HSTS_SECONDS }}"
             - name: DEFAULT_FROM_EMAIL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This changeset addresses our need to increase the HSTS lease time now we're in production. It does this by defining config for a one-year-long lease in seconds, and exposing that as an env var

(Resolves #882 )
