### PR TITLE
540: Reinstate scheduled publishing fields for all pages

### DIFF
--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -276,7 +276,7 @@ class Article(BasePage):
     ]
 
     # Settings panels
-    settings_panels = [FieldPanel("slug")]
+    settings_panels = BasePage.settings_panels + [FieldPanel("slug")]
 
     # Tabs
     edit_handler = TabbedInterface(

--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -92,7 +92,10 @@ class Articles(BasePage):
     ]
 
     # Settings panels
-    settings_panels = [FieldPanel("slug"), FieldPanel("show_in_menus")]
+    settings_panels = BasePage.settings_panels + [
+        FieldPanel("slug"),
+        FieldPanel("show_in_menus"),
+    ]
 
     edit_handler = TabbedInterface(
         [

--- a/developerportal/apps/content/models.py
+++ b/developerportal/apps/content/models.py
@@ -92,7 +92,10 @@ class ContentPage(BasePage):
     ]
 
     # Settings panels
-    settings_panels = [FieldPanel("slug"), FieldPanel("show_in_menus")]
+    settings_panels = BasePage.settings_panels + [
+        FieldPanel("slug"),
+        FieldPanel("show_in_menus"),
+    ]
 
     # Tabs
     edit_handler = TabbedInterface(

--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -443,7 +443,7 @@ class Event(BasePage):
     ]
 
     # Settings panels
-    settings_panels = [FieldPanel("slug")]
+    settings_panels = BasePage.settings_panels + [FieldPanel("slug")]
 
     edit_handler = TabbedInterface(
         [

--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -136,7 +136,10 @@ class Events(BasePage):
     ]
 
     # Settings panels
-    settings_panels = [FieldPanel("slug"), FieldPanel("show_in_menus")]
+    settings_panels = BasePage.settings_panels + [
+        FieldPanel("slug"),
+        FieldPanel("show_in_menus"),
+    ]
 
     edit_handler = TabbedInterface(
         [

--- a/developerportal/apps/people/models.py
+++ b/developerportal/apps/people/models.py
@@ -293,7 +293,7 @@ class Person(BasePage):
     ]
 
     # Settings panels
-    settings_panels = [FieldPanel("slug")]
+    settings_panels = BasePage.settings_panels + [FieldPanel("slug")]
 
     # Tabs
     edit_handler = TabbedInterface(

--- a/developerportal/apps/people/models.py
+++ b/developerportal/apps/people/models.py
@@ -81,7 +81,10 @@ class People(BasePage):
     ]
 
     # Settings panels
-    settings_panels = [FieldPanel("slug"), FieldPanel("show_in_menus")]
+    settings_panels = BasePage.settings_panels + [
+        FieldPanel("slug"),
+        FieldPanel("show_in_menus"),
+    ]
 
     edit_handler = TabbedInterface(
         [

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -286,7 +286,10 @@ class Topics(BasePage):
     ]
 
     # Settings panels
-    settings_panels = [FieldPanel("slug"), FieldPanel("show_in_menus")]
+    settings_panels = BasePage.settings_panels + [
+        FieldPanel("slug"),
+        FieldPanel("show_in_menus"),
+    ]
 
     edit_handler = TabbedInterface(
         [

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -214,7 +214,10 @@ class Topic(BasePage):
     ]
 
     # Settings panels
-    settings_panels = [FieldPanel("slug"), FieldPanel("show_in_menus")]
+    settings_panels = BasePage.settings_panels + [
+        FieldPanel("slug"),
+        FieldPanel("show_in_menus"),
+    ]
 
     # Tabs
     edit_handler = TabbedInterface(

--- a/developerportal/apps/videos/models.py
+++ b/developerportal/apps/videos/models.py
@@ -72,7 +72,10 @@ class Videos(BasePage):
         )
     ]
 
-    settings_panels = [FieldPanel("slug"), FieldPanel("show_in_menus")]
+    settings_panels = BasePage.settings_panels + [
+        FieldPanel("slug"),
+        FieldPanel("show_in_menus"),
+    ]
 
     edit_handler = TabbedInterface(
         [

--- a/developerportal/apps/videos/models.py
+++ b/developerportal/apps/videos/models.py
@@ -237,7 +237,7 @@ class Video(BasePage):
         ),
     ]
 
-    settings_panels = [FieldPanel("slug")]
+    settings_panels = BasePage.settings_panels + [FieldPanel("slug")]
 
     # Tabs
     edit_handler = TabbedInterface(


### PR DESCRIPTION
This changeset addresses the absence of the "Scheduled Publishing" fields on most of the pages in the CMS. They are now reinstated for all page types apart from the Homepage, including the 'grouping' pages like `Videos` and `Events`, not just `Video` and `Event`

This now matches default behaviour for Wagtail pages - there's nothing special to test, beyond confirming that the pages can be saved (which they can)

(Resolves #540)

## How to test
It's up on the [dev environment](https://developer-portal.dev.mdn.mozit.cloud/admin/), but also here's a screenshot of what to look for:

<img width="1134" alt="Screenshot 2020-01-22 at 14 47 56" src="https://user-images.githubusercontent.com/101457/72904083-3d9d6c00-3d26-11ea-98c3-5b24798c7cb9.png">



