### PR TITLE
1625: Minor refactor to domain_from_url helper

### DIFF
--- a/developerportal/apps/common/tests/test_app_filters.py
+++ b/developerportal/apps/common/tests/test_app_filters.py
@@ -1,13 +1,19 @@
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
+
+from wagtail.core.models import Site
 
 from developerportal.templatetags.app_filters import domain_from_url
 
 
 class FilterTestCase(TestCase):
+    @override_settings(ALLOWED_HOSTS=["developer.mozilla.com"])
     def test_domain_from_url(self):
 
-        request = RequestFactory().get("/", HTTP_HOST="developer.mozilla.com")
+        Site.objects.create(
+            hostname="developer.mozilla.com", site_name="Test Site", root_page_id=1
+        )
 
+        request = RequestFactory().get("/", HTTP_HOST="developer.mozilla.com")
         assert request.META["HTTP_HOST"] == "developer.mozilla.com"
 
         cases = [

--- a/developerportal/templatetags/app_filters.py
+++ b/developerportal/templatetags/app_filters.py
@@ -78,7 +78,7 @@ def domain_from_url(url, request):
     if parsed.netloc:
         try:
             output = ".".join(parsed.netloc.split(".")[-2:])
-        except Exception:  # Deliberately broad
+        except (AttributeError, IndexError):
             pass
     else:
         site = Site._find_for_request(request=request)

--- a/developerportal/templatetags/app_filters.py
+++ b/developerportal/templatetags/app_filters.py
@@ -6,7 +6,7 @@ from django.utils.safestring import mark_safe
 
 import pygments
 from pygments import formatters, lexers
-from wagtail.core.models import Page
+from wagtail.core.models import Page, Site
 
 register = template.Library()
 
@@ -73,12 +73,15 @@ def split_across_two_columns(list_):
 
 @register.filter
 def domain_from_url(url, request):
+    output = ""
     parsed = urlparse(url)
     if parsed.netloc:
         try:
             output = ".".join(parsed.netloc.split(".")[-2:])
         except Exception:  # Deliberately broad
-            output = ""
+            pass
     else:
-        output = request.META.get("HTTP_HOST", "")
+        site = Site._find_for_request(request=request)
+        if site:
+            output = site.hostname
     return output


### PR DESCRIPTION
This changeset refactors `app_filters.domain_from_url`, which produces a _display_ string of the hostname for the target URL for a card link, in some situations (eg the 'What we're developing' section on https://developer.mozilla.com/topics/av1-video/)

We now use Wagtail's own lookup function to get a fallback domain hostname, rather than just pull it from HTTP headers.

This 
a) is less trusting of whatever value is in the header and only show a hostname if it's one we're expecting to (ie, it matches a configured Site in Django/Wagtail)

and

b) ensures that we show and use the configured site's hostname (ie the CDN hostname) not the hostname of the CMS in rendered pages (because this is the value that's configured in the Site record)

## How to test

- Code review is probably enough here, as there are also unit tests, but it is deployed to Staging, too
- Please challenge if you think this is an unnecesary change, or if you disagree that always showing the CDN hostname is more trouble than help.
