### PR TITLE
1581: improve the UX of refining a view of Posts, Events or People 

### DIFF
--- a/developerportal/apps/articles/templates/articles.html
+++ b/developerportal/apps/articles/templates/articles.html
@@ -10,8 +10,8 @@
   {% static "img/icons/article-white.svg" as page_icon_asset_url %}
   {% include "molecules/header-strip.html" with content=page.title element="h1" page_icon_asset_url=page_icon_asset_url %}
 
-  <div id="posts-list">
-    {% include "organisms/filter-list.html" with type="article_or_video" resources=resources no_resources_message="No relevant posts found" hide_pagination=False page_anchor="#posts-list" %}
+  <div id="results-list">
+    {% include "organisms/filter-list.html" with type="article_or_video" resources=resources no_resources_message="No relevant posts found" hide_pagination=False %}
   </div>
   {% include "organisms/newsletter-signup.html" %}
 {% endblock content %}

--- a/developerportal/apps/common/constants.py
+++ b/developerportal/apps/common/constants.py
@@ -49,8 +49,8 @@ FUTURE_EVENTS_QUERYSTRING_VALUE = "future"
 DEFAULT_EVENTS_LOOKAHEAD_WINDOW_MONTHS = 6
 
 
-# Note: see app_tags.pagination_additional_filter_params to add support/whitelisting
-# to anynew querystring keys you add here, else they will be ignored
+# Note: see app_tags.pagination_additional_filter_params to add support
+# for any new querystring keys you add here, else they will be ignored
 ENVIRONMENT_PRODUCTION = "production"
 ENVIRONMENT_STAGING = "staging"
 ENVIRONMENT_DEVELOPMENT = "development"

--- a/developerportal/apps/common/tests/test_app_tags.py
+++ b/developerportal/apps/common/tests/test_app_tags.py
@@ -210,7 +210,7 @@ class AppTagsTestCase(TestCase):
                 ),
             },
             {
-                # Show that only whitelisted params are covered - 'evil', area'
+                # Show that only expected params are covered - 'evil', area'
                 # and 'location' will be skipped
                 "input_querystring": (
                     f"?{PAGINATION_QUERYSTRING_KEY}=234&{ROLE_QUERYSTRING_KEY}=test"

--- a/developerportal/apps/events/templates/events.html
+++ b/developerportal/apps/events/templates/events.html
@@ -25,8 +25,8 @@
       {% endif %}
     {% endfor %}
   </div>
-  <div id="events-list">
-    {% include "organisms/filter-list.html" with type="event" resources=events no_resources_message="No relevant events found" hide_pagination=False page_anchor="#events-list" %}
+  <div id="results-list">
+    {% include "organisms/filter-list.html" with type="event" resources=events no_resources_message="No relevant events found" hide_pagination=False %}
   </div>
   {% include "organisms/newsletter-signup.html" %}
 </main>

--- a/developerportal/apps/people/templates/people.html
+++ b/developerportal/apps/people/templates/people.html
@@ -11,8 +11,8 @@
 {% include "molecules/header-strip.html" with content=page.title element="h1" page_icon_asset_url=page_icon_asset_url %}
 
 <main role="main">
-  <div id="people-list">
-    {% include "organisms/filter-list.html" with type="person" resources=people no_resources_message="No people found" page_anchor="#people-list" %}
+  <div id="results-list">
+    {% include "organisms/filter-list.html" with type="person" resources=people no_resources_message="No people found" %}
   </div>
   {% include "organisms/newsletter-signup.html" %}
 </main>

--- a/developerportal/templates/molecules/filter-form.html
+++ b/developerportal/templates/molecules/filter-form.html
@@ -3,7 +3,7 @@
 <form
   class="filter-form js-filter-form"
   data-controls="{{ type }}-cards"
-  action="{{request.path}}" {# so we drop any anchor/hash from the URL (eg on events) #}
+  action="{{request.path}}#results-list"
 >
   {% if filters|has_at_least_two_filters %}
   <header class="filter-form-section js-filter-form-clear-section">

--- a/developerportal/templates/molecules/pagination.html
+++ b/developerportal/templates/molecules/pagination.html
@@ -5,7 +5,7 @@
 
   <span class="step-links">
   {% if items.has_previous %}
-    <a class="mzp-c-button mzp-t-small" href="?{{PAGINATION_QUERYSTRING_KEY}}={{ items.previous_page_number }}{{additional_qs_params}}{{page_anchor}}">Prev</a>
+    <a class="mzp-c-button mzp-t-small" href="?{{PAGINATION_QUERYSTRING_KEY}}={{ items.previous_page_number }}{{additional_qs_params}}#results-list">Prev</a>
   {% else %}
     <button class="mzp-c-button mzp-t-small" disabled>Prev</button>
   {% endif %}
@@ -15,7 +15,7 @@
   </span>
 
   {% if items.has_next %}
-    <a class="mzp-c-button mzp-t-small" href="?{{PAGINATION_QUERYSTRING_KEY}}={{ items.next_page_number }}{{additional_qs_params}}{{page_anchor}}">Next</a>
+    <a class="mzp-c-button mzp-t-small" href="?{{PAGINATION_QUERYSTRING_KEY}}={{ items.next_page_number }}{{additional_qs_params}}#results-list">Next</a>
   {% else %}
     <button class="mzp-c-button mzp-t-small" disabled>Next</button>
   {% endif %}


### PR DESCRIPTION
This changeset adds a change that takes the user to the top of the results list when they "Refine Results" on any page that features the filter form.

(Pagination already did this, so it made sense to also have Refine Results land users on the same part of the page, especially because the default view of an Events page focuses on featured content, not results.

(Related issue #1581)

## How to test

- Code is deployed on [staging](https://developer-portal.stage.mdn.mozit.cloud/)
- Please check filtering and pagination (you may need to deselect filters to get enough content) takes the user to the top of the results:
  - https://developer-portal.stage.mdn.mozit.cloud/posts/
  - https://developer-portal.stage.mdn.mozit.cloud/events/
  - https://developer-portal.stage.mdn.mozit.cloud/communities/people/

I think the experience is better like this, but please say if you disagree