### PR TITLE
943: Support warming the CDN after it has been invalidated

### DIFF
--- a/developerportal/apps/common/tests/test_utils.py
+++ b/developerportal/apps/common/tests/test_utils.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 import pytz
 
-from ..utils import get_past_event_cutoff, paginate_resources
+from ..utils import get_all_urls_from_sitemap, get_past_event_cutoff, paginate_resources
 
 
 class EventCutoffTestCase(TestCase):
@@ -49,3 +49,67 @@ class HelperFunctionTests(TestCase):
         resources = paginate_resources(resources, per_page=10, page_ref="")
         self.assertEqual(repr(resources), "<Page 1 of 3>")
         self.assertEqual([x for x in resources], [x for x in range(1, 11)])
+
+
+class HelperFunctionTestsRequiringFixtures(TestCase):
+
+    fixtures = ["common.json"]
+
+    def test_get_all_urls_from_sitemap(self):
+
+        urls = get_all_urls_from_sitemap()
+        self.assertEqual(len(urls), 32)
+
+        hostname = "http://developer-portal-127-0-0-1.nip.io:433"  # from common.json
+
+        expected = [
+            f"{hostname}/",
+            f"{hostname}/topics/",
+            f"{hostname}/topics/css/",
+            f"{hostname}/topics/javascript/",
+            f"{hostname}/posts/",
+            f"{hostname}/posts/faster-smarter-javascript-debugging-in-firefox/",
+            (
+                f"{hostname}/posts/"
+                "developer-roadshow-2019-returns-vr-iot-and-all-things-web/"
+            ),
+            (
+                f"{hostname}/posts/"
+                "standardizing-wasi-system-interface-run-webassembly-outside-web/"
+            ),
+            f"{hostname}/posts/firefox-66-sound-silence/",
+            f"{hostname}/posts/fearless-security-thread-safety/",
+            f"{hostname}/posts/how-make-vr-web-new-video-series/",
+            f"{hostname}/posts/firefox-67-dark-mode-css-webrender-and-more/",
+            f"{hostname}/posts/web-design-survey-findings-and-next-steps/",
+            f"{hostname}/posts/9-biggest-mistakes-css-grid/",
+            f"{hostname}/posts/technical-details-recent-firefox-add-outage/",
+            f"{hostname}/posts/scroll-anchoring-firefox-66/",
+            f"{hostname}/posts/javascript-and-evidence-based-language-design/",
+            (
+                f"{hostname}/posts/"
+                "calls-between-javascript-and-webassembly-are-finally-fast/"
+            ),
+            f"{hostname}/posts/es6-depth-iterators-and-loop/",
+            f"{hostname}/posts/es6-depth-destructuring/",
+            f"{hostname}/posts/indicating-focus-improve-accessibility/",
+            (
+                f"{hostname}/posts/"
+                "fluent-10-localization-system-natural-sounding-translations/"
+            ),
+            f"{hostname}/posts/overscripted-digging-javascript-execution-scale/",
+            (
+                f"{hostname}/posts/firefox-brings-you-smooth-"
+                "video-playback-with-the-worlds-fastest-av1-decoder/"
+            ),
+            f"{hostname}/posts/depths-technical-details-behind-av1/",
+            f"{hostname}/posts/new-firefox-devtools-65/",
+            f"{hostname}/posts/css-grid-level-2-subgrid-is-coming-to-firefox/",
+            f"{hostname}/events/",
+            f"{hostname}/communities/",
+            f"{hostname}/communities/people/",
+            f"{hostname}/communities/people/josh-marinacci/",
+            f"{hostname}/videos/",
+        ]
+
+        self.assertEqual(urls, expected)

--- a/developerportal/apps/common/utils.py
+++ b/developerportal/apps/common/utils.py
@@ -6,6 +6,8 @@ from django.apps import apps
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.utils.timezone import now as tz_now
 
+from wagtail.contrib.sitemaps import Sitemap
+
 
 def _combined_query(models, fn):
     """Execute callback `fn` for each model and chain the resulting querysets."""
@@ -109,3 +111,12 @@ def paginate_resources(resources, per_page, page_ref):
         resources = paginator.page(1)
 
     return resources
+
+
+def get_all_urls_from_sitemap():
+    sitemap = Sitemap()
+    site = sitemap.get_wagtail_site()
+    site.domain = site.hostname  # We need to patch this else it blows up
+    location_dict = sitemap.get_urls(site=site)
+
+    return [x["location"] for x in location_dict]

--- a/developerportal/apps/taskqueue/tests/test_tasks.py
+++ b/developerportal/apps/taskqueue/tests/test_tasks.py
@@ -2,7 +2,12 @@ from unittest import mock
 
 from django.test import TestCase
 
-from ..tasks import invalidate_entire_cdn, selectively_invalidate_cdn
+from ..tasks import (
+    _warm_cdn,
+    invalidate_entire_cdn,
+    selectively_invalidate_cdn,
+    warm_entire_cdn,
+)
 
 
 class TasksTestCase(TestCase):
@@ -22,4 +27,94 @@ class TasksTestCase(TestCase):
         selectively_invalidate_cdn()
         mock_invalidate_cdn.assert_called_once_with(
             invalidation_targets=["/events/*", "/communities/people/*", "/topics/*"]
+        )
+
+    @mock.patch("developerportal.apps.taskqueue.tasks.get_all_urls_from_sitemap")
+    @mock.patch("developerportal.apps.taskqueue.tasks._warm_cdn")
+    def test_warm_entire_cdn(self, mock_warm_cdn, mock_get_all_urls_from_sitemap):
+
+        _urls = ["/foo/", "/bar/", "/baz/bam"]
+
+        mock_get_all_urls_from_sitemap.return_value = _urls
+
+        warm_entire_cdn()
+        mock_get_all_urls_from_sitemap.assert_called_once_with()
+        mock_warm_cdn.assert_called_once_with(_urls)
+
+    @mock.patch("developerportal.apps.taskqueue.tasks.requests.get")
+    def test__warm_cdn__happy_path(self, mock_requests_get):
+
+        mock_response = mock.Mock(name="mock_response")
+        mock_response.status_code = 200
+        mock_requests_get.return_value = mock_response
+
+        with self.assertLogs(
+            "developerportal.apps.taskqueue.tasks", level="INFO"
+        ) as cm:
+            _urls = ["/foo/", "/bar/", "/baz/bam"]
+            _warm_cdn(_urls)
+            assert mock_requests_get.call_count == 3
+            assert [x[0][0] for x in mock_requests_get.call_args_list] == _urls
+
+        self.assertEqual(
+            cm.output,
+            [
+                (
+                    "INFO:developerportal.apps.taskqueue.tasks:"
+                    "Warming CDN. 3 URLs obtained from sitemap."
+                ),
+                ("INFO:developerportal.apps.taskqueue.tasks:" "Requesting 1/3: /foo/"),
+                ("INFO:developerportal.apps.taskqueue.tasks:" "Requesting 2/3: /bar/"),
+                (
+                    "INFO:developerportal.apps.taskqueue.tasks:"
+                    "Requesting 3/3: /baz/bam"
+                ),
+                ("INFO:developerportal.apps.taskqueue.tasks:" "Warming complete."),
+            ],
+        )
+
+    @mock.patch("developerportal.apps.taskqueue.tasks.requests.get")
+    def test__warm_cdn__unhappy_path(self, mock_requests_get):
+        with self.assertLogs(
+            "developerportal.apps.taskqueue.tasks", level="INFO"
+        ) as cm:
+
+            mock_response = mock.Mock(name="mock_response")
+            mock_response.status_code = 404
+            mock_requests_get.return_value = mock_response
+
+            _urls = ["/foo/", "/bar/", "/baz/bam"]
+            _warm_cdn(_urls)
+            assert mock_requests_get.call_count == 3
+            assert [x[0][0] for x in mock_requests_get.call_args_list] == _urls
+
+        empty_exception_traceback_string = "\nNoneType: None"
+
+        self.assertEqual(
+            cm.output,
+            [
+                (
+                    "INFO:developerportal.apps.taskqueue.tasks:"
+                    "Warming CDN. 3 URLs obtained from sitemap."
+                ),
+                ("INFO:developerportal.apps.taskqueue.tasks:" "Requesting 1/3: /foo/"),
+                (
+                    "ERROR:developerportal.apps.taskqueue.tasks:"
+                    f"Failed to get /foo/ {empty_exception_traceback_string}"
+                ),
+                ("INFO:developerportal.apps.taskqueue.tasks:" "Requesting 2/3: /bar/"),
+                (
+                    "ERROR:developerportal.apps.taskqueue.tasks:"
+                    f"Failed to get /bar/ {empty_exception_traceback_string}"
+                ),
+                (
+                    "INFO:developerportal.apps.taskqueue.tasks:"
+                    "Requesting 3/3: /baz/bam"
+                ),
+                (
+                    "ERROR:developerportal.apps.taskqueue.tasks:"
+                    f"Failed to get /baz/bam {empty_exception_traceback_string}"
+                ),
+                ("INFO:developerportal.apps.taskqueue.tasks:" "Warming complete."),
+            ],
         )


### PR DESCRIPTION
This changeset addresses the desire to 'warm' the CDN by requesting pages so that they are re-populated in the CDN.

This is not a super-elegant solution, but is a short/med-term compromise while we also have bulk CDN invalidation going following any page being published.

(Related issue #943)

## Key changes

After 15 minutes:
* for a total cache invalidation, request every URL in the sitemap
* for a selective cache invalidation, request the top-level paths that were invalidated (which is not perfect, but at least better than not warming anything)

_Am not expecting this to be approved without some discussion - there are gaps/issues here that are worth thinking about, including race conditions and concurrent invalidation and warming requests (and whether this matters...) - so please be picky!_ 

## Example

**Task code runs...** 
```
INFO:developerportal.apps.taskqueue.tasks:[Invalidate entire CDN] Issuing purge command
INFO:developerportal.apps.taskqueue.utils:Purging Cloudfront distribtion ID E1SQ3REY21XTNU.
INFO:developerportal.apps.taskqueue.utils:Got a positive response from Cloudfront. Invalidation status: InProgress
```


**And enqueues another warming task:**
```
worker_1     | [2020-01-02 13:04:46,973: INFO/MainProcess] Received task: developerportal.apps.taskqueue.tasks.warm_entire_cdn[7e32f883-56cd-47cc-a522-fd6b19c0b7c0]  ETA:[2020-01-02 13:05:01.969827+00:00]
worker_1     | [2020-01-02 13:05:02,934: INFO/ForkPoolWorker-4] Warming CDN. 60 URLs obtained from sitemap.
worker_1     | [2020-01-02 13:05:02,934: INFO/ForkPoolWorker-4] Requesting 1/60: https://REDACTED/
worker_1     | [2020-01-02 13:05:03,143: INFO/ForkPoolWorker-4] Requesting 2/60: https://REDACTED/topics/
worker_1     | [2020-01-02 13:05:03,284: INFO/ForkPoolWorker-4] Requesting 3/60: https://REDACTED/topics/css/
worker_1     | [2020-01-02 13:05:03,395: INFO/ForkPoolWorker-4] Requesting 4/60: https://REDACTED/topics/javascript/
worker_1     | [2020-01-02 13:05:03,517: INFO/ForkPoolWorker-4] Requesting 5/60: https://REDACTED/topics/test-topic/
worker_1     | [2020-01-02 13:05:03,632: INFO/ForkPoolWorker-4] Requesting 6/60: https://REDACTED/topics/unused-test-topic/
worker_1     | [2020-01-02 13:05:03,771: INFO/ForkPoolWorker-4] Requesting 7/60: https://REDACTED/topics/av1-video/
worker_1     | [2020-01-02 13:05:03,881: INFO/ForkPoolWorker-4] Requesting 8/60: https://REDACTED/topics/browser-extensions/
worker_1     | [2020-01-02 13:05:03,992: INFO/ForkPoolWorker-4] Requesting 9/60: https://REDACTED/topics/developer-tools/
worker_1     | [2020-01-02 13:05:04,101: INFO/ForkPoolWorker-4] Requesting 10/60: https://REDACTED/topics/firefox-mobile/
worker_1     | [2020-01-02 13:05:04,217: INFO/ForkPoolWorker-4] Requesting 11/60: https://REDACTED/posts/
worker_1     | [2020-01-02 13:05:04,389: INFO/ForkPoolWorker-4] Requesting 12/60: https://REDACTED/posts/faster-smarter-javascript-debugging-in-firefox/
worker_1     | [2020-01-02 13:05:04,549: INFO/ForkPoolWorker-4] Requesting 13/60: https://REDACTED/posts/developer-roadshow-2019-returns-vr-iot-and-all-things-web/
worker_1     | [2020-01-02 13:05:04,744: INFO/ForkPoolWorker-4] Requesting 14/60: https://REDACTED/posts/standardizing-wasi-system-interface-run-webassembly-outside-web/
worker_1     | [2020-01-02 13:05:04,911: INFO/ForkPoolWorker-4] Requesting 15/60: https://REDACTED/posts/firefox-66-sound-silence/
worker_1     | [2020-01-02 13:05:05,072: INFO/ForkPoolWorker-4] Requesting 16/60: https://REDACTED/posts/fearless-security-thread-safety/
worker_1     | [2020-01-02 13:05:05,245: INFO/ForkPoolWorker-4] Requesting 17/60: https://REDACTED/posts/how-make-vr-web-new-video-series/
worker_1     | [2020-01-02 13:05:05,381: INFO/ForkPoolWorker-4] Requesting 18/60: https://REDACTED/posts/firefox-67-dark-mode-css-webrender-and-more/
worker_1     | [2020-01-02 13:05:05,565: INFO/ForkPoolWorker-4] Requesting 19/60: https://REDACTED/posts/web-design-survey-findings-and-next-steps/
worker_1     | [2020-01-02 13:05:05,718: INFO/ForkPoolWorker-4] Requesting 20/60: https://REDACTED/posts/9-biggest-mistakes-css-grid/
worker_1     | [2020-01-02 13:05:05,884: INFO/ForkPoolWorker-4] Requesting 21/60: https://REDACTED/posts/technical-details-recent-firefox-add-outage/
worker_1     | [2020-01-02 13:05:06,056: INFO/ForkPoolWorker-4] Requesting 22/60: https://REDACTED/posts/scroll-anchoring-firefox-66/
worker_1     | [2020-01-02 13:05:06,219: INFO/ForkPoolWorker-4] Requesting 23/60: https://REDACTED/posts/javascript-and-evidence-based-language-design/
worker_1     | [2020-01-02 13:05:06,360: INFO/ForkPoolWorker-4] Requesting 24/60: https://REDACTED/posts/calls-between-javascript-and-webassembly-are-finally-fast/
worker_1     | [2020-01-02 13:05:06,507: INFO/ForkPoolWorker-4] Requesting 25/60: https://REDACTED/posts/es6-depth-iterators-and-loop/
worker_1     | [2020-01-02 13:05:06,646: INFO/ForkPoolWorker-4] Requesting 26/60: https://REDACTED/posts/es6-depth-destructuring/
worker_1     | [2020-01-02 13:05:06,792: INFO/ForkPoolWorker-4] Requesting 27/60: https://REDACTED/posts/indicating-focus-improve-accessibility/
worker_1     | [2020-01-02 13:05:06,917: INFO/ForkPoolWorker-4] Requesting 28/60: https://REDACTED/posts/fluent-10-localization-system-natural-sounding-translations/
worker_1     | [2020-01-02 13:05:07,057: INFO/ForkPoolWorker-4] Requesting 29/60: https://REDACTED/posts/overscripted-digging-javascript-execution-scale/
worker_1     | [2020-01-02 13:05:07,209: INFO/ForkPoolWorker-4] Requesting 30/60: https://REDACTED/posts/firefox-brings-you-smooth-video-playback-with-the-worlds-fastest-av1-decoder/
worker_1     | [2020-01-02 13:05:07,388: INFO/ForkPoolWorker-4] Requesting 31/60: https://REDACTED/posts/depths-technical-details-behind-av1/
worker_1     | [2020-01-02 13:05:07,552: INFO/ForkPoolWorker-4] Requesting 32/60: https://REDACTED/posts/new-firefox-devtools-65/
worker_1     | [2020-01-02 13:05:07,712: INFO/ForkPoolWorker-4] Requesting 33/60: https://REDACTED/posts/css-grid-level-2-subgrid-is-coming-to-firefox/
worker_1     | [2020-01-02 13:05:07,852: INFO/ForkPoolWorker-4] Requesting 34/60: https://REDACTED/posts/test-article/
worker_1     | [2020-01-02 13:05:07,971: INFO/ForkPoolWorker-4] Requesting 35/60: https://REDACTED/posts/new-post/
worker_1     | [2020-01-02 13:05:08,110: INFO/ForkPoolWorker-4] Requesting 36/60: https://REDACTED/events/
worker_1     | [2020-01-02 13:05:08,277: INFO/ForkPoolWorker-4] Requesting 37/60: https://REDACTED/events/test-event-2/
worker_1     | [2020-01-02 13:05:08,393: INFO/ForkPoolWorker-4] Requesting 38/60: https://REDACTED/events/event/
worker_1     | [2020-01-02 13:05:08,528: INFO/ForkPoolWorker-4] Requesting 39/60: https://REDACTED/events/event-b/
worker_1     | [2020-01-02 13:05:08,661: INFO/ForkPoolWorker-4] Requesting 40/60: https://REDACTED/events/old-event-c/
worker_1     | [2020-01-02 13:05:08,763: INFO/ForkPoolWorker-4] Requesting 41/60: https://REDACTED/events/old-event-d/
worker_1     | [2020-01-02 13:05:08,873: INFO/ForkPoolWorker-4] Requesting 42/60: https://REDACTED/events/old-event-e/
worker_1     | [2020-01-02 13:05:08,975: INFO/ForkPoolWorker-4] Requesting 43/60: https://REDACTED/events/old-event-f/
worker_1     | [2020-01-02 13:05:09,090: INFO/ForkPoolWorker-4] Requesting 44/60: https://REDACTED/events/old-event-g/
worker_1     | [2020-01-02 13:05:09,190: INFO/ForkPoolWorker-4] Requesting 45/60: https://REDACTED/communities/
worker_1     | [2020-01-02 13:05:09,294: INFO/ForkPoolWorker-4] Requesting 46/60: https://REDACTED/communities/people/
worker_1     | [2020-01-02 13:05:09,439: INFO/ForkPoolWorker-4] Requesting 47/60: https://REDACTED/communities/people/josh-marinacci/
worker_1     | [2020-01-02 13:05:09,549: INFO/ForkPoolWorker-4] Requesting 48/60: https://REDACTED/communities/people/test-mctest/
worker_1     | [2020-01-02 13:05:09,658: INFO/ForkPoolWorker-4] Requesting 49/60: https://REDACTED/communities/people/person-person/
worker_1     | [2020-01-02 13:05:09,778: INFO/ForkPoolWorker-4] Requesting 50/60: https://REDACTED/communities/people/john/
worker_1     | [2020-01-02 13:05:09,925: INFO/ForkPoolWorker-4] Requesting 51/60: https://REDACTED/communities/people/alice/
worker_1     | [2020-01-02 13:05:10,028: INFO/ForkPoolWorker-4] Requesting 52/60: https://REDACTED/communities/people/george/
worker_1     | [2020-01-02 13:05:10,140: INFO/ForkPoolWorker-4] Requesting 53/60: https://REDACTED/communities/people/paula/
worker_1     | [2020-01-02 13:05:10,271: INFO/ForkPoolWorker-4] Requesting 54/60: https://REDACTED/communities/people/eve-community/
worker_1     | [2020-01-02 13:05:10,426: INFO/ForkPoolWorker-4] Requesting 55/60: https://REDACTED/communities/people/ringo/
worker_1     | [2020-01-02 13:05:10,567: INFO/ForkPoolWorker-4] Requesting 56/60: https://REDACTED/communities/people/another-person/
worker_1     | [2020-01-02 13:05:10,718: INFO/ForkPoolWorker-4] Requesting 57/60: https://REDACTED/communities/people/person-mcperson/
worker_1     | [2020-01-02 13:05:10,843: INFO/ForkPoolWorker-4] Requesting 58/60: https://REDACTED/videos/test-video-one/
worker_1     | [2020-01-02 13:05:10,984: INFO/ForkPoolWorker-4] Requesting 59/60: https://REDACTED/videos/test-video-two/
worker_1     | [2020-01-02 13:05:11,098: INFO/ForkPoolWorker-4] Requesting 60/60: https://REDACTED/about/
worker_1     | [2020-01-02 13:05:11,197: INFO/ForkPoolWorker-4] Warming complete.
worker_1     | [2020-01-02 13:05:11,205: INFO/ForkPoolWorker-4] Task developerportal.apps.taskqueue.tasks.warm_entire_cdn[7e32f883-56cd-47cc-a522-fd6b19c0b7c0] succeeded in 8.355611500002851s: None
```

**Here's how it looks for selective invalidation**

```
INFO:developerportal.apps.taskqueue.tasks:[Selectively invalidate CDN] Issuing purge command for selected CDN keys: ['/events/*', '/communities/people/*', '/topics/*']
INFO:developerportal.apps.taskqueue.utils:Purging Cloudfront distribtion ID E1SQ3REY21XTNU.
INFO:developerportal.apps.taskqueue.utils:Got a positive response from Cloudfront. Invalidation status: InProgress
```

```
worker_1     | [2020-01-02 13:23:00,065: INFO/MainProcess] Received task: developerportal.apps.taskqueue.tasks.selectively_warm_cdn[421d3999-b89d-45d4-a837-66ce7806188c]  ETA:[2020-01-02 13:23:15.061797+00:00]
worker_1     | [2020-01-02 13:23:15,739: INFO/ForkPoolWorker-4] Warming CDN. 3 URLs obtained from sitemap.
worker_1     | [2020-01-02 13:23:15,740: INFO/ForkPoolWorker-4] Requesting 1/3: https://REDACTED/events/
worker_1     | [2020-01-02 13:23:15,927: INFO/ForkPoolWorker-4] Requesting 2/3: https://REDACTED/communities/people/
worker_1     | [2020-01-02 13:23:16,080: INFO/ForkPoolWorker-4] Requesting 3/3: https://REDACTED/topics/
worker_1     | [2020-01-02 13:23:16,215: INFO/ForkPoolWorker-4] Warming complete.
worker_1     | [2020-01-02 13:23:16,232: INFO/ForkPoolWorker-4] Task developerportal.apps.taskqueue.tasks.selectively_warm_cdn[421d3999-b89d-45d4-a837-66ce7806188c] succeeded in 0.49223540000093635s: None
```