### PR TITLE
1264: Simple styling for the Videos page (at /videos/) just in case i…

### DIFF
--- a/developerportal/apps/videos/models.py
+++ b/developerportal/apps/videos/models.py
@@ -49,6 +49,11 @@ class VideoTopic(Orderable):
 
 
 class Videos(BasePage):
+    # IMPORTANT: The Videos page has to exist in the CMS ( at /videos/) so that
+    # it can be the parent page of actual Video pages eg, but it is not intended
+    # to be shown in menus nor accessed directly, so it is only ever
+    # in existence in draft form.
+
     parent_page_types = ["home.HomePage"]
     subpage_types = ["Video"]
     template = "videos.html"

--- a/developerportal/apps/videos/templates/videos.html
+++ b/developerportal/apps/videos/templates/videos.html
@@ -4,15 +4,30 @@
 {% block body_class %}videos{% endblock %}
 
 {% block content %}
+  {% comment %}
+
+  The Videos page has to exist in the CMS ( at /videos/) so that it can be the
+  parent page of actual Video pages eg (/videos/my-video-page/), but it
+  is not intended to be shown in menus nor accessed directly, so it is only ever
+  in existence in draft form.
+
+  As such, this template only has basic styling as a simple safety net in case
+  the page is made live (either in error or deliberately, before additional
+  styling is added)
+
+  {% endcomment %}
+
   <main role="main">
-    <ul>
-      {% for video in page.videos.all %}
-        <li>
-          <a href="{% pageurl video %}">
-            {{ video.title }}
-          </a>
-        </li>
-      {% endfor %}
-    </ul>
+    <div class="mzp-l-content">
+      <ul>
+        {% for video in page.videos.all %}
+          <li>
+            <a href="{% pageurl video %}">
+              {{ video.title }}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
   </main>
 {% endblock content %}


### PR DESCRIPTION
This changeset adds simple/basic styling for the Videos page (at /videos/) just in case it's ever published in error. It is not a highly functional page, just a list of links to all published `Video` pages in the CMS.

**Context:** 
The Videos page has to exist in the CMS ( at /videos/) so that it can be the parent page of actual Video pages eg (/videos/my-video-page/), but it is not intended to be shown in menus nor accessed directly, so it is only ever in existence in draft form.

As such, this template only has basic styling as a simple safety net in case the page is made live (either in error or deliberately, before additional styling is added)

## How to test

- Code is up on Dev. View the Draft of the Videos page to see what the page WOULD look like if it were ever published: https://developer-portal.dev.mdn.mozit.cloud/admin/pages/5/view_draft/


Example from local dev:
![Screenshot 2020-05-04 at 12 46 28](https://user-images.githubusercontent.com/101457/80964219-5e3a8f00-8e08-11ea-8146-4f11a6f31e4f.png)


