### PR TITLE
886: Add template filter to move the cachebreaker string from inside the filename to a querystring

### DIFF
--- a/developerportal/templates/atoms/social-meta.html
+++ b/developerportal/templates/atoms/social-meta.html
@@ -34,7 +34,7 @@
   {% endif %}
   {% if not image %}
     {# Fallback images are hosted by Django, so need absolute URLs creating #}
-    <meta property="og:image" content="{{base_url}}{{fallback_image_url}}">
+    <meta property="og:image" content="{{base_url}}{{fallback_image_url|filename_cachebreaker_to_querystring}}">
   {% else %}
     {% comment %}
       There's no need to add the base URL if the image file exists as it's externally
@@ -42,7 +42,7 @@
       Note: in local dev, if you use local file storage (not S3) the OG tags will
       have relative URLs - but that hopefully shouldn't be a real problem.
     {% endcomment %}
-    <meta property="og:image" content="{{ image.url }}">
+    <meta property="og:image" content="{{ image.url|filename_cachebreaker_to_querystring }}">
   {% endif %}
   <meta property="og:image:width" content="{% firstof image.width fallback_image_width %}">
   <meta property="og:image:height" content="{% firstof image.height fallback_image_height %}">

--- a/developerportal/templatetags/app_tags.py
+++ b/developerportal/templatetags/app_tags.py
@@ -86,7 +86,7 @@ def filename_cachebreaker_to_querystring(url):
     static/img/foo.jpg will, too
     """
 
-    pattern = re.compile(r"(\.[a-f0-9]+)(\.\w+)$")
+    pattern = re.compile(r"(\.[a-f0-9]+)\.\w+$")
     hits = pattern.search(url)
     if not hits:
         logger.info(f"Couldn't extract has from URL {url}. Leaving unchanged.")


### PR DESCRIPTION
This changeset adds and uses a new template filter that, for a given URL, checks if it has a cachebreaking hash and if it does, converts it to be a URL that uses the hash as a querystring cachebreaker instead.

eg:
    INPUT: 'https://example.com/static/foo.12313abc.jpg'
    OUTPUT: 'https://example.com/static/foo.jpg?h=12313abc'

Why? So that images automatically embedded in social media posts (via OpenGraph tags) don't end up as broken links with a new release that changes the hash in the filename -- by moving the hash to a querystring, we get the benefit of cachebreaking but with a much softer edge that won't result in links 404ing even if the cachebreaking hash has changed. (ie, querystring cachebreakers are more forgiving.)

Note that `ManifestFileStorage` (used by `django-whitenoise` in this project) makes hash-named versions of the files, but also _does_ keep the original around,so we are safe to assume that if `static/img/foo.213123.jpg` exists, then `static/img/foo.jpg` will, too

This template filter is _only_ used for in `social-meta.html`, for the OpenGraph image tag 

(Resolves #868)

## Before

<img width="862" alt="Screenshot 2019-12-03 at 21 28 26" src="https://user-images.githubusercontent.com/101457/70092311-ed533900-1615-11ea-8ed4-852052b743ac.png">


## After

<img width="914" alt="Screenshot 2019-12-03 at 21 04 34" src="https://user-images.githubusercontent.com/101457/70092308-ecbaa280-1615-11ea-845b-7aea48ee3548.png">

## Proof that images not served from staticfiles are not affected

<img width="895" alt="Screenshot 2019-12-03 at 21 05 26" src="https://user-images.githubusercontent.com/101457/70092309-ecbaa280-1615-11ea-92d4-8f3635a9df43.png">

And here's proof that the default placeholder image (which is the common case here) will be loaded regardless of the querystring:
* https://developer.mozilla.com/static/img/placeholders/article.jpg?h=0asdasda
* https://developer.mozilla.com/static/img/placeholders/article.jpg
* https://developer.mozilla.com/static/img/placeholders/article.jpg?h=differentquerystring
