### PR TITLE
1237 Fix notification bar css glitch

### DIFF
--- a/src/css/molecules/notification-bar.scss
+++ b/src/css/molecules/notification-bar.scss
@@ -2,12 +2,7 @@
   .mzp-c-notification-bar-cta {
     text-decoration: underline;
     &:hover {
-      color: $color-marketing-gray-40;
+      color: $color-marketing-gray-40 !important;
     }
-  }
-
-  .mzp-c-notification-bar-button {
-    right: $spacing-xs;
-    top: $spacing-xs;
   }
 }


### PR DESCRIPTION
* rollover state for CTA link
* position of Close trigger

BEFORE

<img width="778" alt="Screenshot 2020-03-11 at 22 51 07" src="https://user-images.githubusercontent.com/101457/76471810-a41c3d80-63eb-11ea-835c-83b9804e2db3.png">


AFTER

<img width="768" alt="Screenshot 2020-03-11 at 22 55 12" src="https://user-images.githubusercontent.com/101457/76471811-a4b4d400-63eb-11ea-8ba7-930ec46009a6.png">
