### PR TITLE
1514: Ingest descriptions from feeds where possible

### DIFF
--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -33,6 +33,7 @@ from wagtail.search import index
 
 from ..common.blocks import ExternalAuthorBlock, ExternalLinkBlock
 from ..common.constants import (
+    DESCRIPTION_MAX_LENGTH,
     PAGINATION_QUERYSTRING_KEY,
     RICH_TEXT_FEATURES_SIMPLE,
     SEARCH_QUERYSTRING_KEY,
@@ -67,8 +68,11 @@ class Articles(BasePage):
         blank=True,
         default="",
         features=RICH_TEXT_FEATURES_SIMPLE,
-        help_text="Optional short text description, max. 400 characters",
-        max_length=400,
+        help_text=(
+            "Optional short text description, "
+            f"max. {DESCRIPTION_MAX_LENGTH} characters"
+        ),
+        max_length=DESCRIPTION_MAX_LENGTH,
     )
 
     # Meta fields
@@ -180,8 +184,11 @@ class Article(BasePage):
         blank=True,
         default="",
         features=RICH_TEXT_FEATURES_SIMPLE,
-        help_text="Optional short text description, max. 400 characters",
-        max_length=400,
+        help_text=(
+            "Optional short text description, "
+            f"max. {DESCRIPTION_MAX_LENGTH} characters"
+        ),
+        max_length=DESCRIPTION_MAX_LENGTH,
     )
     body = CustomStreamField(
         help_text=(
@@ -199,7 +206,9 @@ class Article(BasePage):
 
     # Card fields
     card_title = CharField("Title", max_length=140, blank=True, default="")
-    card_description = TextField("Description", max_length=400, blank=True, default="")
+    card_description = TextField(
+        "Description", max_length=DESCRIPTION_MAX_LENGTH, blank=True, default=""
+    )
     card_image = ForeignKey(
         "mozimages.MozImage",
         null=True,

--- a/developerportal/apps/common/constants.py
+++ b/developerportal/apps/common/constants.py
@@ -1,5 +1,7 @@
 RESOURCE_COUNT_CHOICES = ((3, "3"), (6, "6"), (9, "9"))
 
+DESCRIPTION_MAX_LENGTH = 400
+
 RICH_TEXT_FEATURES = (
     "bold",
     "blockquote",

--- a/developerportal/apps/content/models.py
+++ b/developerportal/apps/content/models.py
@@ -20,7 +20,7 @@ from wagtail.admin.edit_handlers import (
 from wagtail.core.fields import RichTextField
 from wagtail.images.edit_handlers import ImageChooserPanel
 
-from ..common.constants import RICH_TEXT_FEATURES_SIMPLE
+from ..common.constants import DESCRIPTION_MAX_LENGTH, RICH_TEXT_FEATURES_SIMPLE
 from ..common.fields import CustomStreamField
 from ..common.models import BasePage
 from ..common.validators import check_for_svg_file
@@ -42,8 +42,11 @@ class ContentPage(BasePage):
         blank=True,
         default="",
         features=RICH_TEXT_FEATURES_SIMPLE,
-        help_text="Optional short text description, max. 400 characters",
-        max_length=400,
+        help_text=(
+            "Optional short text description, "
+            f"max. {DESCRIPTION_MAX_LENGTH} characters"
+        ),
+        max_length=DESCRIPTION_MAX_LENGTH,
     )
     body = CustomStreamField(
         help_text=(
@@ -78,7 +81,10 @@ class ContentPage(BasePage):
 
     # Meta fields
     nav_description = TextField(
-        "Navigation description", max_length=400, blank=True, default=""
+        "Navigation description",
+        max_length=DESCRIPTION_MAX_LENGTH,
+        blank=True,
+        default="",
     )
     icon = FileField(
         upload_to="contentpage/icons",

--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -38,6 +38,7 @@ from ..common.constants import (
     COUNTRY_QUERYSTRING_KEY,
     DATE_PARAMS_QUERYSTRING_KEY,
     DEFAULT_EVENTS_LOOKAHEAD_WINDOW_MONTHS,
+    DESCRIPTION_MAX_LENGTH,
     FUTURE_EVENTS_QUERYSTRING_VALUE,
     PAGINATION_QUERYSTRING_KEY,
     PAST_EVENTS_QUERYSTRING_VALUE,
@@ -290,8 +291,11 @@ class Event(BasePage):
         blank=True,
         default="",
         features=RICH_TEXT_FEATURES_SIMPLE,
-        help_text="Optional short text description, max. 400 characters",
-        max_length=400,
+        help_text=(
+            "Optional short text description, "
+            f"max. {DESCRIPTION_MAX_LENGTH} characters"
+        ),
+        max_length=DESCRIPTION_MAX_LENGTH,
     )
     start_date = DateField(default=datetime.date.today)
     end_date = DateField(blank=True, null=True)
@@ -353,7 +357,9 @@ class Event(BasePage):
 
     # Card fields
     card_title = CharField("Title", max_length=140, blank=True, default="")
-    card_description = TextField("Description", max_length=400, blank=True, default="")
+    card_description = TextField(
+        "Description", max_length=DESCRIPTION_MAX_LENGTH, blank=True, default=""
+    )
     card_image = ForeignKey(
         "mozimages.MozImage",
         null=True,

--- a/developerportal/apps/externalcontent/models.py
+++ b/developerportal/apps/externalcontent/models.py
@@ -30,7 +30,7 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 
 from ..common.blocks import ExternalAuthorBlock
-from ..common.constants import RICH_TEXT_FEATURES_SIMPLE
+from ..common.constants import DESCRIPTION_MAX_LENGTH, RICH_TEXT_FEATURES_SIMPLE
 from ..common.models import BasePage
 
 logger = logging.getLogger(__name__)
@@ -45,8 +45,11 @@ class ExternalContent(BasePage):
         blank=True,
         default="",
         features=RICH_TEXT_FEATURES_SIMPLE,
-        help_text="Optional short text description, max. 400 characters",
-        max_length=400,
+        help_text=(
+            "Optional short text description, "
+            f"max. {DESCRIPTION_MAX_LENGTH} characters"
+        ),
+        max_length=DESCRIPTION_MAX_LENGTH,
     )
     external_url = URLField(
         "URL",

--- a/developerportal/apps/home/models.py
+++ b/developerportal/apps/home/models.py
@@ -22,6 +22,7 @@ from wagtail.core.fields import StreamBlock, StreamField
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from ..common.blocks import FeaturedExternalBlock
+from ..common.constants import DESCRIPTION_MAX_LENGTH
 from ..common.models import BasePage
 
 
@@ -107,7 +108,9 @@ class HomePage(BasePage):
 
     # Card fields
     card_title = CharField("Title", max_length=140, blank=True, default="")
-    card_description = TextField("Description", max_length=400, blank=True, default="")
+    card_description = TextField(
+        "Description", max_length=DESCRIPTION_MAX_LENGTH, blank=True, default=""
+    )
     card_image = ForeignKey(
         "mozimages.MozImage",
         null=True,

--- a/developerportal/apps/ingestion/tests/test_utils.py
+++ b/developerportal/apps/ingestion/tests/test_utils.py
@@ -9,6 +9,7 @@ import pytz
 from dateutil.tz import tzlocal
 
 from developerportal.apps.ingestion.utils import (
+    _get_item_description,
     _get_slug,
     fetch_external_data,
     ingest_content,
@@ -100,6 +101,11 @@ class UtilsTestCaseWithoutFixtures(TestCase):
             title="ECSY Developer tools extension",
             authors=["Fernando Serrano"],
             url="https://blog.mozvr.com/ecsy-developer-tools/",
+            description=(
+                "<p>Two months ago we released ECSY, a framework-agnostic Entity "
+                "Component System library you could use to build real time "
+                "applications with the engine of your choice.</p>"
+            ),
             image_url="https://blog.mozvr.com/content/images/2019/12/ecsy-header.png",
             timestamp=datetime.datetime(2019, 12, 10, 22, 47, 43, tzinfo=pytz.UTC),
         )
@@ -116,6 +122,10 @@ class UtilsTestCaseWithoutFixtures(TestCase):
             title="Where do Browser Styles Come From?",
             authors=["Mozilla Developer"],
             url="https://www.youtube.com/watch?v=spK_S0HfzFw",
+            description=(
+                "<p>Not sure where that default 8px of margin on the body "
+                "comes from? Here's how to find out!</p>"
+            ),
             image_url="https://i4.ytimg.com/vi/spK_S0HfzFw/hqdefault.jpg",
             timestamp=datetime.datetime(2019, 12, 11, 11, 0, 10, tzinfo=tzlocal()),
         )
@@ -172,6 +182,7 @@ class UtilsTestCaseWithFixtures(TestCase):
                 title="Test one",
                 authors=["Fernando McTest"],
                 url="https://example.com/thing/one/",
+                description="<p>Test description one</p>",
                 # image_url="https://example.com/one.png",
                 # Image ingestion is tested elsewhere
                 timestamp=datetime.datetime(2020, 1, 10, 22, 47, 43, tzinfo=pytz.UTC),
@@ -180,6 +191,7 @@ class UtilsTestCaseWithFixtures(TestCase):
                 title="Test two",
                 authors=["Alice McTest"],
                 url="https://example.com/thing/two/",
+                description="<p>Test description two</p>",
                 # image_url="https://example.com/two.png",
                 # Image ingestion is tested elsewhere
                 timestamp=datetime.datetime(2020, 1, 10, 22, 47, 43, tzinfo=pytz.UTC),
@@ -188,6 +200,7 @@ class UtilsTestCaseWithFixtures(TestCase):
                 title="Test three",
                 authors=["Mary McTest"],
                 url="https://example.com/thing/three/",
+                description="<p>Test description three</p>",
                 # image_url="https://example.com/three.png",
                 # Image ingestion is tested elsewhere
                 timestamp=datetime.datetime(2020, 1, 10, 22, 47, 43, tzinfo=pytz.UTC),
@@ -201,9 +214,24 @@ class UtilsTestCaseWithFixtures(TestCase):
         ingest_content(type_=IngestionConfiguration.CONTENT_TYPE_VIDEO)
         assert Video.objects.count() == 3
 
-        assert Video.objects.filter(title="Test one").count() == 1
-        assert Video.objects.filter(title="Test two").count() == 1
-        assert Video.objects.filter(title="Test three").count() == 1
+        assert (
+            Video.objects.filter(
+                title="Test one", description="<p>Test description one</p>"
+            ).count()
+            == 1
+        )
+        assert (
+            Video.objects.filter(
+                title="Test two", description="<p>Test description two</p>"
+            ).count()
+            == 1
+        )
+        assert (
+            Video.objects.filter(
+                title="Test three", description="<p>Test description three</p>"
+            ).count()
+            == 1
+        )
 
         # None of these has been published yet
         assert Video.objects.filter(first_published_at__isnull=True).count() == 3
@@ -218,6 +246,7 @@ class UtilsTestCaseWithFixtures(TestCase):
                 title="Test four",
                 authors=["Barry McTest"],
                 url="https://example.com/thing/four/",
+                description="<p>Test description four</p>",
                 # image_url="https://example.com/four.png",
                 # Image ingestion is tested elsewhere
                 timestamp=datetime.datetime(2020, 1, 10, 22, 47, 43, tzinfo=pytz.UTC),
@@ -235,10 +264,30 @@ class UtilsTestCaseWithFixtures(TestCase):
         ingest_content(type_=IngestionConfiguration.CONTENT_TYPE_ARTICLE)
         assert ExternalArticle.objects.count() == 4
 
-        assert ExternalArticle.objects.filter(title="Test one for Post").count() == 1
-        assert ExternalArticle.objects.filter(title="Test two for Post").count() == 1
-        assert ExternalArticle.objects.filter(title="Test three for Post").count() == 1
-        assert ExternalArticle.objects.filter(title="Test four for Post").count() == 1
+        assert (
+            ExternalArticle.objects.filter(
+                title="Test one for Post", description="<p>Test description one</p>"
+            ).count()
+            == 1
+        )
+        assert (
+            ExternalArticle.objects.filter(
+                title="Test two for Post", description="<p>Test description two</p>"
+            ).count()
+            == 1
+        )
+        assert (
+            ExternalArticle.objects.filter(
+                title="Test three for Post", description="<p>Test description three</p>"
+            ).count()
+            == 1
+        )
+        assert (
+            ExternalArticle.objects.filter(
+                title="Test four for Post", description="<p>Test description four</p>"
+            ).count()
+            == 1
+        )
 
         # None of these has been published yet
         assert (
@@ -279,6 +328,7 @@ class UtilsTestCaseWithFixtures(TestCase):
                 title="Test one",
                 authors=["Fernando McTest"],
                 url="https://example.com/thing/one/",
+                description="<p>Test description</p>",
                 # image_url="https://example.com/one.png",
                 # Image ingestion is tested elsewhere
                 timestamp=datetime.datetime(2020, 1, 10, 22, 47, 43, tzinfo=pytz.UTC),
@@ -314,6 +364,7 @@ class UtilsTestCaseWithFixtures(TestCase):
                 title="Test one",
                 authors=["Fernando McTest"],
                 url="https://example.com/thing/one/",
+                description="<p>Test description</p>",
                 # image_url="https://example.com/one.png",
                 # Image ingestion is tested elsewhere
                 timestamp=datetime.datetime(2020, 1, 10, 22, 47, 43, tzinfo=pytz.UTC),
@@ -322,7 +373,6 @@ class UtilsTestCaseWithFixtures(TestCase):
 
         mock_fetch_external_data.return_value = video_return_value
 
-        # First try Video content
         assert Video.objects.count() == 0
 
         with self.assertLogs(
@@ -342,6 +392,7 @@ class UtilsTestCaseWithFixtures(TestCase):
                     "{'title': 'Test one', "
                     "'authors': ['Fernando McTest'], "
                     "'url': 'https://example.com/thing/one/', "
+                    "'description': '<p>Test description</p>', "
                     "'timestamp': datetime.datetime(2020, 1, 10, 22, 47, 43, "
                     "tzinfo=<UTC>), 'owner': <User: ingestion_user>}"
                 ),
@@ -402,6 +453,7 @@ class UtilsTestCaseWithFixtures(TestCase):
         data = dict(
             title="ECSY Developer tools extension",
             authors=["Fernando Serrano"],  # not used for now
+            description="<p>Test description</p>",
             url="https://blog.mozvr.com/ecsy-developer-tools/",
             image_url="https://blog.mozvr.com/content/images/2019/12/ecsy-header.png",
             timestamp=datetime.datetime(2019, 12, 10, 22, 47, 43, tzinfo=pytz.UTC),
@@ -412,7 +464,7 @@ class UtilsTestCaseWithFixtures(TestCase):
         )
         obj.refresh_from_db()
         self.assertEqual(type(obj), ExternalArticle)
-        self.assertEqual(obj.slug, "ecsy-developer-tools-extension-c0a61483f56d")
+        self.assertEqual(obj.slug, "ecsy-developer-tools-extension-6705c559c5d3")
         self.assertEqual(obj.title, data["title"])
         self.assertEqual(obj.draft_title, data["title"])
         self.assertEqual(obj.external_url, data["url"])
@@ -433,6 +485,7 @@ class UtilsTestCaseWithFixtures(TestCase):
             title="Where do Browser Styles Come From?",
             authors=["Mozilla Developer"],  # Not used for now
             url="https://www.youtube.com/watch?v=spK_S0HfzFw",
+            description="<p>Test description</p>",
             image_url="https://i4.ytimg.com/vi/spK_S0HfzFw/hqdefault.jpg",
             timestamp=datetime.datetime(2019, 12, 11, 11, 0, 10, tzinfo=tzlocal()),
         )
@@ -442,7 +495,7 @@ class UtilsTestCaseWithFixtures(TestCase):
         )
         obj.refresh_from_db()
         self.assertEqual(type(obj), Video)
-        self.assertEqual(obj.slug, "where-do-browser-styles-come-from-a36dd198ae6c")
+        self.assertEqual(obj.slug, "where-do-browser-styles-come-from-cd6673c468b5")
         self.assertEqual(obj.title, data["title"])
         self.assertEqual(obj.draft_title, data["title"])
         self.assertEqual(obj.video_url[0].value.url, data["url"])
@@ -474,3 +527,47 @@ class UtilsTestCaseWithFixtures(TestCase):
         for case in cases:
             with self.subTest(input_=case["input"], expected=case["expected"]):
                 self.assertEqual(_get_slug(case["input"]), case["expected"])
+
+    def test__get_item_description(self):
+
+        cases = [
+            {
+                "input": "<h1>header</h1><p>test description</p>",
+                "expected": "<p>test description</p>",
+                "desc_": "skips header",
+            },
+            {
+                "input": "<p>test description!</p><p>another thing</p>",
+                "expected": "<p>test description!</p>",
+                "desc_": "multiple p nodes",
+            },
+            {
+                "input": "<h1>header</h1><p>test description",
+                "expected": "<p>test description</p>",
+                "desc_": "bad HTML 1 gets fixed",
+            },
+            {
+                "input": "<h1>header</h1><p>test description!<p>another thing</p>",
+                "expected": "<p>test description!</p>",
+                "desc_": "bad HTML 2 gets fixed",
+            },
+            {
+                "input": "<h1>header</h1><span>test description.<span>",
+                "expected": "",
+                "desc_": "No <p> node - skip it entirely",
+            },
+            {"input": "", "expected": "", "desc_": "Empty string"},
+            {"input": None, "expected": "", "desc_": "Description is None"},
+            {
+                "input": f"<p>{ 'x' * 393}, but not this</p>",
+                "expected": f"<p>{ 'x' * 393}</p>",
+                "desc_": "<p> node > 400 chars gets cut, but still wrapped in <p>",
+            },
+        ]
+        for case in cases:
+            with self.subTest(label=case["desc_"]):
+
+                mock_entry = mock.Mock(description=case["input"])
+                assert mock_entry.description == case["input"]  # Confirm patch
+
+                self.assertEqual(_get_item_description(mock_entry), case["expected"])

--- a/developerportal/apps/people/models.py
+++ b/developerportal/apps/people/models.py
@@ -32,6 +32,7 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 from ..common.blocks import PersonalWebsiteBlock
 from ..common.constants import (
     COUNTRY_QUERYSTRING_KEY,
+    DESCRIPTION_MAX_LENGTH,
     PAGINATION_QUERYSTRING_KEY,
     RICH_TEXT_FEATURES_SIMPLE,
     ROLE_CHOICES,
@@ -63,13 +64,19 @@ class People(BasePage):
         blank=True,
         default="",
         features=RICH_TEXT_FEATURES_SIMPLE,
-        help_text="Optional short text description, max. 400 characters",
-        max_length=400,
+        help_text=(
+            "Optional short text description, "
+            f"max. {DESCRIPTION_MAX_LENGTH} characters"
+        ),
+        max_length=DESCRIPTION_MAX_LENGTH,
     )
 
     # Meta fields
     nav_description = TextField(
-        "Navigation description", max_length=400, blank=True, default=""
+        "Navigation description",
+        max_length=DESCRIPTION_MAX_LENGTH,
+        blank=True,
+        default="",
     )
     keywords = ClusterTaggableManager(through=PeopleTag, blank=True)
     icon = FileField(
@@ -227,7 +234,9 @@ class Person(BasePage):
 
     # Card fields
     card_title = CharField("Title", max_length=140, blank=True, default="")
-    card_description = TextField("Description", max_length=400, blank=True, default="")
+    card_description = TextField(
+        "Description", max_length=DESCRIPTION_MAX_LENGTH, blank=True, default=""
+    )
     card_image = ForeignKey(
         "mozimages.MozImage",
         null=True,

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -27,7 +27,7 @@ from wagtail.core.models import Orderable
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from ..common.blocks import FeaturedExternalBlock
-from ..common.constants import RICH_TEXT_FEATURES_SIMPLE
+from ..common.constants import DESCRIPTION_MAX_LENGTH, RICH_TEXT_FEATURES_SIMPLE
 from ..common.models import BasePage
 from ..common.utils import (
     get_combined_articles,
@@ -75,8 +75,11 @@ class Topic(BasePage):
         blank=True,
         default="",
         features=RICH_TEXT_FEATURES_SIMPLE,
-        help_text="Optional short text description, max. 400 characters",
-        max_length=400,
+        help_text=(
+            "Optional short text description, "
+            f"max. {DESCRIPTION_MAX_LENGTH} characters"
+        ),
+        max_length=DESCRIPTION_MAX_LENGTH,
     )
     featured = StreamField(
         StreamBlock(
@@ -133,7 +136,9 @@ class Topic(BasePage):
 
     # Card fields
     card_title = CharField("Title", max_length=140, blank=True, default="")
-    card_description = TextField("Description", max_length=400, blank=True, default="")
+    card_description = TextField(
+        "Description", max_length=DESCRIPTION_MAX_LENGTH, blank=True, default=""
+    )
     card_image = ForeignKey(
         "mozimages.MozImage",
         null=True,
@@ -146,7 +151,10 @@ class Topic(BasePage):
 
     # Meta
     nav_description = TextField(
-        "Navigation description", max_length=400, blank=True, default=""
+        "Navigation description",
+        max_length=DESCRIPTION_MAX_LENGTH,
+        blank=True,
+        default="",
     )
     icon = FileField(
         upload_to="topics/icons",

--- a/developerportal/apps/videos/models.py
+++ b/developerportal/apps/videos/models.py
@@ -31,7 +31,12 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 
 from ..common.blocks import ExternalLinkBlock
-from ..common.constants import RICH_TEXT_FEATURES, RICH_TEXT_FEATURES_SIMPLE, VIDEO_TYPE
+from ..common.constants import (
+    DESCRIPTION_MAX_LENGTH,
+    RICH_TEXT_FEATURES,
+    RICH_TEXT_FEATURES_SIMPLE,
+    VIDEO_TYPE,
+)
 from ..common.models import BasePage
 from ..common.utils import get_combined_articles_and_videos
 
@@ -121,8 +126,11 @@ class Video(BasePage):
         blank=True,
         default="",
         features=RICH_TEXT_FEATURES_SIMPLE,
-        help_text="Optional short text description, max. 400 characters",
-        max_length=400,
+        help_text=(
+            "Optional short text description, "
+            f"max. {DESCRIPTION_MAX_LENGTH} characters"
+        ),
+        max_length=DESCRIPTION_MAX_LENGTH,
     )
     body = RichTextField(
         blank=True,
@@ -174,7 +182,9 @@ class Video(BasePage):
 
     # Card fields
     card_title = CharField("Title", max_length=140, blank=True, default="")
-    card_description = TextField("Description", max_length=400, blank=True, default="")
+    card_description = TextField(
+        "Description", max_length=DESCRIPTION_MAX_LENGTH, blank=True, default=""
+    )
     card_image = ForeignKey(
         "mozimages.MozImage",
         null=True,


### PR DESCRIPTION
This changeset increases the amount of information we use from RSS and Atom feeds when automatically creating `ExternalArticle` and `Video` draft pages, respectively.

In both formats, It looks for a `description` element in the output of the feed parser and, if it contains a `<p>` node, uses that as the `description` field for the page that is auto-created.

Note:
* If there is more than one `<p>` node in the parsed input's `description`, it uses only the first  one
* If there is no `<p>` node, the `description` is not used at all
* If there is a `<p>` node but its contents are longer than 393 characters (ie, the 400 max limit, minus seven characters for `<p>` and `</p>` tags, the content is truncated inside the `p` node is truncated, **so descriptions MUST be read before the page is published**

Examples from local build:

![Screenshot 2020-06-15 at 13 29 31](https://user-images.githubusercontent.com/101457/84660038-31ea5600-af10-11ea-9b95-fdb628bc9d5a.png)

![Screenshot 2020-06-15 at 13 29 15](https://user-images.githubusercontent.com/101457/84660014-2bf47500-af10-11ea-87e5-f842add9b9eb.png)

![Screenshot 2020-06-15 at 13 33 21](https://user-images.githubusercontent.com/101457/84660066-3b73be00-af10-11ea-9d5c-bf35706c5cd1.png)
![Screenshot 2020-06-15 at 13 33 33](https://user-images.githubusercontent.com/101457/84660067-3c0c5480-af10-11ea-8af0-e534a60927c1.png)

(Related issue #1514)

## How to test

- Code is deployed to Staging, but setting up the appropriate state to import items again without spamming moderators is awkward. So, the next time we get new content to import the importer will set descriptions that can be checked - @valgrimm watch out for a notification email from stage 😄 