### PR TITLE
1476: Review and adjust image-resizing directives

### DIFF
--- a/developerportal/templates/atoms/social-meta.html
+++ b/developerportal/templates/atoms/social-meta.html
@@ -26,9 +26,9 @@
 {% static "img/placeholders/post_16_9.jpg" as fallback_image_url %}
 {% with fallback_image_width="600" fallback_image_height="338" %}
   {% if page.social_image %}
-    {% image page.social_image width-1200 as image %}
+    {% image page.social_image width-600 as image %}
   {% elif page.card_image %}
-    {% image page.card_image width-1200 as image %}
+    {% image page.card_image width-600 as image %}
   {% endif %}
   {% if not image %}
     {# Fallback images are hosted by Django, so need absolute URLs creating #}

--- a/developerportal/templates/molecules/card-featured.html
+++ b/developerportal/templates/molecules/card-featured.html
@@ -8,17 +8,17 @@
     a StreamBlock with an `image` key (such as an image on an external link)
   {% endcomment %}
   {% if aspect_ratio == "3_2" %}
-      {% image resource.image_3_2 width-480 as img %}
+      {% image resource.image_3_2 width-600 as img %}
     {% else %}
-      {% image resource.image width-480 as img %}
+      {% image resource.image width-400 as img %}
   {% endif %}
 
 {% elif resource.card_image %}
 
   {% if aspect_ratio == "3_2" %}
-      {% image resource.card_image_3_2 width-480 as img %}
+      {% image resource.card_image_3_2 width-600 as img %}
     {% else %}
-      {% image resource.card_image width-480 as img %}
+      {% image resource.card_image width-400 as img %}
   {% endif %}
 
 {% endif %}

--- a/developerportal/templates/molecules/cards/card-article.html
+++ b/developerportal/templates/molecules/cards/card-article.html
@@ -2,7 +2,7 @@
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
 
-{% image resource.card_image width-636 as card_image %}
+{% image resource.card_image width-480 as card_image %}
 {% static "img/placeholders/post_16_9.jpg" as fallback_image %}
 
 <div class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">

--- a/developerportal/templates/molecules/cards/card-event.html
+++ b/developerportal/templates/molecules/cards/card-event.html
@@ -3,7 +3,7 @@
 {% load wagtailimages_tags %}
 {% load app_tags %}
 
-{% image resource.card_image width-636 as card_image %}
+{% image resource.card_image width-480 as card_image %}
 {% static "img/placeholders/event_16_9.jpg" as fallback_image %}
 
 <div class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">

--- a/developerportal/templates/molecules/cards/card-video.html
+++ b/developerportal/templates/molecules/cards/card-video.html
@@ -2,7 +2,7 @@
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
 
-{% image resource.card_image width-636 as card_image %}
+{% image resource.card_image width-480 as card_image %}
 {% static "img/placeholders/post_16_9.jpg" as fallback_image %}
 
 <div class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">

--- a/developerportal/templates/molecules/image-block.html
+++ b/developerportal/templates/molecules/image-block.html
@@ -6,6 +6,6 @@
 {% if image_mime_type == 'image/gif' %}
   {% render_gif block.value %}
 {% else %}
-  {% image block.value width-672 as rendition %}
+  {% image block.value width-800 as rendition %}
   {% include "atoms/image.html" with image=block.value rendition=rendition %}
 {% endif %}

--- a/developerportal/templates/organisms/article-header.html
+++ b/developerportal/templates/organisms/article-header.html
@@ -2,7 +2,7 @@
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
 
-{% image page.card_image width-464 as card_image %}
+{% image page.card_image width-480 as card_image %}
 {% if type == "event" %}
   {% static "img/placeholders/event_16_9.jpg" as fallback_image %}
 {% else %}


### PR DESCRIPTION
This changeset brings the resizing rules left over from the original design into a better fit with the redesign, reducing the risk of fuzziness due to significant automatic resizing of images. It also takes into account the different needs of a 3:2 image compared to a 16:9 image.

It also makes the default width of an image in an image block wider, to suit the new use in the Content Page.

With the above, experiments showed that targetting precisely the exact rendered image dimensions (eg 771px wide for an image block in a Content Page) rather than a rounded, slightly larger number (eg 800px wide) led to the smaller image actually appearing fuzzier than the slightly larger image -- ie, the browser resize is better than a Wagtail hard resize. Given the relatively small file-size difference here (15kb in the 771 vs 800 example, which is the largest these images would be used), I think that's a reasonable trade-off.


## How to test

- Code is now on Dev **and** Stage - please just confirm that images in the following places still look fine (or better!)

- [ ] Homepage featured cards
- [ ] Topic page featured cards
- [ ] Posts list
- [ ] Events list
- [ ] Event detail (image in side bar)
- [ ] Content page featuring a main image (eg the Hubs page on Dev if there's not an appropriate page on Stage yet)