### PR TITLE
1144: Task completion survey: mute the prompt if the user dismisses it

### DIFF
--- a/developerportal/templates/survey.html
+++ b/developerportal/templates/survey.html
@@ -16,7 +16,7 @@
   <button class="mzp-c-notification-bar-button mzp-js-notification-trigger" type="button"></button>
   <p>
       Your feedback is important. Would you
-        <a target="_blank" rel="noreferrer noopener" href="{{survey_url}}" class="mzp-c-notification-bar-cta">
+        <a target="_blank" rel="noreferrer noopener" href="{{survey_url}}" class="mzp-c-notification-bar-cta js-survey-link">
           complete a short survey
         </a>
       after visiting?

--- a/src/js/task-completion-prompt.js
+++ b/src/js/task-completion-prompt.js
@@ -1,27 +1,92 @@
 /* eslint-disable prefer-template */
-const { getCookie } = require('./utils');
+const { getCookieValue, setCookieValue } = require('./utils');
+
+const SURVEY_COOKIE_NAME = 'dwf_show_task_completion_survey';
+const SURVEY_COOKIE_NEW_EXPIRY = 60 * 60 * 24 * 7 * 6; // six weeks in seconds
+const USE_SECURE_COOKIE = window.location.protocol === 'https:';
 
 /**
- * Reveals the task-completion survey prompt, as required
+ * Helper function to display the task-completion survey prompt.
+ * For now, it's revealing a pre-rendered, hidden, div in the template.
+ * In the future (once https://github.com/mozilla/protocol/pull/460 is
+ * resolved) we'll switch to an entirely client-side-rendered solution.
+ */
+
+const displaySurvey = function displaySurvey() {
+  // reveal the survey prompt, if appropriate
+  const showSurvey = getCookieValue(SURVEY_COOKIE_NAME);
+  // eslint-disable-next-line no-unused-expressions
+  if (showSurvey === 'True') {
+    const elements = document.getElementsByClassName(
+      'js-task-completion-survey',
+    );
+    // There should be 0 or 1 to reveal, but let's not assume
+    Array.from(elements).map(target => target.removeAttribute('hidden'));
+  }
+};
+
+/**
+ * Handler function to ensure the survey-triggering cookie gets set to False,
+ * which means the survey won't be shown again. Deleting the cookie means the
+ * user has chance of being asked again, but setting it to False means they
+ * won't until the cookie expires – which we set to being six weeks from here.
+ */
+
+const setSurveyCookieToFalse = function surveyCookieToFalse() {
+  let cookieString = `False;max-age=${SURVEY_COOKIE_NEW_EXPIRY}`;
+
+  if (USE_SECURE_COOKIE) {
+    cookieString = `${cookieString};secure=true;`;
+  }
+
+  setCookieValue(SURVEY_COOKIE_NAME, cookieString);
+};
+
+/**
+ * Bind a handler to the given target (a link or button) that triggers
+ * code to set the survey cookie to False upon click.
+ *
+ * @param {Element} target
+ */
+const bindCookieUpdate = function bindCookieUpdate(target) {
+  target.addEventListener('click', setSurveyCookieToFalse);
+};
+
+/**
+ * Bind handlers to the 'trigger points' in the given notification panel so that
+ * the cookie update is done when they are clicked
+ *
+ * @param {Element} notificationPanel
+ */
+
+const setupListeners = function setupListeners(notificationPanel) {
+  // eslint-disable-next-line no-debugger
+  const closeTriggers = notificationPanel.querySelectorAll(
+    '.mzp-js-notification-trigger',
+  );
+
+  // There should be 0 or 1 of each, but let's not assume
+  Array.from(closeTriggers).map(closeTrigger => bindCookieUpdate(closeTrigger));
+
+  // DISABLED FOR NOW: also set the cookie to False after visiting the survey link
+  // const surveyLinks = notificationPanel.querySelectorAll('.js-survey-link');
+  // Array.from(surveyLinks).map(surveyLink => bindCookieUpdate(surveyLink));
+};
+
+/**
+ * Reveals the task-completion survey prompt, as required, and configures
+ * event handling
  *
  * @class TaskCompletionPrompt
  */
-
 module.exports = class TaskCompletionPrompt {
   static init() {
-    const showSurvey = getCookie('dwf_show_task_completion_survey');
+    const elements = document.querySelectorAll('.js-task-completion-survey');
+    return Array.from(elements).map(element => new this(element));
+  }
 
-    if (showSurvey === 'True') {
-      const target = document.getElementsByClassName(
-        'js-task-completion-survey',
-      );
-
-      // There should be 0 or 1 to reveal, but let's not assume
-      if (target) {
-        for (let i = 0; i < target.length; i += 1) {
-          target[i].removeAttribute('hidden');
-        }
-      }
-    }
+  constructor(notificationPanel) {
+    displaySurvey();
+    setupListeners(notificationPanel);
   }
 };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -48,7 +48,7 @@ exports.parseForm = form => {
  * @param {string} name  // cookie name
  * @returns {string}  // cookie value
  */
-exports.getCookie = name => {
+exports.getCookieValue = name => {
   let cookieValue = null;
   if (document.cookie) {
     const cookies = document.cookie.split(';');
@@ -61,6 +61,34 @@ exports.getCookie = name => {
       // Does this cookie string begin with the name (and equals sign) we want?
       if (cookie.substring(0, name.length + 1) === target) {
         cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+};
+
+/**
+ * Helper function to set cookie value given a cookie name
+ *
+ * @param {string} name  // cookie name
+ * @param {string} cookieValue  // cookie value to store
+ * @returns {string}  // cookie value
+ */
+exports.setCookieValue = (name, cookieValue) => {
+  if (document.cookie) {
+    const cookies = document.cookie.split(';');
+    // eslint-disable-next-line no-restricted-syntax
+    for (let i = 0; i < cookies.length; i += 1) {
+      let cookie = cookies[i];
+      cookie = cookie.trim();
+
+      // eslint-disable-next-line prefer-template
+      const target = name + '=';
+      // Does this cookie string begin with the name (and equals sign) we want?
+      if (cookie.substring(0, name.length + 1) === target) {
+        const newCookieString = target + cookieValue;
+        document.cookie = newCookieString;
         break;
       }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,8 @@ const config = {
 
 if (process.env.NODE_ENV === 'production') {
   config.plugins = [...config.plugins, new OptimizeCssAssetsPlugin()];
+  config.devtool = 'hidden-source-map';
+} else {
+  config.devtool = 'source-map';
 }
-
 module.exports = config;


### PR DESCRIPTION
(You should have reviewed PR #1150 before looking at this one, because this builds onthat) 

This changeset adds code that makes use of the django-waffle cookie that determines whether a survey prompt should be shown or not. If its value is True, that means the survey is shown to the user. If it is False, the survey is not shown, but the cookie persists until its expiry date.

Now, when a user clicks the "X" to close/dismiss the notification, this rewrites the value stored in the cookie, to be False, not True. It also has to set a new expiry time, else it'll only exist for the life of the browser session, so we set it to six weeks from now, meaning the user will have a cookie that says "Don't ask me about a survey" for six weeks, after which time it will expire and the user _might_ then (depending on the percentage settings of the survey waffle flag on the server) see a subsequent request to complete a survey - but it will at least have been six weeks.

Note that the decision was taken to ONLY tweak the cookie when the notification is dismissed, and not when the user clicks on the link to view the survey. This seemed to be more sensible in terms of giving users a chance to lose the link/tab and choose to view it again, while also allowing them to expressly dismiss the notificaition.

(Related issue #1144)

## How to test

This will work locally (if you set `WAFFLE_SECURE=False` in your `settings/local.py`) but is also deployed to the [CDN for the dev env](https://developer-portal-cdn.dev.mdn.mozit.cloud/), so everyone can try it.

- zap your cookies for the domain, or use private browsing
- visit the site and confim you see the survey-request notification (it's being shown to 99.9% of visitors, so you should see it)
- in devtools, view your cookies - you'll see `dwf_show_task_completion_survey` is one, with a value of `True`. Note the expiry time.
<img width="509" alt="Screenshot 2020-02-03 at 17 50 52" src="https://user-images.githubusercontent.com/101457/73677672-a97cbe80-46ae-11ea-8996-de5723374c94.png">

- dismiss the notification with the `X`
<img width="943" alt="Screenshot 2020-02-03 at 14 27 35" src="https://user-images.githubusercontent.com/101457/73677685-b00b3600-46ae-11ea-86ae-2ed5821b2a80.png">

- reload the page
- confirm that the survey-request dialog is no longer shown
- view your cookies again, note that the waffle one now has a value of `False` and that its expiry is six weeks from now.
<img width="506" alt="Screenshot 2020-02-03 at 17 51 00" src="https://user-images.githubusercontent.com/101457/73677801-f1034a80-46ae-11ea-8e31-0a6a27fc0cae.png">


- also inspect the new/updated cookie and share your views on whether additional settings/parameters need to be set on it, too.  
