### PR TITLE
1207: Add support for styling specified links as buttons in Wagtail's rich-text editor

### DIFF
--- a/developerportal/apps/common/constants.py
+++ b/developerportal/apps/common/constants.py
@@ -49,6 +49,7 @@ RICH_TEXT_FEATURES = (
     "image",
     "italic",
     "link",
+    "button-block",  # custom - see common/wagtail_hooks.py
     "ol",
     "ul",
 )

--- a/developerportal/apps/common/wagtail_hooks.py
+++ b/developerportal/apps/common/wagtail_hooks.py
@@ -1,6 +1,9 @@
 # pylint: disable=no-member
-from django.utils.html import escape
+from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.utils.html import escape, format_html
 
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 from wagtail.core import hooks
 from wagtail.core.rich_text import LinkHandler
 
@@ -24,3 +27,42 @@ class NewWindowExternalLinkHandler(LinkHandler):
 @hooks.register("register_rich_text_features")
 def register_external_link(features):
     features.register_link_type(NewWindowExternalLinkHandler)
+
+
+@hooks.register("register_rich_text_features")
+def register_button_section_feature(features):
+    """Support marking a block of links as buttons within Draftail."""
+    feature_name = "button-block"
+    type_ = "button-block"
+    tag = "div"
+    control = {
+        "type": type_,
+        "label": "",
+        "description": "Add a block will that render any links inside it as buttons",
+        "element": "div",
+        "icon": "icon icon-placeholder",
+    }
+    features.register_editor_plugin(
+        "draftail", feature_name, draftail_features.BlockFeature(control)
+    )
+    features.register_converter_rule(
+        "contentstate",
+        feature_name,
+        {
+            "from_database_format": {tag: BlockElementHandler(type_)},
+            "to_database_format": {
+                "block_map": {
+                    type_: {"element": "div", "props": {"class": "links-as-buttons"}}
+                }
+            },
+        },
+    )
+    features.default_features.append("button-block")
+
+
+@hooks.register("insert_global_admin_css", order=100)
+def global_admin_css():
+    """Slot in custom CMS CSS to render the above button-block element nicely."""
+    return format_html(
+        '<link rel="stylesheet" href="{}">', static("css/admin_extras.css")
+    )

--- a/developerportal/apps/common/wagtail_hooks.py
+++ b/developerportal/apps/common/wagtail_hooks.py
@@ -31,10 +31,16 @@ def register_external_link(features):
 
 @hooks.register("register_rich_text_features")
 def register_button_section_feature(features):
-    """Support marking a block of links as buttons within Draftail."""
+    """Support marking a group of links as buttons within Draftail (which can then be
+    styled with custom CSS in the Admin) + ensure the block enclosing the links is
+    rendered with a custom CSS class we can target in the published page."""
+
     feature_name = "button-block"
     type_ = "button-block"
     tag = "div"
+    # The value of _type contributes to an Admin CSS classname
+    # of `.Draftail-block--button-block`
+
     control = {
         "type": type_,
         "label": "",
@@ -52,7 +58,12 @@ def register_button_section_feature(features):
             "from_database_format": {tag: BlockElementHandler(type_)},
             "to_database_format": {
                 "block_map": {
-                    type_: {"element": "div", "props": {"class": "links-as-buttons"}}
+                    type_: {
+                        "element": "div",
+                        "props": {
+                            "class": "links-as-buttons"
+                        },  # This CSS class is what's used on the rendered page
+                    }
                 }
             },
         },
@@ -60,7 +71,9 @@ def register_button_section_feature(features):
     features.default_features.append("button-block")
 
 
-@hooks.register("insert_global_admin_css", order=100)
+@hooks.register(
+    "insert_global_admin_css", order=10
+)  #  positive int for `order` means it will run after Wagtail core
 def global_admin_css():
     """Slot in custom CMS CSS to render the above button-block element nicely."""
     return format_html(

--- a/src/css/admin.scss
+++ b/src/css/admin.scss
@@ -1,0 +1,12 @@
+/* Custom CSS for the Wagtail Admin */
+
+.Draftail-block--button-block {
+  border: 2px dotted gray;
+  padding: 10px 0px 10px 5px;
+  a {
+    background: black;
+    border: 2px solid black;
+    color: white;
+    padding: 3px;
+  }
+}

--- a/src/css/atoms/buttons.scss
+++ b/src/css/atoms/buttons.scss
@@ -1,0 +1,6 @@
+.links-as-buttons {
+  margin-bottom: 24px;
+  a {
+    @extend .mzp-c-button;
+  }
+}

--- a/src/css/atoms/buttons.scss
+++ b/src/css/atoms/buttons.scss
@@ -3,4 +3,8 @@
   a {
     @extend .mzp-c-button;
   }
+
+  @media #{$mq-md} {
+    margin-bottom: 100px;
+  }
 }

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -29,6 +29,7 @@
 @import 'global/section';
 
 // Atoms.
+@import 'atoms/buttons';
 @import 'atoms/code';
 @import 'atoms/embed';
 @import 'atoms/icon';

--- a/src/js/admin-extras.js
+++ b/src/js/admin-extras.js
@@ -1,0 +1,1 @@
+import '../css/admin.scss';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const config = {
   entry: {
     bundle: './src/js/index.js',
     head: './src/js/head-includes.js',
+    admin_extras: './src/js/admin-extras.js',
   },
   output: {
     filename: 'js/[name].js',
@@ -44,7 +45,7 @@ const config = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: 'css/bundle.css',
+      filename: 'css/[name].css',
     }),
   ],
 };


### PR DESCRIPTION
(Note: a big hat-tip goes to @kalobtaulien for his assistance with this, making it a much smaller change than writing an entirely new Draftail Entity. \o/ )

This changeset supports a way of marking certain links in a rich-text area as buttons, so that they are rendered as such in the published page.

(This should allow us to make pages that feature lots of buttons without the page becoming too heavy/complex, which appears to be a factor in editing hanging after a certain tipping point.)

It acheives this by adding a new button to the Draftail editor which adds a new block (a div, lightly styled with a dashed grey border) inside which one can add hyperlinks using rich-text editor's standard link button. Any links inside this block will be rendered as buttons in the published (and previewed) page, and are lightly styled to look similar within the rich-text editor itself.

Editor:
<img width="685" alt="Screenshot 2020-03-10 at 21 26 45" src="https://user-images.githubusercontent.com/101457/76361070-1d496100-6316-11ea-976e-374f11bbaff4.png">

Rendered:
<img width="713" alt="Screenshot 2020-03-10 at 21 16 50" src="https://user-images.githubusercontent.com/101457/76361090-26d2c900-6316-11ea-8014-54a3115124ac.png">

@valgrimm This changeset doesn't 100% sort out the spacing-after-buttons issue, but we can address that separately - eg with a button to add a "spacer" block if we really want it, or increase the default spacing after a rich-text area (or just after one of these new button blocks).

(Related issue #1207)

## How to test

- once this code is staged on dev, add/edit a Post or any other page with a full rich-text editor. Click the icon to add a `button-block` block and add some links inside it.
- Here's [a page](https://developer-portal.dev.mdn.mozit.cloud/topics/test-topic/example-page-links-blocks-buttons/) i made to test on dev, too