### PR TITLE
1496: Improve position of Mozilla Developer logo for mobile viewport

### DIFF
--- a/src/css/molecules/header.scss
+++ b/src/css/molecules/header.scss
@@ -5,7 +5,16 @@
   }
 
   .mzp-c-navigation-logo {
-    margin-top: 23px; // 1px less than default, but is noticeable if not set
+    /* On mobile: set a negative margin to align better with hamburger menu. Remember
+      that the Mozilla Developer logo is taller than the black Mozilla bar on its own */
+    margin-top: -10px;
+    width: 165px; // This is to ensure the logo doesn't flow under the hamburger on mobile Safari
+
+    @media #{$mq-md} {
+      /* wider viewports need some specific tweaks to override the mobile defaults */
+      margin-top: 23px; // 1px less than default, but is noticeable if not set
+      width: 114px;
+    }
   }
 
   .mzp-c-navigation-logo a {


### PR DESCRIPTION
Previously, the logo was being shown as if stacked below the hamburgr icon. In fact, had desktop-specific margin-top on it which we correct in this changeset. Indeed, the change is to introduce a negative margin because the CSS in the Mozilla Protocol design system expects use of a single black-bar Mozilla logo, not a composite Mozilla Developer logo.

Some explicit-width-sizing work was also needed to make Safari render the logo in the right place. This does not affect desktop layout behaviour.

Cross-browser checked in Browserstack for iOS Safari on XS and iPhone 11; Chrome and FF on Pixel 4, plus PC and Mac evergreen desktop Chrome, FF, Edge and IE11, as appropriate

Resolves #1496

## How to test

- Code is staged on [dev](developer-portal.dev.mdn.mozit.cloud/) server 

# Screenshot before 
![Screenshot 2020-05-20 at 15 16 59](https://user-images.githubusercontent.com/101457/82457131-fb562280-9aac-11ea-8dab-77bbd9d6741d.png)


# Screenshots after

![Screenshot 2020-05-20 at 14 59 39](https://user-images.githubusercontent.com/101457/82457164-0610b780-9aad-11ea-8c6d-69442e31502a.png)
![Screenshot 2020-05-20 at 14 59 44](https://user-images.githubusercontent.com/101457/82457166-06a94e00-9aad-11ea-9274-d4e1cae77f04.png)
![Screenshot 2020-05-20 at 15 00 13](https://user-images.githubusercontent.com/101457/82457171-0741e480-9aad-11ea-917d-1c3098aa7f0c.png)
![Screenshot 2020-05-20 at 15 00 17](https://user-images.githubusercontent.com/101457/82457176-07da7b00-9aad-11ea-9001-b6ff3352ca95.png)
![Screenshot 2020-05-20 at 15 00 37](https://user-images.githubusercontent.com/101457/82457177-07da7b00-9aad-11ea-91f2-e0f60ee8ba3c.png)
![Screenshot 2020-05-20 at 15 00 42](https://user-images.githubusercontent.com/101457/82457179-08731180-9aad-11ea-8fae-e018547499eb.png)
