### PR TITLE
1270: Stop marking external links with a special icon

### DIFF
--- a/developerportal/apps/common/wagtail_hooks.py
+++ b/developerportal/apps/common/wagtail_hooks.py
@@ -18,10 +18,7 @@ class NewWindowExternalLinkHandler(LinkHandler):
         href = attrs["href"]
         # Let's add the target attr, and also rel="noopener" + noreferrer fallback.
         # See https://github.com/whatwg/html/issues/4078.
-        return (
-            '<a href="%s" class="external-link" target="_blank" '
-            'rel="noopener noreferrer">' % escape(href)
-        )
+        return '<a href="%s" target="_blank" rel="noopener noreferrer">' % escape(href)
 
 
 @hooks.register("register_rich_text_features")

--- a/developerportal/templates/atoms/icons/external.svg
+++ b/developerportal/templates/atoms/icons/external.svg
@@ -1,4 +1,0 @@
-{% load app_tags %}
-
-{% random_hash as hash %}
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path d="M13.269 1.6H9.6a.8.8 0 1 1 0-1.6h5.6a.8.8 0 0 1 .8.8v5.6a.8.8 0 1 1-1.6 0V2.731L8.566 8.566a.8.8 0 1 1-1.132-1.132L13.27 1.6zM5.6 0a.8.8 0 1 1 0 1.6H2.4a.8.8 0 0 0-.8.8v11.2a.8.8 0 0 0 .8.8h11.2a.8.8 0 0 0 .8-.8v-3.2a.8.8 0 1 1 1.6 0v3.2a2.4 2.4 0 0 1-2.4 2.4H2.4A2.4 2.4 0 0 1 0 13.6V2.4A2.4 2.4 0 0 1 2.4 0h3.2z" id="{{ hash }}-a"/></defs><g fill="none" fill-rule="evenodd"><mask id="{{ hash }}-b" fill="#fff"><use xlink:href="#{{ hash }}-a"/></mask><use fill="currentColor" fill-rule="nonzero" xlink:href="#{{ hash }}-a"/><path fill="currentColor" mask="url(#{{ hash }}-b)" d="M0 0h16v16H0z"/></g></svg>

--- a/developerportal/templates/molecules/card-featured.html
+++ b/developerportal/templates/molecules/card-featured.html
@@ -43,11 +43,6 @@ Note that this partial needs wrapping with a div and a section with the appropri
       <span>
         {% firstof resource.card_title resource.title %}
       </span>
-      {% if external_page or resource.is_external %}
-      <span class="no-wrap">&#65279;<span class="icon icon-external">
-          {% include "atoms/icons/external.svg" %}
-      </span></span>
-      {% endif %}
     </h2>
     <div class="mzp-c-card-desc">
       {% if resource.card_description %}

--- a/developerportal/templates/molecules/cards/card-article.html
+++ b/developerportal/templates/molecules/cards/card-article.html
@@ -20,7 +20,7 @@
           Article
       </div>
       <h2 class="mzp-c-card-title">
-        {% firstof resource.card_title resource.title %} {% if resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}
+        {% firstof resource.card_title resource.title %}
       </h2>
     </div>
   </a>

--- a/developerportal/templates/molecules/cards/card-event.html
+++ b/developerportal/templates/molecules/cards/card-event.html
@@ -25,7 +25,7 @@
         {{ resource.event_dates_full|safe }}
       </div>
       <h2 class="mzp-c-card-title">
-        {% firstof resource.card_title resource.title %} {% if resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}
+        {% firstof resource.card_title resource.title %}
       </h2>
 
       {% make_list_from_args resource.city resource.country as simple_address %}

--- a/developerportal/templates/molecules/cards/card-video.html
+++ b/developerportal/templates/molecules/cards/card-video.html
@@ -23,7 +23,7 @@
          Video
       </div>
       <h2 class="mzp-c-card-title">
-        {% firstof resource.card_title resource.title %} {% if resource.is_external %}<span class="no-wrap">&#65279;<span class="icon icon-external">{% include "atoms/icons/external.svg" %}</span></span>{% endif %}
+        {% firstof resource.card_title resource.title %}
       </h2>
     </div>
   </a>

--- a/developerportal/templates/molecules/related-links.html
+++ b/developerportal/templates/molecules/related-links.html
@@ -10,9 +10,6 @@
       {% for link in links|by_key:"value" %}
         <li>
           <a href="{{ link.url }}" target="_blank" rel="noopener noreferrer">
-            <span class="icon icon-external">
-              {% include "atoms/icons/external.svg" %}
-            </span>
             <span class="related-links-link-text">
               {{ link.title }}
             </span>

--- a/developerportal/templates/organisms/event-agenda.html
+++ b/developerportal/templates/organisms/event-agenda.html
@@ -27,7 +27,7 @@
         {% elif agenda_item.external_speaker.name %}
           {% with agenda_item.external_speaker as speaker %}
             {% if speaker.url %}
-              <a href="{{ speaker.url }}" class="external-link" target="_blank" rel="nofollow noopener">
+              <a href="{{ speaker.url }}" target="_blank" rel="nofollow noopener">
                 {{ speaker.name }}
               </a>
             {% else %}

--- a/developerportal/templates/organisms/event-map.html
+++ b/developerportal/templates/organisms/event-map.html
@@ -5,7 +5,7 @@
     <div class="h-card">
       <h5 class="p-name no-underline">
         {% if resource.venue_url %}
-        <a href="{{ resource.venue_url }}" class="u-url external-link" target="_blank" rel="nofollow noopener">
+        <a href="{{ resource.venue_url }}" class="u-url" target="_blank" rel="nofollow noopener">
           {{ resource.venue_name }}
         </a>
         {% else %}

--- a/src/css/molecules/card.scss
+++ b/src/css/molecules/card.scss
@@ -552,12 +552,6 @@
   flex-direction: column;
   flex-grow: 1;
   padding: 24px;
-
-  .icon-external {
-    position: relative;
-    margin-left: 10px;
-    top: -2px;
-  }
 }
 
 .card-content-main {

--- a/src/css/molecules/related-links.scss
+++ b/src/css/molecules/related-links.scss
@@ -42,8 +42,4 @@
       }
     }
   }
-
-  .icon-external {
-    margin-right: 16px;
-  }
 }


### PR DESCRIPTION
* Drop markup that includes the external.svg
* Drop related CSS
* Drop external.svg icon

(Related issue #1270)

## How to test

- Staged on dev. Add an external video/post/event to a relevant page and you'll see you can still follow the link in a new tab as before, but you won't see the external icon any more


## Screenshots

Just an example...

**BEFORE**

![Screenshot 2020-04-02 at 13 57 48](https://user-images.githubusercontent.com/101457/78252031-20390b00-74ea-11ea-9e50-fc92f7855c88.png)


**AFTER**

![Screenshot 2020-04-02 at 13 58 31](https://user-images.githubusercontent.com/101457/78252044-24652880-74ea-11ea-971c-6e53d865647d.png)
