### PR TITLE
1510: Make "Posts"-page content indexable for Wagtail search

### DIFF
--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -29,6 +29,7 @@ from wagtail.core.blocks import PageChooserBlock
 from wagtail.core.fields import RichTextField, StreamBlock, StreamField
 from wagtail.core.models import Orderable
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.search import index
 
 from ..common.blocks import ExternalAuthorBlock, ExternalLinkBlock
 from ..common.constants import (
@@ -305,6 +306,12 @@ class Article(BasePage):
             ObjectList(settings_panels, heading="Settings", classname="settings"),
         ]
     )
+
+    # Search config
+    search_fields = BasePage.search_fields + [  # Inherit search_fields from Page
+        index.SearchField("description")
+        # "title" is already specced in BasePage
+    ]
 
     def get_absolute_url(self):
         # For the RSS feed

--- a/developerportal/apps/externalcontent/models.py
+++ b/developerportal/apps/externalcontent/models.py
@@ -27,6 +27,7 @@ from wagtail.core.blocks import PageChooserBlock
 from wagtail.core.fields import RichTextField, StreamBlock, StreamField
 from wagtail.core.models import Orderable
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.search import index
 
 from ..common.blocks import ExternalAuthorBlock
 from ..common.constants import RICH_TEXT_FEATURES_SIMPLE
@@ -197,6 +198,12 @@ class ExternalArticle(ExternalContent):
             ObjectList(settings_panels, heading="Settings", classname="settings"),
         ]
     )
+
+    # Search config
+    search_fields = BasePage.search_fields + [  # Inherit search_fields from Page
+        index.SearchField("description")
+        # "title" is already specced in BasePage
+    ]
 
     @property
     def article(self):
@@ -378,6 +385,12 @@ class ExternalVideo(ExternalContent):
             ObjectList(settings_panels, heading="Settings", classname="settings"),
         ]
     )
+
+    # Search config
+    search_fields = BasePage.search_fields + [  # Inherit search_fields from Page
+        index.SearchField("description")
+        # "title" is already specced in BasePage
+    ]
 
     @property
     def video(self):

--- a/developerportal/apps/taskqueue/celery.py
+++ b/developerportal/apps/taskqueue/celery.py
@@ -18,7 +18,7 @@ app.autodiscover_tasks()
 
 app.conf.beat_schedule = {
     "run-publish-scheduled-command-every-hour": {
-        "task": ("developerportal.apps.taskqueue.tasks.publish_scheduled_pages"),
+        "task": "developerportal.apps.taskqueue.tasks.publish_scheduled_pages",
         "schedule": crontab(minute=55),  # Five minutes to each hour
         "args": (),
     },
@@ -31,13 +31,20 @@ app.conf.beat_schedule = {
     # because we only want to run one celerybeat scheduler (for now) to keep things
     # simpler at the ops level.
     "ingest-articles-every-two-hours": {
-        "task": ("developerportal.apps.ingestion.tasks.ingest_articles"),
+        "task": "developerportal.apps.ingestion.tasks.ingest_articles",
         "schedule": crontab(minute=17, hour="*/2"),  # Every two hours, at 17 min past
         "args": (),
     },
     "ingest-videos-every-two-hours": {
-        "task": ("developerportal.apps.ingestion.tasks.ingest_videos"),
+        "task": "developerportal.apps.ingestion.tasks.ingest_videos",
         "schedule": crontab(minute=37, hour="*/2"),  # Every two hours, at 37 min past
+        "args": (),
+    },
+    "rebuild-search-index-weekly": {
+        "task": "developerportal.apps.taskqueue.tasks.update_wagtail_search_index",
+        "schedule": crontab(
+            minute=30, hour=9, day_of_week="thu"
+        ),  # Once a week: Thursdays at 0930 UTC (server time)
         "args": (),
     },
 }

--- a/developerportal/apps/taskqueue/tasks.py
+++ b/developerportal/apps/taskqueue/tasks.py
@@ -15,10 +15,18 @@ logger = logging.getLogger(__name__)
 
 
 @app.task
+def update_wagtail_search_index():
+    log_prefix = "[Wagtail Search]"
+    logger.info(f"{log_prefix} Trying to update search index")
+    call_command("wagtail_update_index")
+
+
+@app.task
 def publish_scheduled_pages():
     log_prefix = "[Publish scheduled pages]"
     logger.info(f"{log_prefix} Trying to publish/unpublish scheduled pages")
     call_command("publish_scheduled_pages")
+    update_wagtail_search_index()
 
 
 @app.task

--- a/developerportal/apps/taskqueue/tests/test_tasks.py
+++ b/developerportal/apps/taskqueue/tests/test_tasks.py
@@ -2,7 +2,11 @@ from unittest import mock
 
 from django.test import TestCase
 
-from ..tasks import invalidate_entire_cdn, selectively_invalidate_cdn
+from ..tasks import (
+    invalidate_entire_cdn,
+    selectively_invalidate_cdn,
+    update_wagtail_search_index,
+)
 
 
 class TasksTestCase(TestCase):
@@ -22,4 +26,34 @@ class TasksTestCase(TestCase):
         selectively_invalidate_cdn()
         mock_invalidate_cdn.assert_called_once_with(
             invalidation_targets=["/events/*", "/communities/people/*", "/topics/*"]
+        )
+
+    @mock.patch("developerportal.apps.taskqueue.tasks.call_command")
+    def test_update_wagtail_search_index(self, mock_call_command):
+        assert not mock_call_command.called
+        update_wagtail_search_index()
+        mock_call_command.assert_called_once_with("wagtail_update_index")
+
+
+class ConfigurationTestCase(TestCase):
+
+    # Disable the autodiscovery when importing for the test
+    @mock.patch("developerportal.apps.taskqueue.celery.app.autodiscover_tasks")
+    def test_expected_tasks_are_configured(self, mock_autodiscover_tasks):
+        # Light check that things are still plugged in...
+        from ..celery import app
+
+        configured_tasks = [x["task"] for x in app.conf.beat_schedule.values()]
+
+        self.assertEqual(
+            sorted(
+                [
+                    "developerportal.apps.taskqueue.tasks.publish_scheduled_pages",
+                    "developerportal.apps.taskqueue.tasks.selectively_invalidate_cdn",
+                    "developerportal.apps.ingestion.tasks.ingest_articles",
+                    "developerportal.apps.ingestion.tasks.ingest_videos",
+                    "developerportal.apps.taskqueue.tasks.update_wagtail_search_index",
+                ]
+            ),
+            sorted(configured_tasks),
         )

--- a/developerportal/apps/videos/models.py
+++ b/developerportal/apps/videos/models.py
@@ -28,6 +28,7 @@ from wagtail.core.fields import RichTextField, StreamBlock, StreamField
 from wagtail.core.models import Orderable
 from wagtail.embeds.blocks import EmbedBlock
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.search import index
 
 from ..common.blocks import ExternalLinkBlock
 from ..common.constants import RICH_TEXT_FEATURES, RICH_TEXT_FEATURES_SIMPLE, VIDEO_TYPE
@@ -276,6 +277,12 @@ class Video(BasePage):
             ObjectList(settings_panels, heading="Settings", classname="settings"),
         ]
     )
+
+    # Search config
+    search_fields = BasePage.search_fields + [  # Inherit search_fields from Page
+        index.SearchField("description")
+        # "title" is already specced in BasePage
+    ]
 
     def get_absolute_url(self):
         # For the RSS feed

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     "wagtail.documents",
     "wagtail.images",
     "wagtail.search",
+    "wagtail.contrib.postgres_search",
     "wagtail.admin",
     "wagtail.core",
     "storages",
@@ -224,6 +225,14 @@ SECURE_HSTS_SECONDS = int(os.environ.get("SECURE_HSTS_SECONDS", 3600))
 
 # Wagtail settings
 WAGTAIL_SITE_NAME = "Mozilla Developer"
+
+WAGTAILSEARCH_BACKENDS = {
+    "default": {
+        "BACKEND": "wagtail.contrib.postgres_search.backend",
+        "AUTO_UPDATE": True,  # if this slows down editing, we can do things differently
+        "ATOMIC_REBUILD": True,
+    }
+}
 
 # Add support for CodePen oEmbed
 WAGTAILEMBEDS_FINDERS = [


### PR DESCRIPTION
This changeset lays in groundwork for adding Search to the Posts page.

## Key changes:

It: 
1) Enables the Postgres search backend for Wagtail (which is recommended for sites with fewer than 1m pages and straightforward search requirements). It is set to automatically update the search index, and to do so atomically, so that search is always available

2) Adds configuration to the relevant Page subclasses that appear on the Posts page so that `wagtailsearch` knows to index them (and which fields on them to index)

3) Add a scheduled task, as per Wagtail recommendations, to fully rebuild the search index (again, atomically) once a week

## How to test

- Unit tests have been added, and for now this is probably best just code reviewed, as subsequent PRs will build on its functionality, making manual testing much easier. 
However, here's an example of it working in the shell for all four types of Pages configured for search:

```
>>> from developerportal.apps.articles.models import *
>>> from developerportal.apps.videos.models import *
>>> from developerportal.apps.externalcontent.models import *

>>> Article.objects.search("Firefox 66")
<SearchResults [<Article: Scroll Anchoring in Firefox 66>, <Article: Firefox 66: The Sound of Silence>]>

>>> ExternalArticle.objects.search("Firefox 66")
<SearchResults []>

>>> ExternalArticle.objects.search("Firefox")
<SearchResults [<ExternalArticle: Firefox Reality for HoloLens 2>, <ExternalArticle: Firefox Reality 10>, <ExternalArticle: High Performance Web Audio with AudioWorklet in Firefox>, <ExternalArticle: Firefox 76: Audio worklets and other tricks>, <ExternalArticle: Extensions in Firefox 76>, <ExternalArticle: Better User Performance and More in this Firefox Reality v9 release>, <ExternalArticle: Firefox 75: Ambitions for April>, ...(remaining elements truncated)...']>

>>> Video.objects.search("Firefox")
<SearchResults [<Video: Max Liu - Learn more about Firefox Lite - Mozilla Developer Roadshow - Taipei (Chinese)>, <Video: Why are there Four Firefoxes?>]>

>>> ExternalVideo.objects.search("Firefox")
<SearchResults []>
>>> ExternalVideo.objects.all()
<PageQuerySet [<ExternalVideo: test video 1>, <ExternalVideo: test video 2>, <ExternalVideo: test external video>]>
>>> ExternalVideo.objects.search("external")
<SearchResults [<ExternalVideo: test external video>]>
>>> ExternalVideo.objects.search("test 2")
<SearchResults [<ExternalVideo: test video 2>]>
>>> ExternalVideo.objects.search("test 1")
<SearchResults [<ExternalVideo: test video 1>]>

```