### PR TITLE
1531: Add Search input to the Events page

### DIFF
--- a/developerportal/apps/events/models.py
+++ b/developerportal/apps/events/models.py
@@ -278,6 +278,7 @@ class Events(BasePage):
 
     def get_filters(self, request):
         return {
+            "show_search_input": True,
             "countries": self.get_relevant_countries(),
             "event_dates": self.get_event_date_options(request),
             "topics": Topic.published_objects.order_by("title"),


### PR DESCRIPTION
A pretty small change because everything 'just works' based on the development done for the filter form as part of adding Search to the Posts page

## How to test

- Code is on [staging](https://developer-portal.stage.mdn.mozit.cloud/events/) - please try it out, including confirming script injections (eg `<script>alert("injected!");</script>` do not get executed