### PR TITLE
1203: Allow Topic pages to have a ContentPage as their child page.

### DIFF
--- a/developerportal/apps/content/models.py
+++ b/developerportal/apps/content/models.py
@@ -23,7 +23,7 @@ class ContentPageTag(TaggedItemBase):
 
 
 class ContentPage(BasePage):
-    parent_page_types = ["home.HomePage", "content.ContentPage"]
+    parent_page_types = ["home.HomePage", "content.ContentPage", "topics.Topic"]
     subpage_types = ["people.People", "content.ContentPage"]
     template = "content.html"
 

--- a/developerportal/apps/content/tests/test_content.py
+++ b/developerportal/apps/content/tests/test_content.py
@@ -2,6 +2,7 @@ from developerportal.apps.common.test_helpers import PatchedWagtailPageTests
 
 from ...home.models import HomePage
 from ...people.models import People
+from ...topics.models import Topic
 from ..models import ContentPage
 
 
@@ -9,7 +10,7 @@ class ContentPageTests(PatchedWagtailPageTests):
     """Tests for the ContentPage model."""
 
     def test_content_page_parent_pages(self):
-        self.assertAllowedParentPageTypes(ContentPage, {ContentPage, HomePage})
+        self.assertAllowedParentPageTypes(ContentPage, {ContentPage, HomePage, Topic})
 
     def test_content_page_subpages(self):
         self.assertAllowedSubpageTypes(ContentPage, {ContentPage, People})

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -83,7 +83,7 @@ class ParentTopic(Orderable):
 class Topic(BasePage):
     resource_type = "topic"
     parent_page_types = ["Topics"]
-    subpage_types = ["Topic"]
+    subpage_types = ["Topic", "content.ContentPage"]
     template = "topic.html"
 
     # Content fields

--- a/developerportal/apps/topics/tests/test_topics.py
+++ b/developerportal/apps/topics/tests/test_topics.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from developerportal.apps.common.test_helpers import PatchedWagtailPageTests
 
+from ...content.models import ContentPage
 from ...home.models import HomePage
 from ..models import Topic, Topics, check_for_svg_file
 
@@ -26,7 +27,7 @@ class TopicTests(PatchedWagtailPageTests):
 
     def test_topic_page_subpages(self):
         """A topic page should not have child pages."""
-        self.assertAllowedSubpageTypes(Topic, {})
+        self.assertAllowedSubpageTypes(Topic, {ContentPage})
 
     def test_topic_page_articles(self):
         """A topic page should have article pages."""


### PR DESCRIPTION
This will make the entire landing/products and technology heirarchy easier to set up the way we need.

A topic page now allows the addition of a Content Page as a child:

![Screenshot 2020-03-09 at 17 36 57](https://user-images.githubusercontent.com/101457/76260758-6800a580-6250-11ea-9374-e9b77257c51c.png)

And the child page's URL path sits beneath that of the parent Topic page:

![Screenshot 2020-03-09 at 17 38 35](https://user-images.githubusercontent.com/101457/76260784-76e75800-6250-11ea-8612-9c8a355ccaff.png)


## How to test
Please try it out on the dev server

https://developer-portal.dev.mdn.mozit.cloud/topics/test-topic/test-subpage-topic-page/

(Related issue #1203) 