### PR TITLE
Move gunicorn config to its own file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN pip install -U pip
 RUN pip install -r requirements.txt --no-cache-dir
 RUN apk --purge del .build-deps
 
+COPY configs/ /app/configs/
 COPY etc/newrelic.ini /app/etc/newrelic.ini
 COPY manage.py requirements.txt /app/
 COPY developerportal/ /app/developerportal/

--- a/configs/gunicorn.py
+++ b/configs/gunicorn.py
@@ -1,0 +1,37 @@
+from os import getenv
+from multiprocessing import cpu_count
+
+bind = f"0.0.0.0:{getenv('APP_PORT', '8000')}"
+
+# Log section
+if getenv('DEBUG') == "true":
+    loglevel = 'debug'
+else:
+    loglevel = 'info'
+
+accesslog = '-'
+errorlog = '-'
+access_log_format = '%(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\" %({X_Forwarded_For}i)s"'
+
+# How long to keep connection alive, this should be timed
+# a little less than the ELB idle timeout
+keepalive = getenv('APP_GUNICORN_TIMEOUT', '118')
+
+# NOTE: use keepalive instead of timeout
+# timout = getenv('APP_GUNICORN_TIMEOUT', '118')
+
+if getenv('DJANGO_ENV') == 'dev':
+    workers = '3'
+else:
+    # Automatically figure number of workers if environment is not set
+    cpu = (cpu_count() * 2 + 1)
+    workers = getenv('APP_GUNICORN_WORKERS', cpu)
+
+worker_connections = getenv('APP_GUNICORN_WORKER_CONNECTIONS', '1000')
+worker_class = getenv('GUNICORN_WORKER_CLASS', 'gunicorn.workers.ggevent.GeventWorker')
+worker_tmp_dir = '/dev/shm'
+
+
+# Called just after a worker has been forked.
+def post_fork(server, worker):
+    server.log.info("Worker spawned (pid: %s)", worker.pid)

--- a/configs/gunicorn.py
+++ b/configs/gunicorn.py
@@ -20,7 +20,7 @@ keepalive = getenv('APP_GUNICORN_TIMEOUT', '118')
 # NOTE: use keepalive instead of timeout
 # timeout = getenv('APP_GUNICORN_TIMEOUT', '118')
 
-if getenv('DJANGO_ENV') is not None and getenv('DJANGO_ENV') == 'dev':
+if getenv('DJANGO_ENV') == 'dev':
     workers = '3'
 else:
     # Automatically figure number of workers if environment is not set

--- a/configs/gunicorn.py
+++ b/configs/gunicorn.py
@@ -4,7 +4,7 @@ from multiprocessing import cpu_count
 bind = f"0.0.0.0:{getenv('APP_PORT', '8000')}"
 
 # Log section
-if getenv('DEBUG').lower() == "true":
+if getenv('DEBUG') is not None and getenv('DEBUG').lower() == "true":
     loglevel = 'debug'
 else:
     loglevel = 'info'
@@ -20,7 +20,7 @@ keepalive = getenv('APP_GUNICORN_TIMEOUT', '118')
 # NOTE: use keepalive instead of timeout
 # timeout = getenv('APP_GUNICORN_TIMEOUT', '118')
 
-if getenv('DJANGO_ENV') == 'dev':
+if getenv('DJANGO_ENV') is not None and getenv('DJANGO_ENV') == 'dev':
     workers = '3'
 else:
     # Automatically figure number of workers if environment is not set

--- a/configs/gunicorn.py
+++ b/configs/gunicorn.py
@@ -4,7 +4,7 @@ from multiprocessing import cpu_count
 bind = f"0.0.0.0:{getenv('APP_PORT', '8000')}"
 
 # Log section
-if getenv('DEBUG').tolower() == "true":
+if getenv('DEBUG').lower() == "true":
     loglevel = 'debug'
 else:
     loglevel = 'info'

--- a/configs/gunicorn.py
+++ b/configs/gunicorn.py
@@ -4,7 +4,7 @@ from multiprocessing import cpu_count
 bind = f"0.0.0.0:{getenv('APP_PORT', '8000')}"
 
 # Log section
-if getenv('DEBUG') == "true":
+if getenv('DEBUG').tolower() == "true":
     loglevel = 'debug'
 else:
     loglevel = 'info'
@@ -18,7 +18,7 @@ access_log_format = '%(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%
 keepalive = getenv('APP_GUNICORN_TIMEOUT', '118')
 
 # NOTE: use keepalive instead of timeout
-# timout = getenv('APP_GUNICORN_TIMEOUT', '118')
+# timeout = getenv('APP_GUNICORN_TIMEOUT', '118')
 
 if getenv('DJANGO_ENV') == 'dev':
     workers = '3'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   app:
     <<: *common
-    command: gunicorn developerportal.wsgi:application --access-logfile=- --timeout=120 --worker-class=gunicorn.workers.ggevent.GeventWorker --bind=0.0.0.0:8000 --reload --workers=3
+    command: gunicorn developerportal.wsgi:application --reload --config configs/gunicorn.py
     ports:
       - '8000:8000'
       # 8000 is left exposed if you want to access it not over SSL,


### PR DESCRIPTION
This moves the gunicorn config to a config file instead of calling
command line options. This will only affect local dev for now, and there
should be another PR to actually have kubernetes use the config file as
well

(Related issue #1213 & #1211)

## Key changes:

- Moves gunicorn config to a config file
