### PR TITLE
1546: Trigger Wagtail's search index rebuild on deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ def deploy(config, environment, cluster) {
         export APP_IMAGE_TAG=${tag}
         make k8s-db-migration-job
         make k8s-deployments
+        make k8s-search-index-update-job
         make k8s-hpa
         make k8s-rollout-status
       """

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -159,6 +159,15 @@ k8s-jenkins-create-rbac:
 k8s-jenkins-delete-rbac:
 	kubectl delete -f jenkins-rbac.yaml
 
+k8s-search-index-update-job: k8s-delete-search-index-update-job
+	env NEW_RELIC_APP_NAME=dev-portal-web-${TARGET_ENVIRONMENT} \
+	j2 search-index-update-job.yaml.j2 | ${KC} apply -f -
+	env JOB_NAME=search-index-update ./wait_for_job.sh
+
+k8s-delete-search-index-update-job:
+	${KC} delete --ignore-not-found job search-index-update
+
+
 ### end core tasks
 ###############################
 
@@ -168,4 +177,5 @@ k8s-jenkins-delete-rbac:
 		k8s-wagtail-deployments k8s-celery-deployments \
 		k8s-delete-wagtail-deployments k8s-delete-celery-deployments \
 		k8s-rollback k8s-history k8s-db-migration-job \
-		k8s-delete-db-migration-job
+		k8s-delete-db-migration-job \
+    k8s-search-index-update-job \ k8s-delete-search-index-update-job

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -6,13 +6,14 @@ Most of these commands require special configuration and permissions available o
 
 - Install `kubectl` (the Kubernetes command-line tool) -- https://kubernetes.io/docs/tasks/tools/install-kubectl/
 
+* Install `j2cli` (Jinja2 command-line tool)
 
-- Install `j2cli` (Jinja2 command-line tool)
 ```sh
 pip install j2cli
 ```
 
 - Install `jq` (lightweight/flexible command-line JSON processor)
+
 ```sh
 brew update
 brew install jq
@@ -25,44 +26,59 @@ brew install jq
 #### Setup
 
 - Move to the `k8s` directory of the developer-portal repo
+
   ```sh
   cd k8s
   ```
 
 - Configure your environment depending upon whether you're deploying to stage or production.
 
-    - Stage
-    ```sh
-    source config/stage.sh
-    ```
-    - Production
-    ```sh
-    source config/prod.sh
-    ```
+  - Stage
+
+  ```sh
+  source config/stage.sh
+  ```
+
+  - Production
+
+  ```sh
+  source config/prod.sh
+  ```
 
 #### Deploying
 
 - Specify the developer-portal image tag you want to deploy. It must be available from DockerHub (see https://cloud.docker.com/u/mdnwebdocs/repository/docker/mdnwebdocs/developer-portal/tags for a list of available tags). New developer-portal images are built and registered on DockerHub after every commit to the `master` branch of https://github.com/mdn/developer-portal.
+
 ```sh
 export APP_IMAGE_TAG=<tag-from-dockerhub>
 ```
 
 - Run the database migrations
+
 ```sh
 make k8s-db-migration-job
 ```
 
 - Rollout the update
+
 ```sh
 make k8s-deployments
 ```
 
+- Update the search index
+
+```sh
+make k8s-search-index-update-job
+```
+
 - Monitor the status of the rollout until it completes
+
 ```sh
 make k8s-rollout-status
 ```
 
 - In an emergency, if the rollout is causing failures, you can roll-back to the previous state.
+
 ```sh
 make k8s-rollback
 ```
@@ -72,6 +88,7 @@ make k8s-rollback
 This section lists the one-time steps required before performing the deployment steps described above.
 
 ##### Provision AWS Resources and K8s Secrets
+
 - Create an AWS RDS PostgreSQL instance
 - Create a K8s secrets resource that provides the `DJANGO_SECRET_KEY`, `POSTGRES_HOST`, and `POSTGRES_PASSWORD` values
 - Create an AWS SSL certificate (for the ELB) and use its ARN as the value for `APP_SERVICE_CERT_ARN`

--- a/k8s/search-index-update-job.yaml.j2
+++ b/k8s/search-index-update-job.yaml.j2
@@ -1,0 +1,27 @@
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: search-index-update
+spec:
+  template:
+    metadata:
+      name: search-index-update
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: search-index-update
+          image: {{ APP_IMAGE }}:{{ APP_IMAGE_TAG }}
+          imagePullPolicy: {{ APP_IMAGE_PULL_POLICY }}
+          command:
+            - python
+          args:
+            - manage.py
+            - wagtail_update_index
+          resources:
+            requests:
+              cpu: {{ APP_CPU_REQUEST }}
+              memory: {{ APP_MEMORY_REQUEST }}
+            limits:
+              cpu: {{ APP_CPU_LIMIT }}
+              memory: {{ APP_MEMORY_LIMIT }}
+{% include 'app.env.yaml.j2' %}


### PR DESCRIPTION
This changeset adds k8s deployment config to rebuild search index after deployment.

This is so that if the changeset being deployed contains changes to the search index (including deploying search to production the first time) we need to make sure the index is ready.

It needs to follow after migrations have been completed, because the `wagtailsearch` app itself has migrations.
- summarise changes here, linking to commits as appropriate

## How to test

- This isn't staged yet - for now code review is enough, then after that I will try deploying it to staging. It won't hit production until the related Epic is ready for launch in a couple of weeks' time, but I will ship it to dev and staging before then
