### PR TITLE
938: Ensure dynamic site renders out GA code

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -303,9 +303,7 @@ LOGIN_ERROR_URL = "/admin/"
 LOGIN_REDIRECT_URL = "/admin/"
 LOGOUT_REDIRECT_URL = "/admin/"
 
-GOOGLE_ANALYTICS = ""
-# GOOGLE_ANALYTICS is _only_ set in settings.worker, because we ONLY want it
-# to appear in the static site, not the live-rendered site.
+GOOGLE_ANALYTICS = os.environ.get("GOOGLE_ANALYTICS", "")
 
 # RSS Feed
 RSS_MAX_ITEMS = 20

--- a/developerportal/settings/worker.py
+++ b/developerportal/settings/worker.py
@@ -1,7 +1,3 @@
 # Extra settings that ONLY apply to the Celery workers/schedulers
 
 from .production import *
-
-# GOOGLE_ANALYTICS is _only_ set in this file, because we ONLY want it
-# to appear in the static site, not the live-rendered site.
-GOOGLE_ANALYTICS = os.environ.get("GOOGLE_ANALYTICS")


### PR DESCRIPTION
Prior to this changeset, we only included the Google Analytics code/JS in static pages, so
that we didn't end up having data beign sent from both the dynamic/CMS pages and also the
static ones.

This changeset updates the settings so that we get/use Google Analytics in all situations,
not just the static-site generation.

This changeset addresses ... by ...

(Resolves #938)

## How to test

- add `GOOGLE_ANALYTICS=testcodehere` to your .env file and down then up your docker stack
- View source on any page - it will (unless you have DNT enabled...) show GA JS, featuring `testcodehere`