### PR TITLE
1225: Update design of the Posts page

### DIFF
--- a/developerportal/apps/articles/templates/articles.html
+++ b/developerportal/apps/articles/templates/articles.html
@@ -1,26 +1,17 @@
 {% extends "base.html" %}
+{% load static %}
 {% load wagtailcore_tags %}
 
 {% comment %} For now we're not renaming CSS classes from articles to posts {% endcomment %}
 {% block body_class %}articles{% endblock %}
 
 {% block content %}
-  <main>
-    <section class="section section-pattern">
-      <div class="mzp-l-content">
-        <div class="section-header">
-          <div>
-            <h2>Posts</h2>
-            {% if page.description %}
-              <div class="page-description">
-                {{ page.description | richtext }}
-              </div>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-      {% include "organisms/filter-list.html" with type="article_or_video" resources=resources no_resources_message="No posts found" %}
-    </section>
-    {% include "organisms/newsletter-signup.html" %}
-  </main>
+
+  {% static "img/icons/article.svg" as page_icon_asset_url %}
+  {% include "molecules/header-strip.html" with content=page.title element="h1" page_icon_asset_url=page_icon_asset_url %}
+
+  <div id="posts-list">
+    {% include "organisms/filter-list.html" with type="article_or_video" resources=resources show_past_date_option=True no_resources_message="No relevant posts found" hide_pagination=False page_anchor="#posts-list" %}
+  </div>
+  {% include "organisms/newsletter-signup.html" %}
 {% endblock content %}

--- a/developerportal/templates/molecules/cards/card-article.html
+++ b/developerportal/templates/molecules/cards/card-article.html
@@ -1,36 +1,27 @@
 {% load static %}
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
-{% load app_filters %}
 
 {% image resource.image width-636 as image %}
 {% image resource.card_image width-636 as card_image %}
 {% static "img/placeholders/post_16_9.jpg" as fallback_image %}
 
-<a
-  href="{% pageurl resource %}"
-  class="card-link {% if card_number and card_number > 3 %}card-overflow{% endif %}"
-  {% if resource.is_external %}
-    target="_blank"
-    rel="noopener noreferrer"
-  {% endif %}
-  data-type="{{ resource.resource_type }}"
->
-  <div class="card {% if full_width %}card-full{% endif %}">
-    <div class="card-image" style="background-image: url('{% firstof card_image.url image.url fallback_image %}')"></div>
-    <div class="card-content">
-      <div class="card-content-main">
-        {% include "molecules/resource-meta.html" with resource=resource %}
-        <h4 class="no-underline">
-          {% firstof resource.card_title resource.title %}{% if resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}
-        </h4>
-        {% if full_width and resource.description %}
-          {{ resource.description | richtext }}
-        {% endif %}
-      </div>
-      {% if show_author and resource.authors|published %}
-        {% include "molecules/article-details.html" with date=resource.date authors=resource.authors|published disable_author_links=True %}
-      {% endif %}
+<div class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
+  <a class="mzp-c-card-block-link"
+    href="{% pageurl resource %}"
+    {% if resource.is_external %} target="_blank" rel="noopener noreferrer" {% endif %}
+    data-type="{{ resource.resource_type }}"
+  >
+    <div class="mzp-c-card-media-wrapper">
+      <img class="mzp-c-card-image" src="{% firstof card_image.url image.url fallback_image %}" alt="">
     </div>
-  </div>
-</a>
+    <div class="mzp-c-card-content card-article-content">
+      <div class="mzp-c-card-tag">
+          Article
+      </div>
+      <h2 class="mzp-c-card-title">
+        {% firstof resource.card_title resource.title %} {% if resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}
+      </h2>
+    </div>
+  </a>
+</div>

--- a/developerportal/templates/molecules/cards/card-video.html
+++ b/developerportal/templates/molecules/cards/card-video.html
@@ -6,27 +6,25 @@
 {% image resource.card_image width-636 as card_image %}
 {% static "img/placeholders/post_16_9.jpg" as fallback_image %}
 
-<a
-  href="{% pageurl resource %}"
-  class="card-link {% if resource.is_external %}js-modal-trigger{% endif %}"
-  {% if resource.is_external %}
+<div class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
+  <a class="mzp-c-card-block-link {% if resource.is_external %}js-modal-trigger{% endif %}"
+    href="{% pageurl resource %}"
+    {% if resource.is_external %}
     data-class-name="mzp-has-media"
     data-title="{{ resource.title }}"
-  {% endif %}
-  data-type="{{ resource.resource_type }}"
->
-  <div class="card {% if full_width %}card-full{% endif %}">
-    <div class="card-image" style="background-image: url('{% firstof card_image.url image.url fallback_image %}')"></div>
-    <div class="card-content">
-      <div class="card-content-main">
-        {% include "molecules/resource-meta.html" with resource=resource %}
-        <h4 class="no-underline">
-          {% firstof resource.card_title resource.title %}{% if resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}
-        </h4>
-        {% if full_width and resource.description %}
-          {{ resource.description | richtext }}
-        {% endif %}
-      </div>
+    {% endif %}
+    data-type="{{ resource.resource_type }}"
+  >
+    <div class="mzp-c-card-media-wrapper">
+      <img class="mzp-c-card-image" src="{% firstof card_image.url image.url fallback_image %}" alt="">
     </div>
-  </div>
-</a>
+    <div class="mzp-c-card-content card-article-content">
+      <div class="mzp-c-card-tag">
+         Video
+      </div>
+      <h2 class="mzp-c-card-title">
+        {% firstof resource.card_title resource.title %} {% if resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}
+      </h2>
+    </div>
+  </a>
+</div>

--- a/developerportal/templates/organisms/filter-list.html
+++ b/developerportal/templates/organisms/filter-list.html
@@ -15,9 +15,7 @@
   <div class="mzp-l-main custom-width">
     <div class="mzp-l-card-half" id="{{ type }}-cards">
       {% for resource in resources %}
-        {% if type == "article" %}
-          {% include "molecules/cards/card.html" with resource=resource.article show_author=True %}
-        {% elif type == "article_or_video" %}
+        {% if type == "article_or_video" %}
           {% if resource.video %}
             {% include "molecules/cards/card.html" with resource=resource.video %}
           {% else %}


### PR DESCRIPTION
This changeset updates the design of the Posts page, building on patterns established elsewhere in the designs

(Related issue #1225)

## How to test

- Staged on dev. Please check that internal links work and that external video and external article links also behave as expected. (External videos should play in a lightbox)
- Cross-browser testing welcome (but will be done later, too) 


## Screenshots

![Screenshot_2020-03-31 Posts(5)](https://user-images.githubusercontent.com/101457/78051058-12ae4480-7375-11ea-927b-a5afd362a947.png)

----
![Screenshot_2020-03-31 Posts(4)](https://user-images.githubusercontent.com/101457/78051072-15a93500-7375-11ea-9ac5-0402016d1443.png)
-----

![Screenshot_2020-03-31 Posts(3)](https://user-images.githubusercontent.com/101457/78051081-16da6200-7375-11ea-95e0-81f2e216a057.png)

