### PR TITLE
1461 FIX: Ensure that if an Event has a description, it is shown

### DIFF
--- a/developerportal/apps/events/templates/event.html
+++ b/developerportal/apps/events/templates/event.html
@@ -12,6 +12,11 @@
 
 <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-right content-page">
   <main role="main" class="mzp-l-main custom-width">
+
+      {{page.description|richtext}}
+
+      {% if page.description and page.body %} <hr> {% endif %}
+
       {% for block in page.body %}
         {% if block.block_type == 'image' %}
           {% include "molecules/image-block.html" with block=block %}


### PR DESCRIPTION
And if an event has both a description AND body streamfield content, we show both, with a HR between them.

And if an event ONLY has body streamfield content set, we show that, with no HR

(Related issue #1461)

## How to test

Code is staged on Dev - take a look at some events to:
  - [ ] Confirm the description is shown on all Events
  - [ ] That the body is shown on Events that have one set - eg https://developer-portal.dev.mdn.mozit.cloud/events/developer-roadshow-2019-asia/
  - [ ] That you like how it looks with the <hr> between the sections - see https://developer-portal.dev.mdn.mozit.cloud/events/pycascades-2020/ for an example where it works less well...

## Screenshots

**Description only present**

![Screenshot 2020-05-12 at 15 55 36](https://user-images.githubusercontent.com/101457/81711099-2f0cc900-946b-11ea-94fe-6d94444ec303.png)

----

**Body streamfield only present**

![Screenshot 2020-05-12 at 15 55 43](https://user-images.githubusercontent.com/101457/81711110-316f2300-946b-11ea-8fac-36e35884eb92.png)

----

**Both present**

![Screenshot 2020-05-12 at 15 55 49](https://user-images.githubusercontent.com/101457/81711116-32a05000-946b-11ea-956b-8f882d614a03.png)
 

