### PR TITLE
1382: Improve spacing after elements in a content page

### DIFF
--- a/src/css/templates/content-page.scss
+++ b/src/css/templates/content-page.scss
@@ -6,6 +6,12 @@ body.content {
   div.syntax-highlight {
     margin-bottom: $spacing-2xl;
   }
+
+  .standfirst-wrapper {
+    .rich-text {
+      margin-bottom: 0px;
+    }
+  }
 }
 
 .mzp-has-sidebar {

--- a/src/css/templates/content-page.scss
+++ b/src/css/templates/content-page.scss
@@ -1,3 +1,13 @@
+body.content {
+  figure,
+  div.rich-text,
+  p.button-block,
+  div.responsive-object,
+  div.syntax-highlight {
+    margin-bottom: $spacing-2xl;
+  }
+}
+
 .mzp-has-sidebar {
   &.mzp-l-sidebar-right {
     &.content-page {


### PR DESCRIPTION
This changeset fixes up the natural spacing on a `ContentPage` so that no hacks with `<br>` in HTML blocks are needed.

It puts a 48px margin below certain content blocks that are allowed in the `CustomStreamField` in the `ContentPage`

Blocks given spacing after them are: Paragraph, Image, Embed or Code snippet

The raw HTML block does NOT get automatic spacing - that seemed unnecessary

Note that it does NOT do this for `CustomStreamField` use anywhere else (eg on an Event page or similar) - that's something we can review as needed


(Related issue #1382)

## Screenshots

**BEFORE**
![Screenshot_2020-05-14 Test topic subpage (For CSS in this case)(1)](https://user-images.githubusercontent.com/101457/81940762-d6b30400-95ef-11ea-937a-a1d8f5bc454c.png)

**AFTER**
![Screenshot_2020-05-14 Test topic subpage (For CSS in this case)(3)](https://user-images.githubusercontent.com/101457/81941182-6062d180-95f0-11ea-8139-fd0e83a89c3a.png)



## How to test

- Code is staged on dev. I had edited [this page](https://developer-portal.dev.mdn.mozit.cloud/admin/pages/379) to remove the HTML `br` blocks and to also put the H2 in the SAME block as the text which follows it (else the H2 will have a bottom margin too). Please confirm you're happy with both the spacing and the approach to authoring the page (it's now less fragmented, which should be less painful!)