### PR TITLE
1011: Fix premature nav reflow issue 

### DIFF
--- a/src/css/molecules/header.scss
+++ b/src/css/molecules/header.scss
@@ -71,6 +71,12 @@
     cursor: pointer;
     font-weight: normal;
 
+    @media #{$mq-xl} {
+      // OVERRIDE to make it the same as $mq-lg, so we can pack more in to the nav
+      // without awkward reflow
+      padding: 0 16px 24px;
+    }
+
     img {
       margin-right: 8px;
     }


### PR DESCRIPTION
This changeset fixes the reflow that occurs when the nav options are particularly numerous and/or long.

Basically, it makes the CSS for the largest viewport use the same, slightly reduced padding values as the next, smaller media query.


_Note that things **are** quite packed in now. If we can move About to the footer, regardless of this change, that would still be useful_

(Resolves #1011)

## How to test

Take a look at https://developer-portal.dev.mdn.mozit.cloud/, which originally was like:

<img width="1103" alt="Screenshot 2019-12-30 at 21 40 49" src="https://user-images.githubusercontent.com/101457/71601986-e0aafd80-2b4d-11ea-89e8-57adc6ffdeca.png">

And is now

<img width="1064" alt="Screenshot 2019-12-30 at 21 55 45" src="https://user-images.githubusercontent.com/101457/71602220-2caa7200-2b4f-11ea-835f-44529eb4a1e2.png">

*Please have a play around with the viewport sizes by resizing your browser and trying to break the layout* 😄 