### PR TITLE
Added a test target to test k8s manifest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,22 @@ def deploy(config, environment, cluster) {
   dir('k8s') {
     try {
 
+      // Verify if k8s manifest is legit
+      notify_slack([
+        status: "Verifying kubernetes deployment manifest (cluster: ${cluster})",
+        message: "developer-portal commit ${tag}"
+      ])
+
+      sh """
+        . config/${config}.sh
+        export APP_IMAGE_TAG=${tag}
+        make test-k8s-deployments
+      """
+      notify_slack([
+        status: "Verfied kubernetes deployment manifest (cluster: ${cluster})",
+        status: 'success'
+      ])
+
       notify_slack([
         status: "Pushing to ${environment} (cluster: ${cluster})",
         message: "developer-portal image ${tag}"

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -94,10 +94,15 @@ k8s-delete-ns:
 k8s-services:
 	j2 app.svc.yaml.j2 | ${KC} apply -f -
 
+test-k8s-services:
+	j2 app.svc.yaml.j2 | kubeval --strict --ignore-missing-schemas
+
 k8s-delete-services:
 	${KC} delete --ignore-not-found svc ${APP_SERVICE_NAME}
 
 k8s-deployments: k8s-wagtail-deployments k8s-celery-deployments k8s-celery-beat-deployments
+
+test-k8s-deployments: test-k8s-wagtail-deployments test-k8s-celery-deployments test-k8s-celery-beat-deployments
 
 k8s-delete-deployments: k8s-delete-wagtail-deployments k8s-delete-celery-deployments k8s-delete-celery-beat-deployments
 
@@ -105,17 +110,33 @@ k8s-wagtail-deployments:
 	env NEW_RELIC_APP_NAME=dev-portal-web-${TARGET_ENVIRONMENT} \
 	j2 app.deploy.yaml.j2 | ${KC} apply -f -
 
+test-k8s-wagtail-deployments:
+	env NEW_RELIC_APP_NAME=dev-portal-web-${TARGET_ENVIRONMENT} \
+	j2 app.deploy.yaml.j2 | kubeval --strict --ignore-missing-schemas
+
 k8s-celery-deployments:
 	env NEW_RELIC_APP_NAME=dev-portal-celery-${TARGET_ENVIRONMENT} \
 	env DJANGO_SETTINGS_MODULE=developerportal.settings.worker \
 	j2 celery.yaml.j2 | ${KC} apply -f -
 
+test-k8s-celery-deployments:
+	env NEW_RELIC_APP_NAME=dev-portal-celery-${TARGET_ENVIRONMENT} \
+	env DJANGO_SETTINGS_MODULE=developerportal.settings.worker \
+	j2 celery.yaml.j2 | kubeval --strict --ignore-missing-schemas
+
 k8s-celery-beat-deployments:
 	env NEW_RELIC_APP_NAME="" \
 	j2 celery-beat.yaml.j2 | ${KC} apply -f -
 
+test-k8s-celery-beat-deployments:
+	env NEW_RELIC_APP_NAME="" \
+	j2 celery-beat.yaml.j2 | kubeval --strict --ignore-missing-schemas
+
 k8s-hpa:
 	j2 hpa.yaml.j2 | ${KC} apply -f -
+
+test-k8s-hpa:
+	j2 hpa.yaml.j2 | kubeval --strict --ignore-missing-schemas
 
 k8s-delete-hpa:
 	${KC} delete --ignode-not-found deploy ${APP_NAME}


### PR DESCRIPTION
Test kubernetest manifest before deploying, utilizes kubeval which has been installed on the CI server

(Related issue #697)

## Key changes:

- Added tests for deployment to test if k8s manifest is valid

## How to test

- Install [kubeval](https://github.com/instrumenta/kubeval) on your local machine 
- Source config file
```
cd k8s
source k8s/config/${dev,stage,prod}.sh
```
- Run make file to run test
```
cd k8s
make test-k8s-deployments
```
