### PR TITLE
1556: Remove unnecessary padding in header strip

### DIFF
--- a/developerportal/templates/molecules/header-strip.html
+++ b/developerportal/templates/molecules/header-strip.html
@@ -16,16 +16,20 @@
       <{{element}}>
         {{ content }}
       </{{element}}>
-      {% if not skip_standfirst %}
-      <div class="standfirst-wrapper">
-      {% if standfirst %}
-        <div class="custom-standfirst">
-          {{standfirst}}
-        </div>
+      {% if skip_standfirst %}
+      {% comment %} Avoid rendering any standfirst at all {% endcomment %}
       {% else %}
-        {{page.description|richtext}}
-      {% endif %}
-      </div>
+        {% if standfirst %}
+        <div class="standfirst-wrapper">
+          <div class="custom-standfirst">
+            {{standfirst}}
+          </div>
+        </div>
+        {% elif page.description %}
+        <div class="standfirst-wrapper">
+          {{page.description|richtext}}
+        </div>
+        {% endif %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
This changeset avoids including an empty div.standfirst-wrapper, because it comes with bottom padding that we don't want when it has no content

Before fix
![Screenshot 2020-06-10 at 12 56 05](https://user-images.githubusercontent.com/101457/84266624-b443d600-ab1c-11ea-80ec-6a57a76f8e19.png)

After
![Screenshot 2020-06-10 at 12 56 01](https://user-images.githubusercontent.com/101457/84266623-b3ab3f80-ab1c-11ea-9066-033a080f88fe.png)

Before fix
![Screenshot 2020-06-10 at 12 56 16](https://user-images.githubusercontent.com/101457/84266628-b4dc6c80-ab1c-11ea-9309-daff2376da47.png)

After
![Screenshot 2020-06-10 at 12 56 13](https://user-images.githubusercontent.com/101457/84266625-b4dc6c80-ab1c-11ea-9583-5bacdb5116d7.png)

After fix - pages with standfirst still have sensible padding
![Screenshot 2020-06-10 at 12 56 47](https://user-images.githubusercontent.com/101457/84266630-b4dc6c80-ab1c-11ea-857e-1ef16331fc2e.png)



And pages with deliberately no standfirst have sensible padding
![Screenshot 2020-06-10 at 12 57 02](https://user-images.githubusercontent.com/101457/84266632-b5750300-ab1c-11ea-8102-ceaaef068624.png)



## How to test

- Code is on [Staging](https://developer-portal.stage.mdn.mozit.cloud/) - please confirm that these all look fine/better

* https://developer-portal.stage.mdn.mozit.cloud/posts/
* https://developer-portal.stage.mdn.mozit.cloud/posts/test-page-search/
* https://developer-portal.stage.mdn.mozit.cloud/events/
* https://developer-portal.stage.mdn.mozit.cloud/events/developer-roadshow-2019-asia/
* https://developer-portal.stage.mdn.mozit.cloud/communities/people/
* https://developer-portal.stage.mdn.mozit.cloud/communities/people/andrzej-mazur/
* https://developer-portal.stage.mdn.mozit.cloud/topics/av1-video/