### PR TITLE
1533: Backend support for Events search

### DIFF
--- a/developerportal/apps/articles/models.py
+++ b/developerportal/apps/articles/models.py
@@ -122,9 +122,6 @@ class Articles(BasePage):
     def get_resources(self, request):
         # This Page class will show both Articles/Posts and Videos in its listing
 
-        # We can't use __in in this deeply related query, so we have to make
-        # a custom Q object instead and pass is in as a filter, then deal with
-        # it later
         topics = request.GET.getlist(TOPIC_QUERYSTRING_KEY)
         topics_q = Q(topics__topic__slug__in=topics) if topics else Q()
 

--- a/developerportal/apps/articles/tests/test_articles.py
+++ b/developerportal/apps/articles/tests/test_articles.py
@@ -57,6 +57,11 @@ class ArticlesTests(PatchedWagtailPageTests):
         articles_page = Articles.objects.all()[0]
         self.assertEqual("Posts", articles_page.title)
 
+    def test_page_functions_with_search_params(self):
+        # If search is misconfigured, this will 500
+        response = self.client.get("/posts/?search=test")
+        assert response.status_code == 200
+
     def test_articles_page_parent_pages(self):
         """The Articles page can exist under another page."""
         self.assertAllowedParentPageTypes(Articles, {HomePage})

--- a/developerportal/apps/common/fixtures/common_plus_extras_for_search_tests.json
+++ b/developerportal/apps/common/fixtures/common_plus_extras_for_search_tests.json
@@ -584,12 +584,136 @@
 	{
 		"model": "events.events",
 		"pk": 33,
-		"fields": {
-			"social_image": null,
-			"featured": "[]",
-			"body": "[]"
-		}
+    "fields": {
+      "social_image": null,
+      "featured": "[{\"type\": \"event\", \"value\": 39, \"id\": \"25ea15ae-c793-4e9c-98e0-27c38c736a58\"}, {\"type\": \"event\", \"value\": 65, \"id\": \"261a28e6-ecea-4f33-a852-2db7483cfe00\"}]",
+      "body": "[{\"type\": \"button\", \"value\": {\"text\": \"Here is a test button\", \"page_link\": null, \"external_link\": \"https://example.com/test\"}, \"id\": \"f28519f5-ad66-4c44-bbaf-8216641f4f25\"}]"
+    }
 	},
+  {
+    "model": "events.event",
+    "pk": 48,
+    "fields": {
+      "social_image": null,
+      "description": "",
+      "start_date": "2020-06-15",
+      "end_date": "2020-06-25",
+      "latitude": null,
+      "longitude": null,
+      "register_url": "https://example.com/register",
+      "official_website": "https://example.com/",
+      "event_content": "https://example.com/event-x-2020-summary",
+      "body": "[{\"type\": \"paragraph\", \"value\": \"<h3>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</h3><p></p><p>Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Quae sequuntur igitur? Atque hoc loco similitudines eas, quibus illi uti solent, dissimillimas proferebas. Nam aliquando posse recte fieri dicunt nulla expectata nec quaesita voluptate. Duo Reges: constructio interrete. Que Manilium, ab iisque M. Vide igitur ne non debeas verbis nostris uti, sententiis tuis. Itaque in rebus minime obscuris non multus est apud eos disserendi labor. Consequatur summas voluptates non modo parvo, sed per me nihilo, si potest; In eo enim positum est id, quod dicimus esse expetendum.</p><p></p><h4>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</h4><p></p><p>Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Quae sequuntur igitur? Atque hoc loco similitudines eas, quibus illi uti solent, dissimillimas proferebas. Nam aliquando posse recte fieri dicunt nulla expectata nec quaesita voluptate.</p><ul><li>Duo Reges: constructio interrete.</li><li>Que Manilium, ab iisque M.</li><li>Vide igitur ne non debeas verbis nostris uti, sententiis tuis.</li></ul><p></p><p>Itaque in rebus minime obscuris non multus est apud eos disserendi labor. Consequatur summas voluptates non modo parvo, sed per me nihilo, si potest; In eo enim positum est id, quod dicimus esse expetendum.</p>\", \"id\": \"97b3a287-b79a-4429-bc3f-2e71c8e2164a\"}]",
+      "venue_name": "Test Hall",
+      "venue_url": "",
+      "address_line_1": "123 Test Street",
+      "address_line_2": "",
+      "address_line_3": "",
+      "city": "Testing-on-the-Wold",
+      "state": "Testshire",
+      "zip_code": "TE55ST",
+      "country": "GB",
+      "agenda": "[]",
+      "speakers": "[]",
+      "card_title": "",
+      "card_description": "",
+      "card_image": null,
+      "card_image_3_2": null
+    }
+  },
+  {
+    "model": "events.event",
+    "pk": 65,
+    "fields": {
+      "social_image": null,
+      "description": "<p>Description text is here. Lorem ipsum <b>dolor sit amet,</b> consectetur adipiscing elit. Hoc etsi multimodis reprehendi potest, tamen accipio, quod dant. <i>Quae fere omnia appellantur uno ingenii nomine, easque virtutes qui habent, ingeniosi vocantur.</i> At iam decimum annum in spelunca iacet. Ergo illi intellegunt quid Epicurus dicat, ego non intellego? Multiple match target. </p>",
+      "start_date": "2020-02-20",
+      "end_date": null,
+      "latitude": null,
+      "longitude": null,
+      "register_url": null,
+      "official_website": "",
+      "event_content": "",
+      "body": "[{\"type\": \"paragraph\", \"value\": \"<p>This is some body text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quodsi ipsam honestatem undique pertectam atque absolutam. Conferam tecum, quam cuique verso rem subicias; Atqui haec patefactio quasi rerum opertarum, cum quid quidque sit aperitur, definitio est. Cum salvum esse flentes sui respondissent, rogavit essentne fusi hostes. Scientiam pollicentur, quam non erat mirum sapientiae cupido patria esse cariorem. Duo Reges: constructio interrete. Quaesita enim virtus est, non quae relinqueret naturam, sed quae tueretur.</p><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quodsi ipsam honestatem undique pertectam atque absolutam. Conferam tecum, quam cuique verso rem subicias; Atqui haec patefactio quasi rerum opertarum, cum quid quidque sit aperitur, definitio est. Cum salvum esse flentes sui respondissent, rogavit essentne fusi hostes. Scientiam pollicentur, quam non erat mirum sapientiae cupido patria esse cariorem. Duo Reges: constructio interrete. Quaesita enim virtus est, non quae relinqueret naturam, sed quae tueretur.</p><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quodsi ipsam honestatem undique pertectam atque absolutam. Conferam tecum, quam cuique verso rem subicias; Atqui haec patefactio quasi rerum opertarum, cum quid quidque sit aperitur, definitio est. Cum salvum esse flentes sui respondissent, rogavit essentne fusi hostes. Scientiam pollicentur, quam non erat mirum sapientiae cupido patria esse cariorem. Duo Reges: constructio interrete. Quaesita enim virtus est, non quae relinqueret naturam, sed quae tueretur.</p><p></p>\", \"id\": \"1c82d453-bea2-4a40-89f9-de8d150ce5d2\"}]",
+      "venue_name": "",
+      "venue_url": "",
+      "address_line_1": "",
+      "address_line_2": "",
+      "address_line_3": "",
+      "city": "",
+      "state": "",
+      "zip_code": "",
+      "country": "CC",
+      "agenda": "[]",
+      "speakers": "[]",
+      "card_title": "",
+      "card_description": "",
+      "card_image": null,
+      "card_image_3_2": null
+    }
+  },
+  {
+    "model": "events.event",
+    "pk": 66,
+    "fields": {
+      "social_image": null,
+      "description": "This description has some keywords that are targets for search tests",
+      "start_date": "2020-02-13",
+      "end_date": null,
+      "latitude": null,
+      "longitude": null,
+      "register_url": null,
+      "official_website": "",
+      "event_content": "",
+      "body": "[{\"type\": \"paragraph\", \"value\": \"<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Illud quaero, quid ei, qui in voluptate summum bonum ponat, consentaneum sit dicere. Non est ista, inquam, Piso, magna dissensio. Sed quoniam et advesperascit et mihi ad villam revertendum est, nunc quidem hactenus; Eam stabilem appellas. Non est igitur voluptas bonum. Quae tamen a te agetur non melior, quam illae sunt, quas interdum optines. Verum tamen cum de rebus grandioribus dicas, ipsae res verba rapiunt; Duo Reges: constructio interrete.</p><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Illud quaero, quid ei, qui in voluptate summum bonum ponat, consentaneum sit dicere. Non est ista, inquam, Piso, magna dissensio. Sed quoniam et advesperascit et mihi ad villam revertendum est, nunc quidem hactenus; Eam stabilem appellas. Non est igitur voluptas bonum. Quae tamen a te agetur non melior, quam illae sunt, quas interdum optines. Verum tamen cum de rebus grandioribus dicas, ipsae res verba rapiunt; Duo Reges: constructio interrete.</p>\", \"id\": \"7450504a-7c98-4de4-88c9-82173dcedc28\"}]",
+      "venue_name": "",
+      "venue_url": "",
+      "address_line_1": "",
+      "address_line_2": "",
+      "address_line_3": "",
+      "city": "",
+      "state": "",
+      "zip_code": "",
+      "country": "AS",
+      "agenda": "[]",
+      "speakers": "[]",
+      "card_title": "",
+      "card_description": "",
+      "card_image": null,
+      "card_image_3_2": null
+    }
+  },
+  {
+    "model": "events.event",
+    "pk": 71,
+    "fields": {
+      "social_image": null,
+      "description": "<p>Description text here, not body text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Illud quaero, quid ei, qui in voluptate summum bonum ponat, consentaneum sit dicere. Superiores tres erant, quae esse possent, quarum est una sola defensa, eaque vehementer. Tum Piso: Quoniam igitur aliquid omnes, quid Lucius noster? Duo Reges: constructio interrete. Multiple match target. </p>",
+      "start_date": "2020-04-02",
+      "end_date": null,
+      "latitude": null,
+      "longitude": null,
+      "register_url": null,
+      "official_website": "",
+      "event_content": "",
+      "body": "[]",
+      "venue_name": "",
+      "venue_url": "",
+      "address_line_1": "",
+      "address_line_2": "",
+      "address_line_3": "",
+      "city": "",
+      "state": "",
+      "zip_code": "",
+      "country": "",
+      "agenda": "[]",
+      "speakers": "[]",
+      "card_title": "",
+      "card_description": "",
+      "card_image": null,
+      "card_image_3_2": null
+    }
+  },
 	{
 		"model": "externalcontent.externalcontent",
 		"pk": 39,
@@ -624,6 +748,17 @@
 		}
 	},
 	{
+		"model": "externalcontent.externalcontent",
+		"pk": 42,
+		"fields": {
+			"social_image": null,
+			"description": "<p>An External Event. Multiple match target.</p>",
+			"external_url": "https://www.example.com/test-event",
+			"card_image": null,
+			"card_image_3_2": null
+		}
+	},
+	{
 		"model": "externalcontent.externalarticle",
 		"pk": 39,
 		"fields": {
@@ -651,6 +786,16 @@
 		}
 	},
 	{
+		"model": "externalcontent.externalevent",
+		"pk": 42,
+		"fields": {
+			"start_date": "2020-05-29",
+      "end_date": null,
+      "city": "",
+      "country": ""
+		}
+	},
+	{
 		"model": "home.homepage",
 		"pk": 3,
 		"fields": {
@@ -668,66 +813,6 @@
 			"card_title": "",
 			"card_description": "",
 			"card_image": null
-		}
-	},
-	{
-		"model": "ingestion.ingestionconfiguration",
-		"pk": 1,
-		"fields": {
-			"source_name": "Mozilla Hacks",
-			"integration_type": "ExternalArticle",
-			"source_url": "https://hacks.mozilla.org/feed/",
-			"last_sync": "2020-01-01T00:00:00Z"
-		}
-	},
-	{
-		"model": "ingestion.ingestionconfiguration",
-		"pk": 2,
-		"fields": {
-			"source_name": "Mozilla Developer (YouTube)",
-			"integration_type": "Video",
-			"source_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCh5UlGiu9d6LegIeUCW4N1w",
-			"last_sync": "2020-01-01T00:00:00Z"
-		}
-	},
-	{
-		"model": "ingestion.ingestionconfiguration",
-		"pk": 3,
-		"fields": {
-			"source_name": "Layout Land (YouTube)",
-			"integration_type": "Video",
-			"source_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UC7TizprGknbDalbHplROtag",
-			"last_sync": "2020-01-01T00:00:00Z"
-		}
-	},
-	{
-		"model": "ingestion.ingestionconfiguration",
-		"pk": 4,
-		"fields": {
-			"source_name": "Mozilla Hacks (YouTube)",
-			"integration_type": "Video",
-			"source_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCijjo5gfAscWgNCKFHWm1EA",
-			"last_sync": "2020-01-01T00:00:00Z"
-		}
-	},
-	{
-		"model": "ingestion.ingestionconfiguration",
-		"pk": 5,
-		"fields": {
-			"source_name": "Mixed Reality Blog",
-			"integration_type": "ExternalArticle",
-			"source_url": "https://blog.mozvr.com/rss",
-			"last_sync": "2020-01-01T00:00:00Z"
-		}
-	},
-	{
-		"model": "ingestion.ingestionconfiguration",
-		"pk": 6,
-		"fields": {
-			"source_name": "Add-ons Blog",
-			"integration_type": "ExternalArticle",
-			"source_url": "https://blog.mozilla.org/addons/feed",
-			"last_sync": "2020-01-01T00:00:00Z"
 		}
 	},
 	{
@@ -2145,6 +2230,170 @@
 			"live_revision": null
 		}
 	},
+	{
+		"model": "wagtailcore.page",
+		"pk": 42,
+		"fields": {
+			"path": "00010204",
+			"depth": 2,
+			"numchild": 0,
+			"title": "Test External Event",
+			"draft_title": "Test External Event",
+			"slug": "test-external-event",
+			"content_type": [
+				"externalcontent",
+				"externalevent"
+			],
+			"live": true,
+			"has_unpublished_changes": false,
+			"url_path": "/test-external-event/",
+			"owner": null,
+			"seo_title": "",
+			"show_in_menus": false,
+			"search_description": "",
+			"go_live_at": null,
+			"expire_at": null,
+			"expired": false,
+			"locked": false,
+			"locked_at": null,
+			"locked_by": null,
+			"first_published_at": "2020-05-29T21:52:43.104Z",
+			"last_published_at": "2020-05-29T21:52:43.104Z",
+			"latest_revision_created_at": "2020-05-29T21:52:43.075Z",
+			"live_revision": null
+		}
+	},  {
+    "model": "wagtailcore.page",
+    "pk": 48,
+    "fields": {
+      "path": "0001000100040001",
+      "depth": 4,
+      "numchild": 0,
+      "title": "event 1",
+      "draft_title": "event 1",
+      "slug": "test-event-1",
+      "content_type": [
+        "events",
+        "event"
+      ],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/events/test-event-1/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "locked_at": null,
+      "locked_by": null,
+      "first_published_at": "2019-11-05T12:09:32.484Z",
+      "last_published_at": "2020-03-30T16:19:39.332Z",
+      "latest_revision_created_at": "2020-03-30T16:19:39.272Z",
+      "live_revision": null
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 71,
+    "fields": {
+      "path": "0001000100040008",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Test Event Two",
+      "draft_title": "Test Event Two",
+      "slug": "test-event-two",
+      "content_type": [
+        "events",
+        "event"
+      ],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/events/test-event-two/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "locked_at": null,
+      "locked_by": null,
+      "first_published_at": "2019-12-11T17:02:42.601Z",
+      "last_published_at": "2020-05-12T14:38:39.446Z",
+      "latest_revision_created_at": "2020-05-12T14:38:39.385Z",
+      "live_revision": null
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 65,
+    "fields": {
+      "path": "0001000100040002",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Test Event 3",
+      "draft_title": "Test Event 3",
+      "slug": "event-three",
+      "content_type": [
+        "events",
+        "event"
+      ],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/events/event-three/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "locked_at": null,
+      "locked_by": null,
+      "first_published_at": "2019-12-11T16:03:27.036Z",
+      "last_published_at": "2020-05-12T14:23:54.419Z",
+      "latest_revision_created_at": "2020-05-12T14:23:54.364Z",
+      "live_revision": null
+    }
+  },
+    {
+    "model": "wagtailcore.page",
+    "pk": 66,
+    "fields": {
+      "path": "0001000100040003",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Test Event Four",
+      "draft_title": "Test Event Four",
+      "slug": "event-four",
+      "content_type": [
+        "events",
+        "event"
+      ],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/events/event-four/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "locked_at": null,
+      "locked_by": null,
+      "first_published_at": "2019-12-11T16:03:27.036Z",
+      "last_published_at": "2020-05-12T14:23:54.419Z",
+      "latest_revision_created_at": "2020-05-12T14:23:54.364Z",
+      "live_revision": null
+    }
+  },
 	{
 		"model": "wagtailcore.collection",
 		"pk": 1,

--- a/developerportal/apps/common/tests/test_utils.py
+++ b/developerportal/apps/common/tests/test_utils.py
@@ -347,6 +347,55 @@ class CustomSearchTests(TestCase):
         self.assertEqual(items[0].id, 25)
         self.assertEqual(items[0].title, "ES6 In Depth: Destructuring")
 
+    def test_get_combined_events__search_terms_only(self):
+
+        cases = [
+            {
+                "desc": "No params (empty string) so no narrower scoping",
+                "terms": "",
+                "expected_count": 5,
+            },
+            {
+                "desc": "No params (None) so no narrower scoping",
+                "terms": None,
+                "expected_count": 5,
+            },
+            {
+                "desc": "Title match: Event",
+                "terms": "Test Event Four",
+                "expected_count": 1,
+                "page_ids": [66],
+            },
+            {
+                "desc": "Description match: Event",
+                "terms": "targets for search",
+                "expected_count": 1,
+                "page_ids": [66],
+            },
+            {
+                "desc": "Broader match: descriptions",
+                "terms": "Multiple match target",
+                "expected_count": 3,
+                "page_ids": [42, 65, 71],
+                # 42 is an ExternalEvent, rest are Events
+            },
+            {
+                "desc": "Targetted title match: ExternalEvent",
+                "terms": "Test External Event",
+                "expected_count": 1,
+                "page_ids": [42],
+            },
+        ]
+        for case in cases:
+            with self.subTest(msg=case["desc"]):
+                items = get_combined_events(self.page, search_terms=case["terms"])
+                _expected_count = case["expected_count"]
+                self.assertEqual(len(items), _expected_count, items)
+                if case.get("page_ids") is not None:
+                    self.assertEqual(
+                        sorted([page.id for page in items]), case["page_ids"]
+                    )
+
     def test_wagtail_version_increase(self):
         """wagtailsearch for Wagtail <=2.9 contains a niggle where terms are not
         escaped appropriately during indexing - which is why we bleach.clean() ours

--- a/developerportal/apps/common/tests/test_utils.py
+++ b/developerportal/apps/common/tests/test_utils.py
@@ -129,9 +129,9 @@ class HelperFunctionTestsWithFixtures(TestCase):
         self.assertGreater(len(items), 0)
 
     def test_get_combined_events(self):
-        """Getting combined events should not return items."""
+        """Getting combined events should return items."""
         items = get_combined_events(self.page)
-        self.assertEqual(len(items), 0)
+        self.assertEqual(len(items), 5)
 
     def test_get_combined_videos(self):
         """Getting combined articles should not return items."""

--- a/developerportal/apps/common/utils.py
+++ b/developerportal/apps/common/utils.py
@@ -102,7 +102,9 @@ def get_combined_articles_and_videos(page, q_object=None, search_terms=None, **f
     )
 
 
-def get_combined_events(page, reverse=False, q_object=None, **filters):
+def get_combined_events(
+    page, reverse=False, q_object=None, search_terms=None, **filters
+):
     """Get internal and external events matching filters."""
 
     return get_resources(
@@ -110,6 +112,7 @@ def get_combined_events(page, reverse=False, q_object=None, **filters):
         ["events.Event", "externalcontent.ExternalEvent"],
         filters=filters,
         q_object=q_object,
+        search_terms=search_terms,
         order_by="start_date",
         reverse=reverse,
     )

--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -278,6 +278,7 @@ class Events(BasePage):
 
     def get_filters(self, request):
         return {
+            "show_search_input": True,
             "countries": self.get_relevant_countries(),
             "event_dates": self.get_event_date_options(request),
             "topics": Topic.published_objects.order_by("title"),

--- a/developerportal/apps/events/tests/test_events.py
+++ b/developerportal/apps/events/tests/test_events.py
@@ -67,6 +67,11 @@ class EventsTests(PatchedWagtailPageTests):
     def test_events_subpages(self):
         self.assertAllowedSubpageTypes(Events, {Event})
 
+    def test_page_functions_with_search_params(self):
+        # If search is misconfigured, this will 500
+        response = self.client.get("/events/?search=test")
+        assert response.status_code == 200
+
     def test_events_get_events(self):
         # General test - more specific ones for the Qs are below.
         # These all fall into the "next X months" default view
@@ -152,7 +157,7 @@ class EventsTests(PatchedWagtailPageTests):
 
         events_page.get_events(fake_request)
         mock_get_combined_events.assert_called_once_with(
-            events_page, q_object=expected_q, reverse=False
+            events_page, q_object=expected_q, search_terms=None, reverse=False
         )
 
     @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")
@@ -164,7 +169,7 @@ class EventsTests(PatchedWagtailPageTests):
 
         events_page = Events.published_objects.first()
         fake_request = RequestFactory().get(
-            ("/?country=CA&country=ZA&topic=foo&topic=bar&topic=baz")
+            "/?country=CA&country=ZA&topic=foo&topic=bar&topic=baz&search=test+event"
         )
 
         # Build the query we expect to be generated
@@ -184,12 +189,79 @@ class EventsTests(PatchedWagtailPageTests):
 
         events_page.get_events(fake_request)
         mock_get_combined_events.assert_called_once_with(
-            events_page, q_object=expected_q, reverse=False
+            events_page, q_object=expected_q, search_terms="test event", reverse=False
+        )
+
+    @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")
+    @mock.patch("developerportal.apps.events.models.get_combined_events")
+    def test_events__get_events__query__filters__no_dates__no_search(
+        self, mock_get_combined_events, mock_get_past_event_cutoff
+    ):
+        mock_get_past_event_cutoff.return_value = datetime.date(2022, 10, 3)
+
+        events_page = Events.published_objects.first()
+        fake_request = RequestFactory().get(
+            "/?country=CA&country=ZA&topic=foo&topic=bar&topic=baz"
+        )
+
+        # Build the query we expect to be generated
+        # no date params past means everything for the next X months
+        overall_date_q = Q(
+            start_date__gte=datetime.date(2022, 10, 3),
+            start_date__lte=datetime.date(2023, 4, 4),
+        )
+
+        countries_q = Q(country__in=["CA", "ZA"])
+        topics_q = Q(topics__topic__slug__in=["foo", "bar", "baz"])
+
+        expected_q = Q()
+        expected_q.add(countries_q, Q.AND)
+        expected_q.add(overall_date_q, Q.AND)
+        expected_q.add(topics_q, Q.AND)
+
+        events_page.get_events(fake_request)
+        mock_get_combined_events.assert_called_once_with(
+            events_page, q_object=expected_q, search_terms=None, reverse=False
         )
 
     @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")
     @mock.patch("developerportal.apps.events.models.get_combined_events")
     def test_events__get_events__query__all_params_including_past_events(
+        self, mock_get_combined_events, mock_get_past_event_cutoff
+    ):
+        mock_get_past_event_cutoff.return_value = datetime.date(2022, 10, 3)
+
+        events_page = Events.published_objects.first()
+        fake_request = RequestFactory().get(
+            (
+                "/?country=CA&country=ZA&topic=foo&topic=bar&topic=baz"
+                f"&date={PAST_EVENTS_QUERYSTRING_VALUE}"
+                "&search=another+test+event"
+            )
+        )
+
+        # Add the Q that INCLUDES all past events
+        overall_date_q = Q(start_date__lte=datetime.date(2022, 10, 3))
+
+        countries_q = Q(country__in=["CA", "ZA"])
+        topics_q = Q(topics__topic__slug__in=["foo", "bar", "baz"])
+
+        expected_q = Q()
+        expected_q.add(countries_q, Q.AND)
+        expected_q.add(overall_date_q, Q.AND)
+        expected_q.add(topics_q, Q.AND)
+
+        events_page.get_events(fake_request)
+        mock_get_combined_events.assert_called_once_with(
+            events_page,
+            q_object=expected_q,
+            search_terms="another test event",
+            reverse=False,
+        )
+
+    @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")
+    @mock.patch("developerportal.apps.events.models.get_combined_events")
+    def test_events__get_events__query__filters_and_past_events__no_search(
         self, mock_get_combined_events, mock_get_past_event_cutoff
     ):
         mock_get_past_event_cutoff.return_value = datetime.date(2022, 10, 3)
@@ -215,12 +287,44 @@ class EventsTests(PatchedWagtailPageTests):
 
         events_page.get_events(fake_request)
         mock_get_combined_events.assert_called_once_with(
-            events_page, q_object=expected_q, reverse=False
+            events_page, q_object=expected_q, search_terms=None, reverse=False
         )
 
     @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")
     @mock.patch("developerportal.apps.events.models.get_combined_events")
     def test_events__get_events__query__all_params_including_future_events(
+        self, mock_get_combined_events, mock_get_past_event_cutoff
+    ):
+        mock_get_past_event_cutoff.return_value = datetime.date(2022, 10, 3)
+
+        events_page = Events.published_objects.first()
+        fake_request = RequestFactory().get(
+            (
+                "/?country=CA&country=ZA&topic=foo&topic=bar&topic=baz"
+                f"&date={FUTURE_EVENTS_QUERYSTRING_VALUE}"
+                f"&search=test+here"
+            )
+        )
+
+        # Add the Q that INCLUDES all future events
+        overall_date_q = Q(start_date__gte=datetime.date(2022, 10, 3))
+
+        countries_q = Q(country__in=["CA", "ZA"])
+        topics_q = Q(topics__topic__slug__in=["foo", "bar", "baz"])
+
+        expected_q = Q()
+        expected_q.add(countries_q, Q.AND)
+        expected_q.add(overall_date_q, Q.AND)
+        expected_q.add(topics_q, Q.AND)
+
+        events_page.get_events(fake_request)
+        mock_get_combined_events.assert_called_once_with(
+            events_page, q_object=expected_q, search_terms="test here", reverse=False
+        )
+
+    @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")
+    @mock.patch("developerportal.apps.events.models.get_combined_events")
+    def test_events__get_events__query__filters_and_future_events__no_search(
         self, mock_get_combined_events, mock_get_past_event_cutoff
     ):
         mock_get_past_event_cutoff.return_value = datetime.date(2022, 10, 3)
@@ -246,12 +350,49 @@ class EventsTests(PatchedWagtailPageTests):
 
         events_page.get_events(fake_request)
         mock_get_combined_events.assert_called_once_with(
-            events_page, q_object=expected_q, reverse=False
+            events_page, q_object=expected_q, search_terms=None, reverse=False
         )
 
     @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")
     @mock.patch("developerportal.apps.events.models.get_combined_events")
     def test_events__get_events__query__all_params_including_past_and_future_events(
+        self, mock_get_combined_events, mock_get_past_event_cutoff
+    ):
+        # So we show all events
+        mock_get_past_event_cutoff.return_value = datetime.date(2022, 10, 3)
+
+        events_page = Events.published_objects.first()
+        fake_request = RequestFactory().get(
+            (
+                "/?country=CA&country=ZA&topic=foo&topic=bar&topic=baz"
+                f"&date={PAST_EVENTS_QUERYSTRING_VALUE}"
+                f"&date={FUTURE_EVENTS_QUERYSTRING_VALUE}"
+                f"&search=another+test+query"
+            )
+        )
+
+        # Add the Q that INCLUDES ALL event dates
+        overall_date_q = Q()
+
+        countries_q = Q(country__in=["CA", "ZA"])
+        topics_q = Q(topics__topic__slug__in=["foo", "bar", "baz"])
+
+        expected_q = Q()
+        expected_q.add(countries_q, Q.AND)
+        expected_q.add(overall_date_q, Q.AND)
+        expected_q.add(topics_q, Q.AND)
+
+        events_page.get_events(fake_request)
+        mock_get_combined_events.assert_called_once_with(
+            events_page,
+            q_object=expected_q,
+            search_terms="another test query",
+            reverse=False,
+        )
+
+    @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")
+    @mock.patch("developerportal.apps.events.models.get_combined_events")
+    def test_events__get_events__query__filters_and_past_and_future_events__no_search(
         self, mock_get_combined_events, mock_get_past_event_cutoff
     ):
         # So we show all events
@@ -279,7 +420,7 @@ class EventsTests(PatchedWagtailPageTests):
 
         events_page.get_events(fake_request)
         mock_get_combined_events.assert_called_once_with(
-            events_page, q_object=expected_q, reverse=False
+            events_page, q_object=expected_q, search_terms=None, reverse=False
         )
 
     @mock.patch("developerportal.apps.events.models.get_past_event_cutoff")

--- a/developerportal/apps/externalcontent/models.py
+++ b/developerportal/apps/externalcontent/models.py
@@ -294,6 +294,7 @@ class ExternalEvent(ExternalContent):
         index.SearchField("description"),
         # Add FilterFields for things we may be filtering on (eg topics)
         index.FilterField("slug"),
+        index.FilterField("start_date"),
     ]
 
     @property


### PR DESCRIPTION
This changeset adds backend support for searching Events.

It uses the same pattern as with Posts page:

    /events/?search=my+query+here

Can also be combined with other parameters

    /events/?topic=css&search=some+keywords

(Related issue #1533)

## How to test

- Code is on [Staging](https://developer-portal-cdn.stage.mdn.mozit.cloud/events/), and you can test it by manipulating the URL, such as above

