### PR TITLE
1141: Fix duplicated year-month filters in Events

### DIFF
--- a/developerportal/apps/events/tests/test_events.py
+++ b/developerportal/apps/events/tests/test_events.py
@@ -268,6 +268,56 @@ class EventsTests(PatchedWagtailPageTests):
         actual = events_page.get_relevant_dates()
         self.assertEqual(actual, expected)
 
+    def test_dates_to_unique_month_years(self):
+        cases = [
+            {
+                "input": [
+                    datetime.date(2022, 10, 3),
+                    datetime.date(2022, 10, 10),
+                    datetime.date(2022, 11, 2),
+                    datetime.date(2022, 10, 3),  # Same as first date
+                ],
+                "expected": [datetime.date(2022, 10, 1), datetime.date(2022, 11, 1)],
+            },
+            {
+                "input": [
+                    datetime.date(2022, 10, 3),
+                    datetime.date(2022, 10, 10),
+                    datetime.date(2023, 12, 3),
+                    datetime.date(2022, 11, 2),
+                ],
+                "expected": [
+                    datetime.date(2022, 10, 1),
+                    datetime.date(2022, 11, 1),
+                    datetime.date(2023, 12, 1),
+                ],
+            },
+            {
+                "input": [
+                    datetime.date(2022, 10, 3),
+                    datetime.date(2023, 12, 3),
+                    datetime.date(2022, 11, 2),
+                ],
+                "expected": [
+                    datetime.date(2022, 10, 1),
+                    datetime.date(2022, 11, 1),
+                    datetime.date(2023, 12, 1),
+                ],
+            },
+            {
+                "input": [
+                    datetime.date(2023, 12, 3),
+                    datetime.date(2023, 12, 3),
+                    datetime.date(2023, 12, 3),
+                ],
+                "expected": [datetime.date(2023, 12, 1)],
+            },
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                actual = Events().dates_to_unique_month_years(case["input"])
+                self.assertEqual(actual, case["expected"])
+
     @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")
     def test_events__get_relevant_countries(self, mock_get_past_event_cutoff):
 


### PR DESCRIPTION
This changeset ensure multiple Events in the same year-month combination don't cause the year-month values to appear multiple times in the filters. It adds a method to squash out the duplicates, with tests

(Resolves #1141)

**Before (example from prod)**

<img width="303" alt="Screenshot 2020-01-25 at 07 27 37" src="https://user-images.githubusercontent.com/101457/73127732-e238db80-3fbc-11ea-9d60-2bd01a1407b3.png">


**After (example from local)**

<img width="1086" alt="Screenshot 2020-01-25 at 21 47 33" src="https://user-images.githubusercontent.com/101457/73127735-ed8c0700-3fbc-11ea-98c6-32d57233a1ab.png">


