### PR TITLE
1453: Add search input in nav

### DIFF
--- a/developerportal/apps/search/templates/site-search.html
+++ b/developerportal/apps/search/templates/site-search.html
@@ -24,7 +24,7 @@
     </main>
 
     <aside class="mzp-l-sidebar custom-width">
-      {% include "molecules/site-search-form.html" %}
+      {% include "molecules/site-search-form.html" with search_input_id="body_query" %}
     </aside>
 
   </div>

--- a/developerportal/apps/search/templates/site-search.html
+++ b/developerportal/apps/search/templates/site-search.html
@@ -24,13 +24,7 @@
     </main>
 
     <aside class="mzp-l-sidebar custom-width">
-      <form class="site-search-form" action="{% url 'search.site_search' %}" method="get">
-        <label for="id_query">
-          Search this site
-        </label>
-        <input class="site-search-field" id="id_query" type="search" name="{{SEARCH_QUERYSTRING_KEY}}" placeholder="Enter search terms" value="{{ search_query|default:'' }}">
-        <button class="visually-hidden" type="submit">Search</button>
-      </form>
+      {% include "molecules/site-search-form.html" %}
     </aside>
 
   </div>

--- a/developerportal/templates/header.html
+++ b/developerportal/templates/header.html
@@ -64,6 +64,9 @@
                       </li>
                     {% endwith %}
                   {% endfor %}
+                  <li class="mzp-c-menu-category">
+                    {% include "molecules/site-search-form.html" with hide_label=True placeholder_text="Search" %}
+                  </li>
                 </ul>
               </nav>
             </div>

--- a/developerportal/templates/header.html
+++ b/developerportal/templates/header.html
@@ -65,7 +65,7 @@
                     {% endwith %}
                   {% endfor %}
                   <li class="mzp-c-menu-category">
-                    {% include "molecules/site-search-form.html" with hide_label=True placeholder_text="Search" %}
+                    {% include "molecules/site-search-form.html" with hide_label=True placeholder_text="Search" search_input_id="nav_search_query" %}
                   </li>
                 </ul>
               </nav>

--- a/developerportal/templates/molecules/site-search-form.html
+++ b/developerportal/templates/molecules/site-search-form.html
@@ -4,18 +4,19 @@ Component for displaying site-search input.
 Optional params:
 - hide_label <Boolean>
 - placeholder_text <str>
+- search_input_id <str>
 
 
 {% endcomment %}
 
 
 <form class="site-search-form" action="{% url 'search.site_search' %}" method="get">
-  <label for="id_query" {% if hide_label %}class="visually-hidden"{% endif %}>
+  <label for="{{search_input_id}}" {% if hide_label %}class="visually-hidden"{% endif %}>
     Search this site
   </label>
   <input
     class="site-search-field"
-    id="id_query"
+    id="{{search_input_id}}"
     type="text"
     name="{{SEARCH_QUERYSTRING_KEY}}" placeholder="{{placeholder_text|default:'Enter search terms'}}" value="{{ search_query|default:'' }}">
   <button class="visually-hidden" type="submit">Search</button>

--- a/developerportal/templates/molecules/site-search-form.html
+++ b/developerportal/templates/molecules/site-search-form.html
@@ -1,0 +1,22 @@
+{% comment %}
+Component for displaying site-search input.
+
+Optional params:
+- hide_label <Boolean>
+- placeholder_text <str>
+
+
+{% endcomment %}
+
+
+<form class="site-search-form" action="{% url 'search.site_search' %}" method="get">
+  <label for="id_query" {% if hide_label %}class="visually-hidden"{% endif %}>
+    Search this site
+  </label>
+  <input
+    class="site-search-field"
+    id="id_query"
+    type="text"
+    name="{{SEARCH_QUERYSTRING_KEY}}" placeholder="{{placeholder_text|default:'Enter search terms'}}" value="{{ search_query|default:'' }}">
+  <button class="visually-hidden" type="submit">Search</button>
+</form>

--- a/developerportal/templates/molecules/site-search-form.html
+++ b/developerportal/templates/molecules/site-search-form.html
@@ -17,7 +17,7 @@ Optional params:
   <input
     class="site-search-field"
     id="{{search_input_id}}"
-    type="text"
+    type="search"
     name="{{SEARCH_QUERYSTRING_KEY}}" placeholder="{{placeholder_text|default:'Enter search terms'}}" value="{{ search_query|default:'' }}">
   <button class="visually-hidden" type="submit">Search</button>
 </form>

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -53,6 +53,7 @@
 @import 'molecules/resource-share';
 @import 'molecules/resource-toolbar';
 @import 'molecules/search-result';
+@import 'molecules/site-search-form';
 
 // Organisms.
 @import 'organisms/article-read-more';

--- a/src/css/molecules/header.scss
+++ b/src/css/molecules/header.scss
@@ -31,19 +31,19 @@
     }
   }
   .mzp-c-menu-item {
-    padding: 0px 24px 12px 0px;
+    padding: 0 24px 12px 0;
     .mzp-c-menu-item-desc {
       margin: $spacing-sm 0 0 $spacing-2xl;
 
       p {
-        margin-bottom: 0px;
+        margin-bottom: 0;
       }
     }
 
     .mzp-c-menu-item-link {
-      padding-bottom: 0px;
+      padding-bottom: 0;
       .mzp-c-menu-item-icon {
-        top: 0px;
+        top: 0;
         @media #{$mq-md} {
           top: 8px;
         }
@@ -53,11 +53,11 @@
 }
 
 .mzp-c-menu-category-list .site-search-form {
-  margin: 4px 0px 0px 0px;
+  margin: 4px 0 0;
   padding: $spacing-lg 0;
 
   @media #{$mq-md} {
-    margin: 4px 0px 0px 0px;
+    margin: 4px 0 0;
     padding: 0 0 0 $spacing-md;
   }
   input.site-search-field {

--- a/src/css/molecules/header.scss
+++ b/src/css/molecules/header.scss
@@ -51,3 +51,22 @@
     }
   }
 }
+
+.mzp-c-menu-category-list .site-search-form {
+  margin: 4px 0px 0px 0px;
+  padding: $spacing-lg 0;
+
+  @media #{$mq-md} {
+    margin: 4px 0px 0px 0px;
+    padding: 0 0 0 $spacing-md;
+  }
+  input.site-search-field {
+    width: 100%;
+    @media #{$mq-md} {
+      width: 200px;
+    }
+    @media #{$mq-xl} {
+      width: 100%;
+    }
+  }
+}

--- a/src/css/molecules/site-search-form.scss
+++ b/src/css/molecules/site-search-form.scss
@@ -2,9 +2,8 @@
   margin-bottom: $spacing-xl;
 
   input.site-search-field {
-    background-image: url('/static/img/icons/search-black.svg');
-    background-position: 3px 3px;
-    background-repeat: no-repeat;
+    background: transparent url('/static/img/icons/search-black.svg') 3px 3px
+      no-repeat;
     background-size: 24px auto;
     height: 2em;
     margin-bottom: $spacing-md;

--- a/src/css/molecules/site-search-form.scss
+++ b/src/css/molecules/site-search-form.scss
@@ -1,0 +1,18 @@
+.site-search-form {
+  margin-bottom: $spacing-xl;
+
+  input.site-search-field {
+    background-image: url('/static/img/icons/search-black.svg');
+    background-position: 3px 3px;
+    background-repeat: no-repeat;
+    background-size: 24px auto;
+    height: 2em;
+    margin-bottom: $spacing-md;
+    padding: $spacing-xs $spacing-xs $spacing-xs $spacing-xl;
+    width: 100%;
+
+    @media #{$mq-md} {
+      width: 80%;
+    }
+  }
+}

--- a/src/css/templates/site-search.scss
+++ b/src/css/templates/site-search.scss
@@ -6,6 +6,14 @@ body.site-search {
       display: block;
       flex-direction: row;
     }
+
+    .mzp-l-sidebar {
+      @media #{$mq-md} {
+        // hidden for non-sm viewports
+        display: none;
+        visibility: hidden;
+      }
+    }
   }
 
   .pagination-block {

--- a/src/css/templates/site-search.scss
+++ b/src/css/templates/site-search.scss
@@ -11,7 +11,6 @@ body.site-search {
       @media #{$mq-md} {
         // hidden for non-sm viewports
         display: none;
-        visibility: hidden;
       }
     }
   }

--- a/src/css/templates/site-search.scss
+++ b/src/css/templates/site-search.scss
@@ -8,25 +8,6 @@ body.site-search {
     }
   }
 
-  .site-search-form {
-    margin-bottom: $spacing-xl;
-
-    input.site-search-field {
-      background-image: url('/static/img/icons/search-black.svg');
-      background-position: 3px 3px;
-      background-repeat: no-repeat;
-      background-size: 24px auto;
-      height: 2em;
-      margin-bottom: $spacing-md;
-      padding: $spacing-xs $spacing-xs $spacing-xs $spacing-xl;
-      width: 100%;
-
-      @media #{$mq-md} {
-        width: 80%;
-      }
-    }
-  }
-
   .pagination-block {
     @media #{$mq-md} {
       text-align: left;


### PR DESCRIPTION
This changeset builds on PR https://github.com/mdn/developer-portal/pull/1624 to add a search input in the main nav

(Related issue #1453)

## Key changes:

- Added search input to main nav: 
  - Refactored the site search form into its own component, then re-used in the site nav.
  - Mobile and desktop breakpoints well supported. 
  - Medium breakpoint is tolerable, but the nav reflow breaks at certain seams.

- Hide the search input on the results page on all views except mobile/smallest viewport:
  - To avoid the duplication of the search input when on the results page (ie, in main page and in nav), I've taken a cue from MDN and we no longer show the search input beside the search results in desktop mode, but we DO show the input with the results at mobile viewport width.)

- Cross-browser tested
    - [X] Android Chrome
    - [X] Android FF
    - [X] Mobile Safari
    - [X] IE 11 Win 10 -> visually imperfect but works
    - [X] Edge Win 10
    - [X] FF Win
    - [X] Chrome Win
    - [X] FF Mac
    - [X] Chrome Mac
    - [X] Safari Mac

- HTML validated

![Screenshot_2020-06-28 Search - Mozilla Developer](https://user-images.githubusercontent.com/101457/85956546-4e5da800-b97e-11ea-911e-4b13c8008877.png)

![Screenshot_2020-06-28 Search - Mozilla Developer(1)](https://user-images.githubusercontent.com/101457/85956547-50276b80-b97e-11ea-8e20-334d35e73eed.png)




## How to test

- Code is deployed to [Stage](https://developer-portal.stage.mdn.mozit.cloud/), which minorly affects PR #1624 

- Try using the search at desktop and mobile breakpoints, in particular. 
- Also try it out on other breakpoints. Any suggestions of ways to make the seams a bit more elegant are welcome!