### PR TITLE
1010 Make "Topics" phrasing dynamic

### DIFF
--- a/developerportal/apps/common/fixtures/common.json
+++ b/developerportal/apps/common/fixtures/common.json
@@ -654,8 +654,8 @@
       "path": "000100010002",
       "depth": 3,
       "numchild": 2,
-      "title": "Topics",
-      "draft_title": "Topics",
+      "title": "Products & Technologies",
+      "draft_title": "Products & Technologies",
       "slug": "topics",
       "content_type": [
         "topics",

--- a/developerportal/apps/common/tests/test_context_processors.py
+++ b/developerportal/apps/common/tests/test_context_processors.py
@@ -1,0 +1,40 @@
+from unittest import mock
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from developerportal import context_processors
+
+from ...topics.models import Topics
+
+
+class ContextProcessorsTestCase(TestCase):
+
+    fixtures = ["common.json"]
+
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_topics_title(self):
+
+        self.assertEqual(Topics.objects.get().title, "Products & Technologies")
+        self.assertIsNone(cache.get(Topics.CACHE_KEY_TOPICS_TITLE))
+        self.assertEqual(
+            context_processors.topics_title(request=mock.Mock()),
+            {"TOPICS_TITLE_LABEL": "Products & Technologies"},
+        )
+        self.assertEqual(
+            cache.get(Topics.CACHE_KEY_TOPICS_TITLE), "Products & Technologies"
+        )
+
+    def test_topics_title__fallback(self):
+        Topics.objects.all().delete()
+        self.assertIsNone(cache.get(Topics.CACHE_KEY_TOPICS_TITLE))
+        self.assertEqual(
+            context_processors.topics_title(request=mock.Mock()),
+            {"TOPICS_TITLE_LABEL": "Topics"},
+        )
+        self.assertIsNone(cache.get(Topics.CACHE_KEY_TOPICS_TITLE))

--- a/developerportal/apps/common/tests/test_models.py
+++ b/developerportal/apps/common/tests/test_models.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from ...content.models import ContentPage
+
+
+class PageBaseModelTestsUsingConcreteClass(TestCase):
+    """Tests that use a concrete ContentPage class to test behaviour
+    from the BasePage"""
+
+    def test_save(self):
+
+        with mock.patch(
+            "developerportal.apps.common.models.cache.delete_many"
+        ) as mock_delete_many:
+
+            self.assertEqual(ContentPage._bulk_invalidation_cache_keys, [])
+
+            page = ContentPage(slug="test", path="00010022", depth=2, title="Test")
+            page._bulk_invalidation_cache_keys = ["foo", "bar", "baz"]
+            page.save()
+            mock_delete_many.assert_called_once_with(["foo", "bar", "baz"])

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -258,9 +258,14 @@ class Topic(BasePage):
 
 
 class Topics(BasePage):
+
     parent_page_types = ["home.HomePage"]
     subpage_types = ["Topic"]
     template = "topics.html"
+
+    # Cache keys associated with this Page type - also see common.models.BasePage
+    CACHE_KEY_TOPICS_TITLE = "topics-titles"
+    _bulk_invalidation_cache_keys = [CACHE_KEY_TOPICS_TITLE]
 
     # Meta fields
     keywords = ClusterTaggableManager(through=TopicsTag, blank=True)

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -111,6 +111,7 @@ TEMPLATES = [
                 "developerportal.context_processors.mapbox_access_token",
                 "developerportal.context_processors.pagination_constants",
                 "developerportal.context_processors.filtering_constants",
+                "developerportal.context_processors.topics_title",
             ],
             "libraries": {
                 "app_filters": "developerportal.templatetags.app_filters",
@@ -335,6 +336,13 @@ CACHES = {
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
     }
 }
+
+CACHE_TIME_TINY = 60 * 5  # 5 mins
+CACHE_TIME_SHORT = 60 * 60  # 1 hour
+CACHE_TIME_MEDIUM = 60 * 60 * 24  # 1 day
+CACHE_TIME_LONG = 60 * 60 * 24 * 7  # 1 week
+CACHE_TIME_VERY_LONG = 60 * 60 * 24 * 28  # 28 days
+
 
 # Mozilla OpenID Connect / Auth0 configuration
 

--- a/developerportal/settings/test.py
+++ b/developerportal/settings/test.py
@@ -4,3 +4,5 @@ CACHES["default"]["KEY_PREFIX"] = "test"
 
 DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 MEDIA_ROOT = "/tmp/test-media/"
+
+AWS_CLOUDFRONT_DISTRIBUTION_ID = None

--- a/developerportal/templates/molecules/filter-form.html
+++ b/developerportal/templates/molecules/filter-form.html
@@ -62,7 +62,7 @@
   {% if filters.topics %}
     <fieldset class="filter-form-section">
       <header class="filter-form-section-header">
-        <h5 class="no-underline">Topic</h5>
+        <h5 class="no-underline">{{TOPICS_TITLE_LABEL}}</h5>
         <a href="#" class="filter-form-clear js-filter-clear" data-controls="{{TOPIC_QUERYSTRING_KEY}}">
           <span class="icon">
             {% include "atoms/icons/close.svg" %}

--- a/developerportal/templates/organisms/topic-links.html
+++ b/developerportal/templates/organisms/topic-links.html
@@ -9,13 +9,13 @@
       <div class="container">
         <div class="section-header">
           {% if pagetheme == 'home' or pagetheme == 'directory' %}
-            <h2>Browse by topic</h2>
+            <h2>Browse {{TOPICS_TITLE_LABEL|lower}}</h2>
           {% endif %}
           {% if pagetheme == 'topic' %}
             <h2>Continue exploring</h2>
           {% endif %}
           {% if pagetheme == 'person' %}
-            <h2>Topics I specialize in</h2>
+            <h2>{{TOPICS_TITLE_LABEL}} I specialize in</h2>
           {% endif %}
         </div>
         {% if topics.count == 1 %}


### PR DESCRIPTION
This changeset addresses the need to stop calling [most] things "Topics" and instead draws the phrasing to use from the current title of the `Topics` page. It does this in a way that minimises database hits just to get that display string.


(Related issue #1010)

## Key changes:

- Update base/common fixture with new phrasing of Topics page title, for local consistency
- Add Python-layer support for dynamically using the title of the Topics page in rendered output:
  * adding a context processor to make the Topics title string available in all templates
  * added write-through caching behaviour to the above, so we don't hit the DB unnecessarily
  * added cache invalidation via a 'bulk invalidate' approach: when a Topics model is saved, all its related/configured
cache keys are zapped
  * tests for the above

- Use the new context variable for the title of the topics page in HTML



## How to test

- have a look around on the [dev](https://developer-portal.dev.mdn.mozit.cloud/) server, but also here are some screenshots to show what has/has not changed:

**Homepage and `/topics/`**
<img width="944" alt="Screenshot 2020-01-20 at 15 42 29" src="https://user-images.githubusercontent.com/101457/72748478-4d467480-3baf-11ea-9b93-8bd4a1121fe4.png">

**Person page when they are associated wtih one or more `Topic`s**
<img width="1293" alt="Screenshot 2020-01-20 at 15 43 27" src="https://user-images.githubusercontent.com/101457/72748479-4d467480-3baf-11ea-8469-ccfceb25cd9b.png">

**Filtering sidebar**
<img width="469" alt="Screenshot 2020-01-20 at 15 46 53" src="https://user-images.githubusercontent.com/101457/72748480-4ddf0b00-3baf-11ea-89ff-130cc7c774f0.png">
<img width="714" alt="Screenshot 2020-01-20 at 15 47 06" src="https://user-images.githubusercontent.com/101457/72748481-4ddf0b00-3baf-11ea-86e6-44e4702825b6.png">
<img width="623" alt="Screenshot 2020-01-20 at 15 47 12" src="https://user-images.githubusercontent.com/101457/72748482-4ddf0b00-3baf-11ea-9512-9d67da233653.png">

**Note that this one has NOT changed (sidebar on Post and Video pages) because I couldn't find a neat way to reuse the title text available from the Topics page**
<img width="457" alt="Screenshot 2020-01-20 at 17 41 34" src="https://user-images.githubusercontent.com/101457/72748483-4e77a180-3baf-11ea-836e-08e63ec4a88d.png">

