### PR TITLE
1312: Navigation accessibility fixup

### DIFF
--- a/developerportal/templates/header.html
+++ b/developerportal/templates/header.html
@@ -20,7 +20,7 @@
                     {% with child_pages=page.get_children.public.live.in_menu %}
                       <li class="mzp-c-menu-category{% if child_pages %} mzp-has-drop-down mzp-js-expandable{% endif %}">
                         {% if child_pages %}
-                        <span class="mzp-c-menu-title" aria-haspopup="true" aria-controls="mzp-c-menu-panel-{{ page.slug }}">{{ page.title }}</span>
+                        <a href="#" class="mzp-c-menu-title" aria-haspopup="true" aria-controls="mzp-c-menu-panel-{{ page.slug }}">{{ page.title }}</a>
                         {% else %}
                         <a class="mzp-c-menu-title" href="{{ page.url }}">
                           {{ page.title }}


### PR DESCRIPTION
This changeset addresses an issue with the navigation that meant the two sections with drop-downs were not accessible via keyboard navigation. 

They now are:

<img width="1339" alt="Screenshot 2020-05-04 at 23 22 01" src="https://user-images.githubusercontent.com/101457/81020005-c7012600-8e5f-11ea-950c-52c228d1d3b6.png">

(Related issue #1312)

## How to test

Code is deployed to the [Dev server](https://developer-portal.dev.mdn.mozit.cloud) (or you can check out this branch) Best to test this in Chrome or Safari if on a Mac as the Firefox needs some prodding to get it to behave the same way :)

- Go to the Dev site. 
- Click in the URL bar 
- Start tapping tab and keep tapping it.
- You will notice that focus for `Products & Technologies` and `Communities` is NO LONGER skipped
- Use Shift + Tab to cycle back if need be
- When `Products & Technologies` or `Communities` is highlighted, hit `Enter` to make the sub-section fold out. 
- Continue tabbing to see focus move through all the child items and then back up to the next main nav item (eg `Events`)
- Shift-Tab backwards a bit. Hitting enter on a subnav item of `Communities` of `Products & Technologies` (eg `Rust`) will load that page.
