### PR TITLE
1233  add ie11 polyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10287,8 +10287,7 @@
     "promise-polyfill": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
-      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
-      "dev": true
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
     },
     "prompts": {
       "version": "2.3.2",
@@ -12631,8 +12630,7 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-      "dev": true
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "js-cookie": "2.2.1"
+    "js-cookie": "2.2.1",
+    "promise-polyfill": "8.1.3",
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@mozilla-protocol/core": "11.0.2",

--- a/src/js/newsletter-subscription.js
+++ b/src/js/newsletter-subscription.js
@@ -6,6 +6,7 @@ const NEWSLETTER_SUBSCRIBE_URL = 'https://www.mozilla.org/en-US/newsletter/';
  * @returns {string} URI-encoded string
  */
 function getPayloadString(form) {
+  let retval = null;
   if (typeof URLSearchParams === 'undefined') {
     // if we lack URLSearchParams or a fully-featured FormData (eg: IE11)
     // let's just manually extract the data we need
@@ -16,11 +17,11 @@ function getPayloadString(form) {
       const field = formInputs[i];
       pairs.push(`${field.name}=${encodeURIComponent(field.value)}`);
     }
-    return pairs.join('&');
-    // eslint-disable-next-line no-else-return
+    retval = pairs.join('&');
   } else {
-    return new URLSearchParams(new FormData(form)).toString();
+    retval = new URLSearchParams(new FormData(form)).toString();
   }
+  return retval;
 }
 
 /**

--- a/src/js/newsletter-subscription.js
+++ b/src/js/newsletter-subscription.js
@@ -6,9 +6,7 @@ const NEWSLETTER_SUBSCRIBE_URL = 'https://www.mozilla.org/en-US/newsletter/';
  * @returns {string} URI-encoded string
  */
 function getPayloadString(form) {
-  try {
-    return new URLSearchParams(new FormData(form)).toString();
-  } catch (err) {
+  if (typeof URLSearchParams === 'undefined') {
     // if we lack URLSearchParams or a fully-featured FormData (eg: IE11)
     // let's just manually extract the data we need
     const formInputs = form.getElementsByTagName('input');
@@ -19,6 +17,9 @@ function getPayloadString(form) {
       pairs.push(`${field.name}=${encodeURIComponent(field.value)}`);
     }
     return pairs.join('&');
+    // eslint-disable-next-line no-else-return
+  } else {
+    return new URLSearchParams(new FormData(form)).toString();
   }
 }
 

--- a/src/js/newsletter-subscription.js
+++ b/src/js/newsletter-subscription.js
@@ -1,5 +1,27 @@
 const NEWSLETTER_SUBSCRIBE_URL = 'https://www.mozilla.org/en-US/newsletter/';
 
+/** Opinionated function for extracting data from the form without needing FormData
+ *
+ * @param {object} form element
+ * @returns {string} URI-encoded string
+ */
+function getPayloadString(form) {
+  try {
+    return new URLSearchParams(new FormData(form)).toString();
+  } catch (err) {
+    // if we lack URLSearchParams or a fully-featured FormData (eg: IE11)
+    // let's just manually extract the data we need
+    const formInputs = form.getElementsByTagName('input');
+    const pairs = [];
+
+    for (let i = 0; i < formInputs.length; i += 1) {
+      const field = formInputs[i];
+      pairs.push(`${field.name}=${encodeURIComponent(field.value)}`);
+    }
+    return pairs.join('&');
+  }
+}
+
 /**
  * Posts serialized data from the given form to the subscription endpoint,
  * return the JSON result
@@ -14,7 +36,7 @@ function submitNewsletterSubscription(form) {
       'X-Requested-With': 'XMLHttpRequest',
       'Content-type': 'application/x-www-form-urlencoded',
     },
-    body: new URLSearchParams(new FormData(form)).toString(),
+    body: getPayloadString(form),
   }).then((response) => response.json());
 }
 

--- a/src/js/polyfills.js
+++ b/src/js/polyfills.js
@@ -164,3 +164,35 @@ if (!Object.remove) {
     });
   })([Element.prototype, CharacterData.prototype, DocumentType.prototype]);
 }
+
+// from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
+if (typeof Object.assign !== 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, 'assign', {
+    value: function assign(target, varArgs) {
+      // .length of function is 2
+      'use strict';
+      if (target === null || target === undefined) {
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource !== null && nextSource !== undefined) {
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true,
+  });
+}

--- a/src/js/polyfills.js
+++ b/src/js/polyfills.js
@@ -1,4 +1,11 @@
 /* eslint-disable */
+
+// import promise polyfill to set it up - see https://github.com/taylorhakes/promise-polyfill
+import 'promise-polyfill/src/polyfill';
+
+// import fetch polyfill to set it up - see https://github.com/github/fetch
+import 'whatwg-fetch';
+
 // source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#Polyfill
 // Production steps of ECMA-262, Edition 6, 22.1.2.1
 if (!Array.from) {

--- a/src/js/tests/newsletter-subscription.test.js
+++ b/src/js/tests/newsletter-subscription.test.js
@@ -67,18 +67,19 @@ test('Happy path', async () => {
   form.submit();
 
   expect(fetch.mock.calls.length).toEqual(1);
-
-  expect(fetch.mock.calls[0][1].headers).toEqual({
-    'X-Requested-With': 'XMLHttpRequest',
-    'Content-type': 'application/x-www-form-urlencoded',
-  });
-  expect(fetch.mock.calls[0][1].method).toEqual('POST');
-  expect(fetch.mock.calls[0][1].body).toEqual(
-    'newsletters=app-dev&fmt=H&email=test%40example.com',
-  );
-  expect(fetch.mock.calls[0][0]).toEqual(
-    'https://www.mozilla.org/en-US/newsletter/',
-  );
+  expect(fetch.mock.calls).toEqual([
+    [
+      'https://www.mozilla.org/en-US/newsletter/',
+      {
+        body: 'newsletters=app-dev&fmt=H&email=test%40example.com',
+        headers: {
+          'Content-type': 'application/x-www-form-urlencoded',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        method: 'POST',
+      },
+    ],
+  ]);
 
   // Show the content in js-newsletter-fields has been updated after a successful POST,
   // but to do that we need to pause a moment
@@ -92,10 +93,11 @@ test('Happy path', async () => {
   );
 });
 
+/* Testing that the overall behaviour still works with IE11, which has
+ * no URLSearchParams or complete FormData implementation
+ * Store original implementation */
+
 test('IE11 manual fallback', async () => {
-  // Testing that the overall behaviour still works with IE11, which has
-  // no URLSearchParams or complete FormData implementation
-  // Store original implementation
   const originalURLSearchParams = URLSearchParams;
 
   // eslint-disable-next-line no-global-assign
@@ -115,20 +117,22 @@ test('IE11 manual fallback', async () => {
   form.submit();
 
   expect(fetch.mock.calls.length).toEqual(1);
-
-  expect(fetch.mock.calls[0][1].headers).toEqual({
-    'X-Requested-With': 'XMLHttpRequest',
-    'Content-type': 'application/x-www-form-urlencoded',
-  });
-  expect(fetch.mock.calls[0][1].method).toEqual('POST');
-  expect(fetch.mock.calls[0][1].body).toEqual(
-    'newsletters=app-dev&fmt=H&email=test%40example.com&privacy=checked',
-    // The manual fallback also sends confirmation that the privacy checkbox was ticked,
-    // because it assembles a payload from all fields
-  );
-  expect(fetch.mock.calls[0][0]).toEqual(
-    'https://www.mozilla.org/en-US/newsletter/',
-  );
+  expect(fetch.mock.calls).toEqual([
+    [
+      'https://www.mozilla.org/en-US/newsletter/',
+      {
+        body:
+          /* The manual fallback also sends confirmation that the privacy checkbox was ticked,
+           * because it assembles a payload from all fields */
+          'newsletters=app-dev&fmt=H&email=test%40example.com&privacy=checked',
+        headers: {
+          'Content-type': 'application/x-www-form-urlencoded',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        method: 'POST',
+      },
+    ],
+  ]);
 
   // Show the content in js-newsletter-fields has been updated after a successful POST,
   // but to do that we need to pause a moment


### PR DESCRIPTION
This changeset addresses functional failures in IE11 due to unsupported JS APIs

* Fix newsletter signup failure in IE11 due to lack of native browser support

  * Add polyfill for `fetch` (which in turn required a `Promise` polyfill)
  * Add workaround for absence of URLSearchParams in IE11 and a fully-featured FormDaga implementation - rather than adding yet more (large) polyfills, some more manual code was a more workable solution

* Add in Object.assign polyfill (from MDN docs) so that the light box will work for viewing external videos within the site in IE11

(Related issue #1233)

## How to test

- Code will be staged on the dev server.  Using Browserstack please confirm you can:
* Sign up to the newsletter from the footer in IE11 and also in evergreen Firefox
* View an external video (see the one at the top of the /posts/) page in a lightbox in IE11 and evergreen Firefox