### PR TITLE
Update RBAC for jenkins

### DIFF
--- a/k8s/jenkins-rbac.yaml
+++ b/k8s/jenkins-rbac.yaml
@@ -12,7 +12,7 @@ rules:
     - get
     - list
     - watch
-- apiGroups: ["", "extensions", "apps"]
+- apiGroups: ["", "extensions", "apps", "autoscaling"]
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: ["batch"]
@@ -35,7 +35,7 @@ rules:
     - get
     - list
     - watch
-- apiGroups: ["", "extensions", "apps"]
+- apiGroups: ["", "extensions", "apps", "autoscaling"]
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: ["batch"]
@@ -58,7 +58,7 @@ rules:
     - get
     - list
     - watch
-- apiGroups: ["", "extensions", "apps"]
+- apiGroups: ["", "extensions", "apps", "autoscaling"]
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: ["batch"]


### PR DESCRIPTION
Updated RBAC for jenkins user to now allow creation of HPA's



## Key changes:

- Updated RBAC to allow creation of HPA

