### PR TITLE
577: Update footer to link to Mozilla info and Community Guidelines

### DIFF
--- a/developerportal/templates/footer.html
+++ b/developerportal/templates/footer.html
@@ -4,13 +4,15 @@
       <div class="mzp-c-footer-legal">
         <p class="mzp-c-footer-license">
           Portions of this content are &copy;1998–{% now "Y" %} by individual mozilla.org
-          contributors. Content available under a
+          contributors.<br>Content available under a
           <a href="https://www.mozilla.org/foundation/licensing/website-content/" rel="license nofollow noopener">Creative Commons license</a>.
         </p>
         <ul class="mzp-c-footer-terms">
+          <li><a href="https://www.mozilla.org/about/" rel="nofollow noopener">About Mozilla</a></li>
           <li><a href="https://www.mozilla.org/privacy/websites/" rel="nofollow noopener">Website Privacy Notice</a></li>
           <li><a href="https://www.mozilla.org/privacy/websites/#cookies" rel="nofollow noopener">Cookies</a></li>
           <li><a href="https://www.mozilla.org/about/legal/" rel="nofollow noopener">Legal</a></li>
+          <li><a href="https://www.mozilla.org/about/governance/policies/participation/" rel="nofollow noopener">Community Participation Guidelines</a></li>
         </ul>
       </div>
     </nav>

--- a/developerportal/templates/footer.html
+++ b/developerportal/templates/footer.html
@@ -5,14 +5,14 @@
         <p class="mzp-c-footer-license">
           Portions of this content are &copy;1998–{% now "Y" %} by individual mozilla.org
           contributors.<br>Content available under a
-          <a href="https://www.mozilla.org/foundation/licensing/website-content/" rel="license nofollow noopener">Creative Commons license</a>.
+          <a href="https://www.mozilla.org/foundation/licensing/website-content/" rel="license noopener">Creative Commons license</a>.
         </p>
         <ul class="mzp-c-footer-terms">
-          <li><a href="https://www.mozilla.org/about/" rel="nofollow noopener">About Mozilla</a></li>
-          <li><a href="https://www.mozilla.org/privacy/websites/" rel="nofollow noopener">Website Privacy Notice</a></li>
-          <li><a href="https://www.mozilla.org/privacy/websites/#cookies" rel="nofollow noopener">Cookies</a></li>
-          <li><a href="https://www.mozilla.org/about/legal/" rel="nofollow noopener">Legal</a></li>
-          <li><a href="https://www.mozilla.org/about/governance/policies/participation/" rel="nofollow noopener">Community Participation Guidelines</a></li>
+          <li><a href="https://www.mozilla.org/about/" rel="noopener">About Mozilla</a></li>
+          <li><a href="https://www.mozilla.org/privacy/websites/" rel="noopener">Website Privacy Notice</a></li>
+          <li><a href="https://www.mozilla.org/privacy/websites/#cookies" rel="noopener">Cookies</a></li>
+          <li><a href="https://www.mozilla.org/about/legal/" rel="noopener">Legal</a></li>
+          <li><a href="https://www.mozilla.org/about/governance/policies/participation/" rel="noopener">Community Participation Guidelines</a></li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
The original request (see #577) was to link to Mozilla's mission. Sense-checked where to place this link with Havi, who suggested we actually link to the About page, because that puts the Mission front and centre, in context.

She also suggested we add the Community Participation Guidelines, so I have.

<img width="729" alt="Screenshot 2019-12-03 at 22 20 45" src="https://user-images.githubusercontent.com/101457/70095114-df081b80-161b-11ea-952f-78af15923917.png">


~Note: the existing footer links all have `nofollow` in them -- is this someting we definitely want?~

(Resolves #577)