### PR TITLE
962: Small but important wording improvement in newsletter signup CTA

### DIFF
--- a/developerportal/templates/organisms/newsletter-signup.html
+++ b/developerportal/templates/organisms/newsletter-signup.html
@@ -1,6 +1,6 @@
 <section id="newsletter" class="section section-background newsletter-signup">
   <div class="container">
-    <h2 class="no-underline">Learn the best of web development</h2>
+    <h2 class="no-underline">Discover the best of web development</h2>
     <p>Sign up for the Mozilla Developer Newsletter:</p>
     <form action="https://www.mozilla.org/en-US/newsletter/" method="post" target="_blank">
       <input type="hidden" name="newsletters" value="app-dev">


### PR DESCRIPTION
This changeset addresses a request to improve the wording of the newsletter call to action, as requested by @havi 

(Resolves #962)

## Before

![Screenshot 2019-12-12 at 17 10 13](https://user-images.githubusercontent.com/101457/70733690-b6121580-1d02-11ea-83a8-29ef4c18903c.png)

## After
![Screenshot 2019-12-12 at 17 11 36](https://user-images.githubusercontent.com/101457/70733691-b6121580-1d02-11ea-81f0-1ef702f6e050.png)
