### PR TITLE
1271: Ensure external video on topic page opens in a modal

### DIFF
--- a/developerportal/templates/molecules/recent-work-item.html
+++ b/developerportal/templates/molecules/recent-work-item.html
@@ -17,8 +17,18 @@ Inputs:
   {% static "img/placeholders/post_16_9.jpg" as fallback_image %}
 {% endif %}
 <section class="mzp-c-card mzp-c-card-small mzp-has-aspect-16-9">
-  {% if external_page %}
-    <a href="{{ resource.url }}" class="card-link" data-type="external_page" target="_blank" rel="nofollow noopener">
+  {% if external_page or resource.is_external %}
+    <a
+      href="{{ resource.url }}"
+      class="card-link {% if resource.resource_type == 'video' %} js-modal-trigger{% endif %}"
+      data-type="{{resource.resource_type}}"
+      target="_blank"
+      rel="nofollow noopener"
+    {% if resource.resource_type == 'video' %}
+      data-class-name="mzp-has-media"
+      data-title="{{ resource.title }}"
+    {% endif %}
+    >
   {% else%}
     <a href="{% pageurl resource %}" class="card-link" data-type="{{ resource.resource_type }}">
   {% endif %}


### PR DESCRIPTION
This changeset ensures that any external videos mentioned in the 'recent work' section of the Topic page will open in a modal/lightbox, rather than taking the user to the third party site.

As part of this work, I also confirmed that external videos in the Posts list also play in a lightbox.

(Related issue #1271)


## How to test

- Code is staged on dev.
- Check that in 'Recent work' on https://developer-portal.dev.mdn.mozit.cloud/topics/test-topic/ a lightbox is used to display the test video
- Also check the same happens for the video on the Posts page (currently listed as the first item)

## Screenshots
![Screenshot 2020-04-01 at 15 47 28](https://user-images.githubusercontent.com/101457/78151152-2d91bf00-7430-11ea-961c-e0bde2d7175a.png)

