### PR TITLE
1172: Remove newsletter signup form and swap for button

### DIFF
--- a/developerportal/templates/organisms/newsletter-signup.html
+++ b/developerportal/templates/organisms/newsletter-signup.html
@@ -1,23 +1,12 @@
 <section id="newsletter" class="section section-background newsletter-signup">
   <div class="container">
     <h2 class="no-underline">Discover the best of web development</h2>
-    <p>Sign up for the Mozilla Developer Newsletter:</p>
-    <form action="https://www.mozilla.org/en-US/newsletter/" method="post" target="_blank">
-      <input type="hidden" name="newsletters" value="app-dev">
-      <input type="hidden" name="fmt" value="H">
-      <p>
-        <label for="newsletter-email">Email address</label>
-        <input type="email" name="email" id="newsletter-email" placeholder="you@example.com" required aria-required="true">
-      </p>
-      <p>
-        <label for="newsletter-privacy" class="mzp-u-inline">
-          <input type="checkbox" name="privacy" id="newsletter-privacy" required aria-required="true">
-          I'm okay with Mozilla handling my info as explained in this <a class="privacy-link" href="https://www.mozilla.org/privacy/websites/" target="_blank" rel="noopener noreferrer">Privacy Notice</a>.
-        </label>
-      </p>
-      <p>
-        <button type="submit" class="mzp-c-button mzp-t-small mzp-t-dark">Sign up now</button>
-      </p>
-    </form>
+    <p>Sign up for the Mozilla Developer Newsletter</p>
+    <p>
+      <a class="mzp-c-button mzp-t-small mzp-t-dark newsletter-signup-link-button"
+        href="https://www.mozilla.com/newsletter/developer/">
+        Sign up now
+      </a>
+    </p>
   </div>
 </section>

--- a/src/css/organisms/newsletter-signup.scss
+++ b/src/css/organisms/newsletter-signup.scss
@@ -11,28 +11,10 @@
     }
   }
 
-  label[for='newsletter-email'] {
-    display: inline-block;
-    margin-right: 4px;
-  }
-
-  a.privacy-link {
-    color: $color-blue-10;
-  }
-
-  input[type='email'] {
-    display: inline-block;
-  }
-
-  select {
-    width: 100%;
-
-    @media screen and (min-width: 480px) {
-      width: 200px;
+  a.newsletter-signup-link-button {
+    margin-bottom: 0px;
+    @media #{$mq-md} {
+      margin-bottom: 50px;
     }
-  }
-
-  p:last-child {
-    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
...Plus link to the *Developer* Newsletter.


At some point, the idea of POSTing from our form to another form on mozilla.org broke.

It sounds like the ideal fix would be to make a JS API call to the "basket" service,
but right now we need a rapid fix, which is to swap the submission button for a
button-styled link to the more appropriate newsletter (rather than the general one)

(Related issue #1172)

## How to test

- load it up locally or [go to dev](https://developer-portal.dev.mdn.mozit.cloud/) and view any page footer. Or just check out these screenshots:

Desktop
![Screenshot 2020-02-06 at 18 20 14](https://user-images.githubusercontent.com/101457/73966733-82bcc300-490e-11ea-8876-1a6210dbb492.png)

Mobile
![Screenshot 2020-02-06 at 18 20 19](https://user-images.githubusercontent.com/101457/73966738-83edf000-490e-11ea-9b37-aa86d3b74a50.png)
