### PR TITLE
1467 small tweaks

### DIFF
--- a/developerportal/templates/survey.html
+++ b/developerportal/templates/survey.html
@@ -11,7 +11,9 @@
   only to the appropriate users after checking whether we should
 {% endcomment %}
 <aside class="mzp-c-notification-bar mzp-t-click js-task-completion-survey" hidden> {# NB: `hidden` attr #}
-  <button class="mzp-c-notification-bar-button mzp-js-notification-trigger" type="button"></button>
+  <button class="mzp-c-notification-bar-button mzp-js-notification-trigger" type="button">
+    <span class="visually-hidden">Close notification</span>
+  </button>
   <p>
       Your feedback is important. Would you
         <a target="_blank" rel="noreferrer noopener" href="{{survey_url}}" class="mzp-c-notification-bar-cta">

--- a/src/js/task-completion-prompt.js
+++ b/src/js/task-completion-prompt.js
@@ -17,6 +17,7 @@ const setSurveyCookie = function setSurveyCookie(value) {
   Cookies.set(SURVEY_COOKIE_NAME, value, {
     expires: SURVEY_COOKIE_EXPIRY,
     secure: USE_SECURE_COOKIE,
+    sameSite: 'strict',
   });
 };
 


### PR DESCRIPTION
This small changeset contains two small fixes for low-grade things that came up via code review and testing:

* Add an accessible name to the "survey close" button
    Hat-tip to @schalkneethling for the pointer

* Make the task-completion-cookie marker be `sameSite=strict` because there is no reason to send it to third parties

![Screenshot 2020-05-15 at 16 56 40](https://user-images.githubusercontent.com/101457/82070750-18fe4300-96cd-11ea-84c6-047d6ca7257d.png)


## How to test

Code is staged on [Dev](https://developer-portal.dev.mdn.mozit.cloud/) server 

- [ ] Check the task completion survey close button works (you may need to clear cookies for that site first to see it again) 

- [ ] Confirm the console does not complain about the cookie misusing `sameSite`