### PR TITLE
1623: Support more featured items in topics

### DIFF
--- a/developerportal/apps/common/tests/test_app_tags.py
+++ b/developerportal/apps/common/tests/test_app_tags.py
@@ -264,11 +264,37 @@ class AppTagsTestCase(TestCase):
     def test_split_featured_items(self):
 
         cases = [
-            {"input": [1, 2, 3, 4, 5], "output": ([1, 2], [3, 4, 5], [])},
-            {"input": [1, 2, 3, 4], "output": ([1, 2], [], [3, 4])},
-            {"input": [1, 2, 3], "output": ([], [1, 2, 3], [])},
-            {"input": [1, 2], "output": ([1, 2], [], [])},
-            {"input": [1], "output": ([1], [], [])},
+            {
+                "input": [1, 2, 3, 4, 5, 6, 7],
+                "output": [
+                    {"items": [1, 2, 3], "count": 3},
+                    {"items": [4, 5, 6, 7], "count": 4},
+                ],
+            },
+            {
+                "input": [1, 2, 3, 4, 5, 6],
+                "output": [
+                    {"items": [1, 2, 3], "count": 3},
+                    {"items": [4, 5, 6], "count": 3},
+                ],
+            },
+            {
+                "input": [1, 2, 3, 4, 5],
+                "output": [
+                    {"items": [1, 2], "count": 2},
+                    {"items": [3, 4, 5], "count": 3},
+                ],
+            },
+            {
+                "input": [1, 2, 3, 4],
+                "output": [
+                    {"items": [1, 2], "count": 2},
+                    {"items": [3, 4], "count": 2},
+                ],
+            },
+            {"input": [1, 2, 3], "output": [{"items": [1, 2, 3], "count": 3}]},
+            {"input": [1, 2], "output": [{"items": [1, 2], "count": 2}]},
+            {"input": [1], "output": [{"items": [1], "count": 1}]},
         ]
 
         for case in cases:

--- a/developerportal/apps/topics/migrations/0053_update_streamblock.py
+++ b/developerportal/apps/topics/migrations/0053_update_streamblock.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='topic',
             name='featured',
-            field=wagtail.core.fields.StreamField([('post', wagtail.core.blocks.PageChooserBlock(page_type=['articles.Article', 'externalcontent.ExternalArticle'])), ('external_page', wagtail.core.blocks.StructBlock([('url', wagtail.core.blocks.URLBlock()), ('title', wagtail.core.blocks.CharBlock()), ('description', wagtail.core.blocks.TextBlock(required=False)), ('image', wagtail.images.blocks.ImageChooserBlock(help_text='16:9 aspect-ratio image', label='16:9 image')), ('image_3_2', wagtail.images.blocks.ImageChooserBlock(help_text='3:2 aspect-ratio image - optiopnal but recommended', label='3:2 image', required=False))]))], blank=True, help_text='Optional space for featured items, max. 5', null=True),
+            field=wagtail.core.fields.StreamField([('post', wagtail.core.blocks.PageChooserBlock(page_type=['articles.Article', 'externalcontent.ExternalArticle'])), ('external_page', wagtail.core.blocks.StructBlock([('url', wagtail.core.blocks.URLBlock()), ('title', wagtail.core.blocks.CharBlock()), ('description', wagtail.core.blocks.TextBlock(required=False)), ('image', wagtail.images.blocks.ImageChooserBlock(help_text='16:9 aspect-ratio image', label='16:9 image')), ('image_3_2', wagtail.images.blocks.ImageChooserBlock(help_text='3:2 aspect-ratio image - optiopnal but recommended', label='3:2 image', required=False))]))], blank=True, help_text='Optional space for featured items, max. 7', null=True),
         ),
         migrations.AlterField(
             model_name='topic',

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -93,12 +93,12 @@ class Topic(BasePage):
                 ("external_page", FeaturedExternalBlock()),
             ],
             min_num=2,
-            max_num=5,
+            max_num=7,
             required=True,
         ),
         null=True,
         blank=True,
-        help_text="Optional space for featured items, max. 5",
+        help_text="Optional space for featured items, max. 7",
     )
     #  "What We've Been Working On" panel
     recent_work = StreamField(

--- a/developerportal/templates/organisms/featured.html
+++ b/developerportal/templates/organisms/featured.html
@@ -24,18 +24,25 @@ Two items:
   {% split_featured_items featured as split_featured %}
 
   {% comment %}
-  `split_featured` is an iterable with the following lists:
-    - top_row_of_2
-    - bottom_row_of_3
-    - bottom_row_b_of_2
-  where only one of bottom_row_of_3 OR bottom_row_b_of_2 will have members
+
+
+  `split_featured` returns an iterable of dicts where each dict represents a list of
+  items to render on a particular row
+  [
+      {
+          items: <List>
+          count: <int>
+      },
+      ...
+  ]
+
   {% endcomment %}
 
-  {% with top_row_of_two=split_featured.0 bottom_row_of_three=split_featured.1 bottom_row_of_two=split_featured.2 %}
+  {% for row in split_featured %}
 
-    {% if top_row_of_two %}
+    {% if row.count == 2 %}
     <div class="mzp-l-card-half">
-      {% for block in top_row_of_two %}
+      {% for block in row.items %}
         <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-3-2">
           {% include "organisms/partials/featured-card-selector.html" with aspect_ratio="3_2" %}
         </section>
@@ -43,18 +50,9 @@ Two items:
     </div>
     {% endif %}
 
-    {% comment %} Only one of bottom_row_of_two or bottom_row_of_three will evaluate to truthy {% endcomment %}
-    {% if bottom_row_of_two %}
-      <div class="mzp-l-card-half">
-        {% for block in bottom_row_of_two %}
-          <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-3-2">
-            {% include "organisms/partials/featured-card-selector.html" with aspect_ratio="3_2" %}
-          </section>
-        {% endfor %}
-      </div>
-    {% elif bottom_row_of_three %}
+    {% if row.count == 3 %}
       <div class="mzp-l-card-third">
-        {% for block in bottom_row_of_three %}
+        {% for block in row.items %}
             <section class="mzp-c-card mzp-c-card-small mzp-has-aspect-16-9">
               {% include "organisms/partials/featured-card-selector.html" %}
             </section>
@@ -62,5 +60,15 @@ Two items:
       </div>
     {% endif %}
 
-  {% endwith %}
+    {% if row.count == 4 %}
+      <div class="mzp-l-card-quarter">
+        {% for block in row.items %}
+            <section class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-16-9">
+              {% include "organisms/partials/featured-card-selector.html" %}
+            </section>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+  {% endfor %}
 </div>

--- a/developerportal/templatetags/app_tags.py
+++ b/developerportal/templatetags/app_tags.py
@@ -181,62 +181,110 @@ def get_menu_item_icon(page):
 
 @register.simple_tag
 def split_featured_items(iterable):
-    """For the given `iterable`, return it split into two lists appropriate
+    """For the given `iterable`, return it split into two lists appropriate to
+    the length of the iterable and compatible with a sensible HTML layout
 
-    The layout will look like this:
+    As such we return the following list of dicts, each containing a list and a total
+
+    rows = [
+        {
+            items: <List>
+            count: <int>
+        },
+        ...
+    ]
+
+    At the moment, `rows` will have one or two members
+
+    Seven items:
+        rows = [
+            {
+                items: [item_1 , item_2, item_3],
+                count: 3
+            },
+            {
+                items: [item_4, item_5, item_6, item_7],
+                count: 4
+            }
+        ]
+
+    Six items:
+        rows = [
+            {
+                items: [item_1 , item_2, item_3],
+                count: 3
+            },
+            {
+                items: [item_4, item_5, item_6],
+                count: 3
+            }
+        ]
 
     Five items:
-        [ 1 ] [ 2 ]
-        [3] [4] [5]
+        rows = [
+            {
+                items: [item_1 , item_2],
+                count: 2
+            },
+            {
+                items: [item_3 , item_4, item_5],
+                count: 3
+            }
+        ]
 
     Four items:
-        [ 1 ] [ 2 ]
-        [ 3 ] [ 4 ]
+        rows = [
+            {
+                items: [item_1 , item_2],
+                count: 2
+            },
+            {
+                items: [item_3 , item_4],
+                count: 2
+            }
+        ]
 
     Three items:
-        [1] [2] [3]
+        rows = [
+            {
+                items: [item_1 , item_2, item_3],
+                count: 3
+            },
+        ]
 
     Two items:
-        [ 1 ] [ 2 ]
+        rows = [
+            {
+                items: [item_1 , item_2],
+                count: 2
+            },
+        ]
 
-    (There is no one-item version supported)
-
-    As such we return the following lists:
-        - top_row_of_2
-        - bottom_row_of_3
-        - bottom_row_b_of_2
-    where only one of bottom_row_of_3 OR bottom_row_b_of_2 will have members
-
-    Five items:
-        top_row_of_2        -> [1, 2]
-        bottom_row_of_3     -> [3, 4, 5]
-        bottom_row_b_of_2   -> []
-
-    Four items:
-        top_row_of_2        -> [1, 2]
-        bottom_row_of_3     -> []
-        bottom_row_b_of_2   -> [3, 4]
-
-    Three items:
-        top_row_of_2        -> []
-        bottom_row_of_3     -> [1, 2, 3]
-        bottom_row_b_of_2   -> []
-
-    Two items:
-        top_row_of_2        -> [1, 2]
-        bottom_row_of_3     -> []
-        bottom_row_b_of_2   -> []
+    One item:
+        rows = [
+            {
+                items: [item_1],
+                count: 1
+            },
+        ]
 
     """
-    output = (iterable, [], [])  # sane default
+    output = []
 
-    if len(iterable) == 5:
-        output = (iterable[:2], iterable[2:], [])
-    elif len(iterable) == 4:
-        output = (iterable[:2], [], iterable[2:])
-    elif len(iterable) == 3:
-        output = ([], iterable, [])
-    elif len(iterable) == 2:
-        output = (iterable, [], [])
+    if len(iterable) in [6, 7]:
+        # Two rows with 3 + 3 or 3 + 4
+        output = [
+            dict(items=iterable[:3], count=len(iterable[:3])),
+            dict(items=iterable[3:], count=len(iterable[3:])),
+        ]
+    elif len(iterable) in [4, 5]:
+        # Two rows with 2 + 2 or 2 + 3
+        output = [
+            dict(items=iterable[:2], count=len(iterable[:2])),
+            dict(items=iterable[2:], count=len(iterable[2:])),
+        ]
+    else:
+        # single row, the same length as the original iterable
+        output = [dict(items=iterable, count=len(iterable))]
 
     return output


### PR DESCRIPTION
This changeset addresses a need to be able to show more than five featured items on a `Topic` page. 

It now allows up to seven, including six.

This change only applies to the Topic page, but it would be easy enough to use on the Homepage and Events page, if need be, simply by increasing the maximum allowed in the editor (a two-character code change).

The previous layout patterns are still supported, with the same results as prior to the refactor

#### Example of six featured cards

![Screenshot_2020-06-27 AV1 Video(1)](https://user-images.githubusercontent.com/101457/85920734-1ff0a780-b86e-11ea-8379-e83bcba9cf69.png)


#### Example of seven featured cards

![Screenshot_2020-06-27 AV1 Video](https://user-images.githubusercontent.com/101457/85920739-28e17900-b86e-11ea-8f7e-f0f7d619af12.png)

(Related issue #1623)

## Key changes:

- Refactored Django tempate tag that splits up a list of _n_ pages into (effectively) a list of sub-lists, with one sub-list for each row, including an explicit count of items in each row
- Refactored "featured items" HTML component to support up to four items in a row
- Generally the Python and HTML code are cleaner and less opinonated than before
- Updated config for the `Topic.featured` Streamfield to allow for 7 items, up from 5. Tweaked the help-text in a way that doesn't need an additional migraiton (because changing help-text is a no-op in database terms, it's fine to edit the last migration that captured the state of that help_text)

## How to test

- Code is deployed to DEV. Please use preview mode of a Topic page to easily confirm that 2....7 items are possible and work fine.

