### PR TITLE
Update log format for developer-portal

### DIFF
--- a/k8s/app.deploy.yaml.j2
+++ b/k8s/app.deploy.yaml.j2
@@ -31,6 +31,7 @@ spec:
             - "--worker-class=meinheld.gmeinheld.MeinheldWorker"
             - "--bind=0.0.0.0:{{ APP_PORT }}"
             - "--access-logfile=-"
+            - "--access-logformat=%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({X_Forwarded_For}i)s"
             - "--timeout={{ APP_GUNICORN_TIMEOUT }}"
             - "developerportal.wsgi:application"
           ports:


### PR DESCRIPTION
This change set updates what gunicorn returns for its logs, specifically it now returns the referer and X-Forwarded-For header which is handy

(Related issue #1210)

## Key changes:

- Update log format for gunicorn

