### PR TITLE
Add additional packages to support other worker_classes in gunicorn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,10 @@ django-countries==6.0
 django-redis==4.10.0
 gunicorn==20.0.4
 meinheld==1.0.1
+gevent==1.4.0
+greenlet==0.4.15
+gevent-socketio==0.3.6
+gevent-websocket==0.10.1
 mozilla-django-oidc==1.2.3
 django-storages==1.9.1
 boto3==1.12.17


### PR DESCRIPTION
This change set adds packages to support additiona; gunicorn worker_classes

(Related issue #1216)

## Key changes:

- Installs `gevent`, `greenlet`, `gevent-socketio` and `gevent-websocket` python packages
