### PR TITLE
469: Upgrade to Wagtail 2.7 and prevent users amending their email addresses

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -373,6 +373,11 @@ WAGTAIL_PASSWORD_RESET_ENABLED = False
 # and blank password means cannot log in unless SSO
 WAGTAILUSERS_PASSWORD_ENABLED = False
 
+# Don't allow a CMS user to change their email via Account Settings,
+# because this will break SSO. (Note that Admins can still change email
+# addresses for users via Settings > Users)
+WAGTAIL_EMAIL_MANAGEMENT_ENABLED = False
+
 # Sentry logging
 REVISION_HASH = os.environ.get("REVISION_HASH", "undefined")
 SENTRY_DSN = os.environ.get("SENTRY_DSN")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ psycopg2==2.8.4
 Pygments==2.5.2
 raven==6.10.0
 readtime==1.1.1
-wagtail==2.6.3
+wagtail==2.7
 wagtail-bakery==0.3.0
 whitenoise==4.1.4
 urlwait==0.4


### PR DESCRIPTION
This changeset addresses the risk of a user breaking SSO for the CMS should they change their email address in the system. It achieves this by upgrading to Wagtail 2.7 ([release notes](https://wagtail.readthedocs.io/en/v2.7/releases/2.7.html)) and making uses of its new `WAGTAIL_EMAIL_MANAGEMENT_ENABLED` setting.

BEFORE

<img width="1076" alt="Screenshot 2019-12-04 at 17 00 06" src="https://user-images.githubusercontent.com/101457/70164370-f21cf900-16b8-11ea-9a5d-5835f2a71647.png">


AFTER

<img width="439" alt="Screenshot 2019-12-04 at 17 12 01" src="https://user-images.githubusercontent.com/101457/70164517-34463a80-16b9-11ea-8537-931d264ea31a.png">


(Note that Admins can still change email addresses for users via `Settings` > `Users` in the CMS admin)
<img width="944" alt="Screenshot 2019-12-04 at 16 38 40" src="https://user-images.githubusercontent.com/101457/70164368-f21cf900-16b8-11ea-866c-2c1e003ddaa5.png">


# A NOTE ABOUT UPGRADING WAGTAIL

I've been through the [Upgrade Considerations](https://wagtail.readthedocs.io/en/v2.7/releases/2.7.html#upgrade-considerations) and I think we don't need to change anything. However, it is worth noting that the [UI for StreamFields](https://wagtail.readthedocs.io/en/v2.7/releases/2.7.html#what-s-new) is revised in this release. There's not much we can doto avoid it, we just have to accept it and roll with it (thankfully, it's a nice UI change!) 

(Resolves  #469)

