### PR TITLE
1534: Add slightly customised search indexing of Event and ExternalEvent

### DIFF
--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -32,6 +32,7 @@ from wagtail.core.blocks import PageChooserBlock
 from wagtail.core.fields import RichTextField, StreamBlock, StreamField
 from wagtail.core.models import Orderable
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.search import index
 
 from ..common.blocks import AgendaItemBlock, ExternalSpeakerBlock, FeaturedExternalBlock
 from ..common.constants import (
@@ -465,6 +466,15 @@ class Event(BasePage):
             ObjectList(settings_panels, heading="Settings", classname="settings"),
         ]
     )
+
+    # Search config
+    search_fields = BasePage.search_fields + [  # Inherit search_fields from Page
+        # "title" is already specced in BasePage
+        index.SearchField("description"),
+        index.SearchField("body"),
+        # Add FilterFields for things we may be filtering on (eg topics)
+        index.FilterField("slug"),
+    ]
 
     @property
     def is_upcoming(self):

--- a/developerportal/apps/externalcontent/models.py
+++ b/developerportal/apps/externalcontent/models.py
@@ -288,6 +288,14 @@ class ExternalEvent(ExternalContent):
         ]
     )
 
+    # Search config
+    search_fields = BasePage.search_fields + [  # Inherit search_fields from Page
+        # "title" is already specced in BasePage
+        index.SearchField("description"),
+        # Add FilterFields for things we may be filtering on (eg topics)
+        index.FilterField("slug"),
+    ]
+
     @property
     def event(self):
         return self


### PR DESCRIPTION
This changeset extends the default indexing of `Event` and `ExternalEvent` pages beyond just `Page.title` to include additional fields from the models:

* `Event` -> `title`, `description` and `body` fields
* `ExternalEvent` -> `title` and `description`

(Related issue #1534)

## How to test

- nothing to test yet, because this is only configuration -- just a quick eyes-over code review os enough. We'll prove these work as part of backend Events search behaviour