### PR TITLE
Switch gunicorn worker class to gevent

### DIFF
--- a/k8s/app.deploy.yaml.j2
+++ b/k8s/app.deploy.yaml.j2
@@ -27,12 +27,7 @@ spec:
           args:
             - "run-program"
             - "gunicorn"
-            - "--workers={{ APP_GUNICORN_WORKERS }}"
-            - "--worker-class=meinheld.gmeinheld.MeinheldWorker"
-            - "--bind=0.0.0.0:{{ APP_PORT }}"
-            - "--access-logfile=-"
-            - "--access-logformat=%(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\" %({X_Forwarded_For}i)s"
-            - "--timeout={{ APP_GUNICORN_TIMEOUT }}"
+            - "--config=configs/gunicorn.py"
             - "developerportal.wsgi:application"
           ports:
             - containerPort: {{ APP_PORT }}


### PR DESCRIPTION
This PR switches the kubernetes deployment to use the gunicorn config
file which in turn switches the worker class to `gevent`

(Related issue #1195)

## Key changes:

- Switches config to a config file
- Switches gunicorn worker class from `meinheld` to `gevent`

## How to test

- You can test locally with `docker-compose`