### PR TITLE
1484: Drop Meinheld dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ django-celery-results==1.2.1
 django-countries==6.1.2
 django-redis==4.10.0
 gunicorn==20.0.4
-meinheld==1.0.1
 gevent==1.4.0
 greenlet==0.4.15
 gevent-socketio==0.3.6


### PR DESCRIPTION
We now use gevent with gunicorn instead of meinheld, so this dependency can be dropped from our requirements

