### PR TITLE
1099: Add a "noindex" meta tag for robots - for Staging and Dev

### DIFF
--- a/developerportal/apps/common/tests/test_app_tags.py
+++ b/developerportal/apps/common/tests/test_app_tags.py
@@ -4,6 +4,9 @@ from wagtail.core.models import Page
 
 from developerportal.apps.common.constants import (
     COUNTRY_QUERYSTRING_KEY,
+    ENVIRONMENT_DEVELOPMENT,
+    ENVIRONMENT_PRODUCTION,
+    ENVIRONMENT_STAGING,
     PAGINATION_QUERYSTRING_KEY,
     ROLE_QUERYSTRING_KEY,
     TOPIC_QUERYSTRING_KEY,
@@ -13,6 +16,7 @@ from developerportal.templatetags.app_tags import (
     filename_cachebreaker_to_querystring,
     get_favicon_path,
     has_at_least_two_filters,
+    is_production_site,
     pagination_additional_filter_params,
 )
 
@@ -242,3 +246,16 @@ class AppTagsTestCase(TestCase):
             with self.subTest(case=case):
                 with override_settings(ACTIVE_ENVIRONMENT=case["input"]):
                     self.assertEqual(get_favicon_path(), case["output"])
+
+    def test_is_production_site(self):
+
+        cases = [
+            {"input": ENVIRONMENT_DEVELOPMENT, "output": False},
+            {"input": ENVIRONMENT_PRODUCTION, "output": True},
+            {"input": ENVIRONMENT_STAGING, "output": False},
+        ]
+
+        for case in cases:
+            with self.subTest(case=case):
+                with override_settings(ACTIVE_ENVIRONMENT=case["input"]):
+                    self.assertEqual(is_production_site(), case["output"])

--- a/developerportal/apps/common/tests/test_head_rendering.py
+++ b/developerportal/apps/common/tests/test_head_rendering.py
@@ -1,0 +1,33 @@
+from django.test import TestCase, override_settings
+
+from developerportal.apps.common.constants import (
+    ENVIRONMENT_DEVELOPMENT,
+    ENVIRONMENT_PRODUCTION,
+    ENVIRONMENT_STAGING,
+)
+
+
+class NoIndexMetaTagTests(TestCase):
+    def test_noindex_tag_absent_in_production_only(self):
+        """Show the <meta> noindex directive for robots is shown on dev and stage
+        but not production"""
+        cases = [
+            {"setting_val": ENVIRONMENT_DEVELOPMENT, "expected": True},
+            {"setting_val": ENVIRONMENT_PRODUCTION, "expected": False},
+            {"setting_val": ENVIRONMENT_STAGING, "expected": True},
+        ]
+
+        for case in cases:
+            with self.subTest(case=case):
+                with override_settings(ACTIVE_ENVIRONMENT=case["setting_val"]):
+                    response = self.client.get("/")
+                    if case["expected"]:
+                        self.assertContains(
+                            response, '<meta name="robots" content="noindex">', 1
+                        )
+                    else:
+                        self.assertNotContains(
+                            response,
+                            '<meta name="robots" content="noindex">',
+                            status_code=200,
+                        )

--- a/developerportal/templates/base.html
+++ b/developerportal/templates/base.html
@@ -29,6 +29,10 @@
     Visit https://www.mozilla.org/contribute for more ways to get involved and
     help support Mozilla.
     -->
+
+    {% is_production_site as is_prod %}
+    {% if not is_prod %}<meta name="robots" content="noindex">{% endif %}
+
     {% with home=request.site.root_page.specific %}
       <title>
         {% block title %}

--- a/developerportal/templatetags/app_tags.py
+++ b/developerportal/templatetags/app_tags.py
@@ -11,6 +11,7 @@ from django.utils.safestring import mark_safe
 from developerportal.apps.common.constants import (
     COUNTRY_QUERYSTRING_KEY,
     ENVIRONMENT_DEVELOPMENT,
+    ENVIRONMENT_PRODUCTION,
     ENVIRONMENT_STAGING,
     ROLE_QUERYSTRING_KEY,
     TOPIC_QUERYSTRING_KEY,
@@ -153,3 +154,8 @@ def get_favicon_path():
     filename = spec.get(settings.ACTIVE_ENVIRONMENT, DEFAULT_FAVICON)
 
     return f"img/icons/{filename}"
+
+
+@register.simple_tag
+def is_production_site():
+    return settings.ACTIVE_ENVIRONMENT == ENVIRONMENT_PRODUCTION


### PR DESCRIPTION
This changeset helps stop robots indexing the dev or staging deployments.

It adds a `"noindex"` directive via a `<meta>` tag, but not on production.

Staging and Dev (and local dev):
<img width="291" alt="Screenshot 2020-01-30 at 16 59 48" src="https://user-images.githubusercontent.com/101457/73474440-65c04700-4386-11ea-9e22-505f9036be63.png">

Production - no tag present:
<img width="242" alt="Screenshot 2020-01-30 at 16 59 45" src="https://user-images.githubusercontent.com/101457/73474681-c3ed2a00-4386-11ea-9011-9c693df5ab6a.png">


(Related issue: #1099)

## How to test

- this one is more easily done via code review, but if you have it checked out locally, you can set `ACTIVE_ENVIRONMENT="production"` or `"staging"` or `"development"` in your `settings/local.py` 