### PR TITLE
Set ndots to 1

### DIFF
--- a/k8s/app.deploy.yaml.j2
+++ b/k8s/app.deploy.yaml.j2
@@ -14,6 +14,10 @@ spec:
       annotations:
         iam.amazonaws.com/role: {{ APP_BUCKET_ROLE_ARN }}
     spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       containers:
         - name: {{ APP_NAME }}
           image: "{{ APP_IMAGE }}:{{ APP_IMAGE_TAG }}"


### PR DESCRIPTION
This addresses intermittent dns resolution issues reported by the pod. We set `ndot` to `1` so that the dns resolution will not iterate through the search domains.

(Related issue #1067)

## Key changes:

- Configures `ndot` to `1`

