### PR TITLE
1097 - HOTFIX: Ensure that previewing an ExternalArticle does not 500

### DIFF
--- a/developerportal/apps/externalcontent/models.py
+++ b/developerportal/apps/externalcontent/models.py
@@ -9,6 +9,7 @@ from django.db.models import (
     ForeignKey,
     URLField,
 )
+from django.http import HttpResponseRedirect
 
 from django_countries.fields import CountryField
 from modelcluster.fields import ParentalKey
@@ -98,6 +99,11 @@ class ExternalContent(BasePage):
     @property
     def url(self):
         return self.external_url
+
+    def serve_preview(self, request, mode_name):
+        # ExternalContent subclasses don't preview like regular Pages: we just need
+        # to show where they link to.
+        return HttpResponseRedirect(self.external_url)
 
 
 class ExternalArticleTopic(Orderable):


### PR DESCRIPTION
Prior to this changeset, the absence of a template for any subclass of ExternalContent (eg External Articles) meant that it was impossible to preview them. The template was never created because such pages are never rendered in the published site only linked to. The Preview aspect was not yet covered.

This changeset overrides the `serve_preview` view to simply redirect to the `external_url` configured for that page/item.

(Resolves #1097 )

No tests, but manually tested