### PR TITLE
994: Update what counts as a future/past Event 

### DIFF
--- a/developerportal/apps/common/tests/test_utils.py
+++ b/developerportal/apps/common/tests/test_utils.py
@@ -1,0 +1,19 @@
+import datetime
+from unittest import mock
+
+from django.test import TestCase
+
+import pytz
+
+from ..utils import get_past_event_cutoff
+
+
+class EventCutoffTestCase(TestCase):
+    @mock.patch("developerportal.apps.common.utils.tz_now")
+    def test_get_past_event_cutoff(self, mock_tz_now):
+
+        mock_tz_now.return_value = datetime.datetime(
+            2002, 3, 5, 12, 34, 56, tzinfo=pytz.UTC
+        )
+
+        self.assertEqual(get_past_event_cutoff(), datetime.date(2002, 3, 4))

--- a/developerportal/apps/common/utils.py
+++ b/developerportal/apps/common/utils.py
@@ -1,7 +1,9 @@
+import datetime
 from itertools import chain
 from operator import attrgetter
 
 from django.apps import apps
+from django.utils.timezone import now as tz_now
 
 
 def _combined_query(models, fn):
@@ -79,3 +81,7 @@ def get_combined_videos(page, **filters):
         order_by="date",
         reverse=True,
     )
+
+
+def get_past_event_cutoff():
+    return (tz_now() - datetime.timedelta(days=1)).date()

--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -35,7 +35,7 @@ from ..common.blocks import AgendaItemBlock, ExternalSpeakerBlock, FeaturedExter
 from ..common.constants import RICH_TEXT_FEATURES_SIMPLE
 from ..common.fields import CustomStreamField
 from ..common.models import BasePage
-from ..common.utils import get_combined_events
+from ..common.utils import get_combined_events, get_past_event_cutoff
 
 
 class EventsTag(TaggedItemBase):
@@ -137,7 +137,7 @@ class Events(BasePage):
     @property
     def events(self):
         """Return future events in chronological order"""
-        return get_combined_events(self, start_date__gte=datetime.date.today())
+        return get_combined_events(self, start_date__gte=get_past_event_cutoff())
 
     @property
     def past_events(self):

--- a/developerportal/apps/events/tests/test_events.py
+++ b/developerportal/apps/events/tests/test_events.py
@@ -45,12 +45,21 @@ class EventsTests(PatchedWagtailPageTests):
         event_yesterday = Event(
             depth=2,
             path="00019997",
-            start_date=now + datetime.timedelta(days=-1),
+            start_date=now - datetime.timedelta(days=1),
             title="Yesterday",
         )
         event_yesterday.save()
 
+        event_day_before_yesterday = Event(
+            depth=2,
+            path="00019992",
+            start_date=now - datetime.timedelta(days=2),
+            title="Day Before Yesterday",
+        )
+        event_day_before_yesterday.save()
+
         events = events_page.events
         self.assertIn(event_today, events)
         self.assertIn(event_tomorrow, events)
-        self.assertNotIn(event_yesterday, events)
+        self.assertIn(event_yesterday, events)  # CORRECT
+        self.assertNotIn(event_day_before_yesterday, events)

--- a/developerportal/apps/people/models.py
+++ b/developerportal/apps/people/models.py
@@ -1,4 +1,3 @@
-import datetime
 from itertools import chain
 from operator import attrgetter
 
@@ -24,6 +23,7 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 from ..common.blocks import PersonalWebsiteBlock
 from ..common.constants import RICH_TEXT_FEATURES_SIMPLE, ROLE_CHOICES
 from ..common.models import BasePage
+from ..common.utils import get_past_event_cutoff
 from .edit_handlers import CustomLabelFieldPanel
 
 
@@ -273,7 +273,7 @@ class Person(BasePage):
         from ..events.models import Event
 
         upcoming_events = Event.published_objects.filter(
-            start_date__gte=datetime.datetime.now()
+            start_date__gte=get_past_event_cutoff()
         )
 
         speaker_events = Event.published_objects.none()

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -1,5 +1,4 @@
 # pylint: disable=no-member
-import datetime
 
 from django.core.exceptions import ValidationError
 from django.db.models import (
@@ -41,6 +40,7 @@ from ..common.utils import (
     get_combined_articles,
     get_combined_events,
     get_combined_videos,
+    get_past_event_cutoff,
 )
 
 
@@ -235,7 +235,7 @@ class Topic(BasePage):
         """Return upcoming events for this topic,
         ignoring events in the past, ordered by start date"""
         return get_combined_events(
-            self, topics__topic__pk=self.pk, start_date__gte=datetime.datetime.now()
+            self, topics__topic__pk=self.pk, start_date__gte=get_past_event_cutoff()
         )
 
     @property


### PR DESCRIPTION
This changeset adds a single source for the cutoff between past and future events, setting it to 'yesterday'

Prior to this changeset, the difference between future and past events is decided based
on datetime.datetime.now() which is likely to be UTC (given k8s), but regardless of what
specific timezone it is or is not, it still draws a single line "down the globe" that
means that, the further west of UTC you live, some events will 'disappear' from future
events before that day has completed.

The fix is simply to keep showing events as 'upcoming' until one calendar day *after*
their start date.

(Resolves #944)

## How to test

- Add an Event with a start date that is yesterday's date
- On `master`, load the /events/ page and confirm you do not see the relevant Event, even though yesterday's date could still be the current date further westward around the globe
- On this feature branch, load the /events/ page and confirm you no longer see the relevant Event

