### PR TITLE
1260: Single Post page refresh

### DIFF
--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -10,6 +10,7 @@ from django.db.models import (
     Q,
     TextField,
 )
+from django.template.loader import render_to_string
 
 import readtime
 from modelcluster.contrib.taggit import ClusterTaggableManager
@@ -294,6 +295,14 @@ class Article(BasePage):
     def get_absolute_url(self):
         # For the RSS feed
         return self.full_url
+
+    @property
+    def verbose_standfirst(self):
+        """Return a marked-safe HTML snippet that can be used as a verbose standfirst"""
+
+        template = "partials/verbose_standfirst.html"
+        rendered = render_to_string(template, context={"page": self})
+        return rendered
 
     @property
     def primary_topic(self):

--- a/developerportal/apps/articles/templates/article.html
+++ b/developerportal/apps/articles/templates/article.html
@@ -27,8 +27,12 @@
   </main>
 
   <aside class="mzp-l-sidebar custom-width">
+    {% if page.authors %}
+    <h4 class="authors-header">Content by</h4>
+    {% else %}
+    {% endif %}
     {% for author_block in page.authors %}
-      {% include "molecules/cards/card-person.html" with person=author_block.value type=author_block.block_type custom_title="Author" %}
+      {% include "molecules/cards/card-person.html" with person=author_block.value type=author_block.block_type %}
     {% endfor %}
   </aside>
 </div>

--- a/developerportal/apps/articles/templates/article.html
+++ b/developerportal/apps/articles/templates/article.html
@@ -6,54 +6,34 @@
 {% block body_class %}article{% endblock %}
 
 {% block content %}
-  <main>
-    {% include "organisms/article-header.html" with title=page.title description=page.description date=page.date i=page.i authors=page.authors|published %}
-    <section class="section">
-      <div class="mzp-l-content article-content">
-        <div class="article-body">
-          <div class="resource-toolbar">
-            {% include "molecules/resource-meta.html" with resource=page read_time=read_time %}
-            {% include "molecules/resource-share.html" %}
-          </div>
-        </div>
-        <article class="article-body">
-          {% for block in page.body %}
-            {% if block.block_type == 'image' %}
-              {% include "molecules/image-block.html" with block=block %}
-            {% else %}
-              {{ block }}
-            {% endif %}
-          {% endfor %}
-          <div class="resource-toolbar resource-toolbar-bottom">
-            {% include "molecules/resource-topic-tags.html" with topics=page.topics.all %}
-            {% include "molecules/resource-share.html" %}
-          </div>
-          {% if page.authors|published %}
-            <footer class="article-authors">
-              {% for author in page.authors|published|by_key:"value" %}
-                {% include "molecules/article-author.html" with author=author %}
-              {% endfor %}
-            </footer>
-          {% endif %}
-        </article>
-        <aside class="article-sidebar">
-          {% if page.related_links %}
-            {% include "molecules/related-links.html" with links=page.related_links %}
-          {% endif %}
-          {% if page.related_resources %}
-            <h4>Read more on this topic</h4>
-            <div class="article-sidebar-cards">
-              {% for resource in page.related_resources|slice:":3" %}
-                {% include "molecules/cards/card.html" with resource=resource %}
-              {% endfor %}
-            </div>
-          {% endif %}
-          {% if page.primary_topic %}
-            {% include "molecules/card-topic.html" with topic=page.primary_topic %}
-          {% endif %}
-        </aside>
+
+{% static "img/icons/article.svg" as page_icon_asset_url %}
+{% include "molecules/header-strip.html" with content=page.title element="h1" standfirst=page.verbose_standfirst %}
+
+<div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-right content-page">
+  <main role="main" class="mzp-l-main custom-width">
+    <article class="article-body">
+      {% for block in page.body %}
+        {% if block.block_type == 'image' %}
+          {% include "molecules/image-block.html" with block=block %}
+        {% else %}
+          {{ block }}
+        {% endif %}
+      {% endfor %}
+      <div class="resource-toolbar resource-toolbar-bottom">
+        {% include "molecules/resource-share.html" %}
       </div>
-    </section>
-    {% include "organisms/newsletter-signup.html" %}
+    </article>
   </main>
+
+  <aside class="mzp-l-sidebar custom-width">
+    {% for author_block in page.authors %}
+      {% include "molecules/cards/card-person.html" with person=author_block.value type=author_block.block_type custom_title="Author" %}
+    {% endfor %}
+  </aside>
+</div>
+
+{% include "organisms/article-read-more.html" with page=page %}
+
+{% include "organisms/newsletter-signup.html" %}
 {% endblock content %}

--- a/developerportal/apps/articles/templates/partials/verbose_standfirst.html
+++ b/developerportal/apps/articles/templates/partials/verbose_standfirst.html
@@ -1,0 +1,7 @@
+{% load wagtailcore_tags %}
+<p class="first-deck">
+  {{page.read_time}} | {{page.date|date}}
+</p>
+{% if page.description %}
+{{page.description|richtext}}
+{% endif %}

--- a/developerportal/templates/molecules/cards/card-person.html
+++ b/developerportal/templates/molecules/cards/card-person.html
@@ -11,17 +11,26 @@
 {% endif %}
 
 <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
-  {% if type == 'speaker' or type == 'person' %}
+  {% if type == 'speaker' or type == 'person' or type == 'author' %}
     <a href="{% pageurl person %}" class="mzp-c-card-block-link" data-type="{{ person.resource_type }}">
   {% endif %}
   {% if type == 'external_speaker' and person.url %}
+    <a href="{{ person.url }}" class="mzp-c-card-block-link" data-type="{{ person.resource_type }}" target="_blank" rel="nofollow noreferrer noopener">
+  {% endif %}
+  {% if type == 'external_author' and person.url %}
     <a href="{{ person.url }}" class="mzp-c-card-block-link" data-type="{{ person.resource_type }}" target="_blank" rel="nofollow noreferrer noopener">
   {% endif %}
       <div class="mzp-c-card-media-wrapper">
         <img class="mzp-c-card-image" src="{% firstof img.url fallback_url %}" alt="">
       </div>
       <div class="mzp-c-card-content">
-        <div class="mzp-c-card-tag">{{person.get_role_display}}</div>
+        <div class="mzp-c-card-tag">
+          {% if custom_title %}
+            {{custom_title}}
+          {% else %}
+            {{person.get_role_display}}
+          {% endif %}
+        </div>
         <h2 class="mzp-c-card-title">
           <span>
             {{ person.title }}

--- a/developerportal/templates/molecules/header-strip.html
+++ b/developerportal/templates/molecules/header-strip.html
@@ -19,7 +19,7 @@
       {% if not skip_standfirst %}
       <div class="standfirst-wrapper">
       {% if standfirst %}
-        <div class="plaintext-standfirst">
+        <div class="custom-standfirst">
           {{standfirst}}
         </div>
       {% else %}

--- a/developerportal/templates/organisms/article-read-more.html
+++ b/developerportal/templates/organisms/article-read-more.html
@@ -1,0 +1,23 @@
+{% load wagtailcore_tags %}
+
+{% if page.related_resources %}
+<div class="article-read-more">
+  <div class="mzp-l-content">
+    <div class="section-header">
+      <h4>Read more on this topic
+        <span>
+          <a href="{% pageurl directory_pages.articles %}?topic={{ page.primary_topic.slug }}">See more</a>
+        </span>
+      </h4>
+    </div>
+
+    <div class="mzp-l-card-third">
+    {% for page in page.related_resources|slice:":3" %}
+      <div class="mzp-c-card mzp-c-card-small mzp-has-aspect-16-9">
+          {% include "molecules/card-featured.html" with resource=page block_type=page.block_type %}
+      </div>
+    {% endfor %}
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/developerportal/templates/organisms/people-section.html
+++ b/developerportal/templates/organisms/people-section.html
@@ -10,13 +10,13 @@
 
 <div class="mzp-l-content people-section">
   <div class="section-header">
-    <h2>{{ title|default:"People" }}
+    <h4>{{ title|default:"People" }}
     {% if show_link and directory_pages.people %}
       <span>
         <a href="{% pageurl directory_pages.people %}{% if is_topic %}?topic={{ page.slug }}{% endif %}">See more</a>
       </span>
     {% endif %}
-    </h2>
+    </h4>
   </div>
 
   {# Render cards side by side, up to three, always same width #}

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -67,6 +67,7 @@
 
 // Organisms.
 @import 'organisms/article-header';
+@import 'organisms/article-read-more';
 @import 'organisms/event-agenda';
 @import 'organisms/event-speakers';
 @import 'organisms/featured';

--- a/src/css/molecules/header-strip.scss
+++ b/src/css/molecules/header-strip.scss
@@ -2,6 +2,7 @@
   background-color: $color-black;
   color: $color-white;
   @media #{$mq-md} {
+    padding: $spacing-md 0px;
     margin-bottom: $layout-xl;
   }
 
@@ -53,8 +54,9 @@
     .standfirst-wrapper {
       @media #{$mq-sm} {
         max-width: 66%;
+        margin-bottom: 16px;
       }
-      .plaintext-standfirst {
+      .custom-standfirst {
         clear: both;
       }
     }

--- a/src/css/molecules/header-strip.scss
+++ b/src/css/molecules/header-strip.scss
@@ -3,7 +3,7 @@
   color: $color-white;
   @media #{$mq-md} {
     padding: $spacing-md 0px;
-    margin-bottom: $layout-xl;
+    margin-bottom: 76px; // + 24px from mzp-l-content == 100px
   }
 
   .icon-wrapper {

--- a/src/css/molecules/item-topic-link.scss
+++ b/src/css/molecules/item-topic-link.scss
@@ -6,7 +6,7 @@
   }
   h3,
   h4 {
-    font-family: Inter, X-LocaleSpecific, sans-serif;
+    font-family: $body-font-family;
     font-size: 1.5rem;
   }
   h4 {
@@ -18,7 +18,7 @@
   }
 
   .mzp-c-card-title span {
-    font-family: Inter, X-LocaleSpecific, sans-serif;
+    font-family: $body-font-family;
     display: block;
     margin: $spacing-sm auto;
   }

--- a/src/css/organisms/article-read-more.scss
+++ b/src/css/organisms/article-read-more.scss
@@ -2,7 +2,7 @@
   .section-header {
     padding: $spacing-sm 0px $spacing-xl;
     h4 {
-      font-family: Inter, X-LocaleSpecific, sans-serif;
+      font-family: $body-font-family;
 
       span {
         display: inline-block;

--- a/src/css/organisms/article-read-more.scss
+++ b/src/css/organisms/article-read-more.scss
@@ -1,0 +1,14 @@
+.article-read-more {
+  .section-header {
+    padding: $spacing-sm 0px $spacing-xl;
+    h4 {
+      font-family: Inter, X-LocaleSpecific, sans-serif;
+
+      span {
+        display: inline-block;
+        padding-left: $spacing-sm;
+        font-size: 0.6em;
+      }
+    }
+  }
+}

--- a/src/css/organisms/homepage-header.scss
+++ b/src/css/organisms/homepage-header.scss
@@ -24,14 +24,14 @@
   }
 
   .c-primary-cta-title {
-    font-family: Inter, X-LocaleSpecific, sans-serif;
+    font-family: $body-font-family;
     font-size: 3rem;
     line-height: 1.1;
     margin-bottom: 0px;
   }
 
   .c-primary-cta-desc {
-    font-family: Inter, X-LocaleSpecific, sans-serif;
+    font-family: $body-font-family;
     font-size: 1.125rem;
     line-height: 1.5;
     margin-top: $spacing-md;

--- a/src/css/organisms/people-section.scss
+++ b/src/css/organisms/people-section.scss
@@ -2,7 +2,7 @@
   .section-header {
     padding: $spacing-sm 0px $spacing-xl;
     h4 {
-      font-family: Inter, X-LocaleSpecific, sans-serif;
+      font-family: $body-font-family;
 
       span {
         display: inline-block;

--- a/src/css/organisms/people-section.scss
+++ b/src/css/organisms/people-section.scss
@@ -1,12 +1,13 @@
 .people-section {
   .section-header {
     padding: $spacing-sm 0px $spacing-xl;
+    h4 {
+      font-family: Inter, X-LocaleSpecific, sans-serif;
 
-    h2 {
       span {
         display: inline-block;
         padding-left: $spacing-sm;
-        font-size: $small-font-size;
+        font-size: 0.6em;
       }
     }
   }

--- a/src/css/organisms/topic-recent-work.scss
+++ b/src/css/organisms/topic-recent-work.scss
@@ -2,7 +2,7 @@
   background-color: $color-marketing-gray-20;
 
   h4 {
-    font-family: Inter, X-LocaleSpecific, sans-serif;
+    font-family: $body-font-family;
     margin: $spacing-md 0 $spacing-2xl;
   }
 }

--- a/src/css/templates/article.scss
+++ b/src/css/templates/article.scss
@@ -5,4 +5,7 @@ body.article {
     }
     margin-bottom: $spacing-2xl;
   }
+  .authors-header {
+    font-family: $body-font-family;
+  }
 }

--- a/src/css/templates/article.scss
+++ b/src/css/templates/article.scss
@@ -1,57 +1,8 @@
-.article-content {
-  display: grid;
-  grid-column-gap: $grid-gap-mobile;
-  grid-row-gap: 24px;
-  grid-template-columns: [body-start sidebar-start] 1fr [sidebar-end body-end];
-
-  @media #{$mq-md} {
-    column-gap: $grid-gap;
-    grid-template-columns:
-      [body-start] repeat(8, 1fr) [body-end sidebar-start] repeat(4, 1fr)
-      [sidebar-end];
-  }
-}
-
-.article-body {
-  grid-column: body;
-  overflow-x: auto;
-
-  h3,
-  h4,
-  h5,
-  h6 {
-    &:not(.no-underline) {
-      background: none;
+body.article {
+  .resource-toolbar {
+    @media #{$mq-md} {
+      float: right;
     }
-  }
-
-  p,
-  li {
-    color: $color-nevada;
-  }
-
-  .mzp-c-button {
-    margin-left: 2px;
-  }
-}
-
-.article-sidebar {
-  grid-column: sidebar;
-}
-
-.article-sidebar-cards {
-  margin-bottom: 24px;
-
-  .card-link {
-    display: block;
-    margin-bottom: 24px;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  .card:not(:last-child) {
-    margin-bottom: 24px;
+    margin-bottom: $spacing-2xl;
   }
 }


### PR DESCRIPTION
This changeset lays in a new design for the Post/Article page.

(Related issue #1260)

A few niggles noticed, and all feedback welcome @malqinneh @valgrimm 

- the related article cards below show the full description of the page (default behaviour, and applies also to the Featured cards), so the page editor should configure a shorter "card description" (in the Card tab for the relevant linked pages). OR we don't include any description text.
- multiple authors make the page very busy!

- in general the author card image is quite large/dominating

- in mobile view, the authors sidebar could do with a header to explain it before you reach the pictures of the people, OR we just hide it entirely in mobile view

## Screenshots

![Screenshot_2020-04-01 Into the Depths The Technical Details Behind AV1](https://user-images.githubusercontent.com/101457/78192514-36a28080-7470-11ea-98c6-48c489257f08.png)

----

![Screenshot_2020-04-01 Into the Depths The Technical Details Behind AV1](https://user-images.githubusercontent.com/101457/78192497-31ddcc80-7470-11ea-8b27-5f9855fe89cd.jpg)

----

![Screenshot_2020-04-01 Into the Depths The Technical Details Behind AV1(1)](https://user-images.githubusercontent.com/101457/78192511-3609ea00-7470-11ea-8200-84e01a44611e.png)

----

## Key changes:

- summarise changes here, linking to commits as appropriate

## How to test

- Staged on dev


