### PR TITLE
1162 Invalidate CDN on whitelisted flag change

### DIFF
--- a/developerportal/apps/common/tests/test_signals.py
+++ b/developerportal/apps/common/tests/test_signals.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from waffle.models import Flag
+
+from ...home.models import HomePage
+from ..constants import WAFFLE_FLAG_TASK_COMPLETION
+
+
+class CDNInvalidationOnWaffleFlagSaveTests(TestCase):
+    def setUp(self):
+        self.whitelisted_flag = Flag.objects.get(name=WAFFLE_FLAG_TASK_COMPLETION)
+        self.non_whitelisted_flag = Flag(name="test_flag")
+        self.non_whitelisted_flag.save()
+        self.homepage = HomePage.objects.get()
+
+    @mock.patch("developerportal.apps.common.wagtail_hooks.invalidate_entire_cdn.delay")
+    def test_purge_cdn_when_whitelisted_waffle_flags_saved(
+        self, mock_invalidate_entire_cdn_delay
+    ):
+        assert not mock_invalidate_entire_cdn_delay.called
+        self.whitelisted_flag.save()
+        assert mock_invalidate_entire_cdn_delay.call_count == 1
+
+    @mock.patch("developerportal.apps.common.wagtail_hooks.invalidate_entire_cdn.delay")
+    def test_purge_cdn_not_called_when_non_whitelisted_waffle_flags_saved(
+        self, mock_invalidate_entire_cdn_delay
+    ):
+        assert not mock_invalidate_entire_cdn_delay.called
+        self.non_whitelisted_flag.save()
+        assert not mock_invalidate_entire_cdn_delay.called
+        self.homepage.save()
+        assert not mock_invalidate_entire_cdn_delay.called


### PR DESCRIPTION
_Please review PR#1150 first, because this builds on behaviour in that_.

Sometimes, when a `django-waffle` Flag has been amended, especially when it's one using a Percent rule and so sets a cookie, the cached state in the CDN may no longer be a useful one (eg: setting the percentage to 0 effectively disables the Flag while keeping it present in the system.) 

We should trigger an eager CDN invalidation when such a flag is changed to ensure the user's experience is as up to date as possible. (This is a little paranoid/edge-case, but there's no harm doing it, given the low likelihood of waffle flag changes.)

(Related issue #1162)

## Key changes:

- summarise changes here, linking to commits as appropriate

## How to test

- with a local build running, go to `/django-admin/waffle/flag/` and save the `show_task_completion_survey` Flag.
- check the console fors signs of the invalidation happening: 
```
worker_1     | [2020-02-03 22:39:43,216: INFO/MainProcess] Received task: developerportal.apps.taskqueue.tasks.invalidate_entire_cdn[3102fe28-c0a2-4e3e-a6a6-5b96f20050a1]
worker_1     | [2020-02-03 22:39:43,221: INFO/ForkPoolWorker-4] [Invalidate entire CDN] Issuing purge command
```
