### PR TITLE
Update cronjob to use IRSA

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -74,13 +74,14 @@ export GOOGLE_ANALYTICS ?= 0
 export ACTIVE_ENVIRONMENT ?= production
 
 # Backup config
+export RDS_BACKUP_NAME ?= "dev-portal-rds-backups"
 export RDS_BACKUP_DBTYPE ?= 'PGSQL'
-export RDS_BACKUP_SCHEDULE ?= '@daily'
 export RDS_BACKUP_IMAGE ?= mdnwebdocs/mdn-rds-backup
-export RDS_BACKUP_IMAGE_TAG ?= 6197650
-export RDS_BACKUP_DIR ?= '/backup'
-export RDS_BACKUP_BUCKET ?= 's3://developer-portal-backups-178589013767/backups'
+export RDS_BACKUP_IMAGE_TAG ?= 88e1721
+export RDS_BACKUP_DIR ?= "/backup"
+export RDS_BACKUP_BUCKET ?= "s3://developer-portal-backups-178589013767/backups"
 export RDS_BACKUP_DEBUG_MODE ?= 'false'
+export RDS_BACKUP_ROLE_ARN ?= "arn:aws:iam::178589013767:role/developer-portal-backups-role"
 
 ###############################
 ### core tasks

--- a/k8s/db-backups-cron.yaml.j2
+++ b/k8s/db-backups-cron.yaml.j2
@@ -1,9 +1,20 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ RDS_BACKUP_NAME }}
+  labels:
+    app: {{ RDS_BACKUP_NAME }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ RDS_BACKUP_ROLE_ARN }}
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: dev-portal-rds-backup
+  name: {{ RDS_BACKUP_NAME }}
+  labels:
+    app: {{ RDS_BACKUP_NAME }}
 spec:
-  schedule: {{ RDS_BACKUP_SCHEDULE }}
+  schedule: "@daily"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 3
   successfulJobsHistoryLimit: 3
@@ -12,9 +23,11 @@ spec:
       template:
         spec:
           restartPolicy: Never
+          serviceAccountName: {{ RDS_BACKUP_NAME }}
           containers:
-            - name: dev-portal-rds-backup
+            - name: {{ RDS_BACKUP_NAME }}
               image: {{ RDS_BACKUP_IMAGE }}:{{ RDS_BACKUP_IMAGE_TAG }}
+              imagePullPolicy: IfNotPresent
               {%- if RDS_BACKUP_DEBUG_MODE == 'true' %}
               command: [ "/bin/bash", "-c", "--" ]
               args: [ "while true; do sleep 30; done;" ]
@@ -26,16 +39,6 @@ spec:
                   value: {{ RDS_BACKUP_DIR }}
                 - name: BACKUP_BUCKET
                   value: {{ RDS_BACKUP_BUCKET }}
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: dev-portal-backups
-                      key: AWS_ACCESS_KEY_ID
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: dev-portal-backups
-                      key: AWS_SECRET_ACCESS_KEY
                 - name: BACKUP_PASSWORD
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
This changeset changes the RDS Cronjob to use Amazons IAM Roles for Service account, you can read more about this here https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/

Related PR: https://github.com/mdn/infra/pull/437
Related Issue: #1578 

## Key changes:

- Replace AWS IAM Access keys with Roles and utilize AWS EKS IAM Roles for Service Accounts

## How to test

- Apply kubernetes manifest
- Run a kubernetes job manually by running the command `kubectl create job --from=cronjob/dev-portal-rds-backups test`