### PR TITLE
1621: Add load-testing tooling and perform initial test

### DIFF
--- a/locust/README.md
+++ b/locust/README.md
@@ -1,0 +1,46 @@
+# Locust.io usage for load testing
+
+This directory contains a basic `locustfile.py` for use when load testing the Developer Portal project.
+
+It expects all the structural pages to be present on the target site, as well as some content pages, which are present on all deployed environments at the time of setting up Locust.
+
+To learn more about Locust, see [https://docs.locust.io/en/stable/index.html](the official docs)
+
+## Quickstart
+
+### Simple local running, using a Docker image
+
+- `cd` into the `locust/` directory of the checked-out project and ensure that `locustfile.py` (or whichever configuration file you wish to run) is present in `locust/`
+
+* **Recommended approach**: spin up a main node and and (at least) four workers, use docker-compose:
+
+```bash
+docker-compose up --scale worker=4
+```
+
+Or if you just want to run a single Docker container:
+
+```bash
+docker run -p 8089:8089 -v $PWD:/mnt/locust locustio/locust -f /mnt/locust/locustfile.py
+```
+
+### View the dashboard
+
+Go to http://localhost:8089/
+
+### Start the tests
+
+**Number of total users to simulate**
+
+- Number of concurrent Locust users. Try starting with 200, but then dial it up for subsequent tests
+
+**Hatch rate**
+
+- Set how fast users are spawned. Try 3 to start with
+
+**Host**
+
+- Enter the hostname of the site you want to test, taking care to specify the CDNed version of the site if that's what you want to load test. Bear in mind that all deployed sites feature rate limiting.
+
+  - CDNed dev and stage sites: https://developer-portal-cdn.{rest of URL for the CMS origin site}
+  - CDNed prod site: https://developer.mozila.com

--- a/locust/docker-compose.yml
+++ b/locust/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  master:
+    image: locustio/locust
+    ports:
+      - '8089:8089'
+    volumes:
+      - ./:/mnt/locust
+    command: -f /mnt/locust/locustfile.py --master -H http://master:8089
+
+  worker:
+    image: locustio/locust
+    volumes:
+      - ./:/mnt/locust
+    command: -f /mnt/locust/locustfile.py --worker --master-host master

--- a/locust/locustfile.py
+++ b/locust/locustfile.py
@@ -1,0 +1,184 @@
+import random
+import string
+
+from locust import between, task
+from locust.contrib.fasthttp import FastHttpUser
+
+
+def get_asset_paths(add_cachebreaker=False) -> list:
+    """Return the JS and CSS bundle paths for the site -- at the moment we have
+    no need for code splitting, etc
+
+    While production uses django-whitenoise to serve files with a cachebreaking
+    hash, the files are also available via their unhashed filename.
+    If we want to, we can ask for them after appending a random cachebreaker
+    param as a querystring to ensure we get a fresh set every time we run the
+    load tests
+    """
+
+    if add_cachebreaker:
+        cachebreaker = f"?v={random.random()}"
+    else:
+        cachebreaker = ""
+
+    return [
+        f"/static/js/bundle.js{cachebreaker}",
+        f"/static/css/bundle.css{cachebreaker}",
+    ]
+
+
+def get_random_string(length=9):
+    return "".join(random.choice(string.ascii_lowercase) for i in range(length))
+
+
+class QuickstartUser(FastHttpUser):
+    wait_time = between(5, 9)
+
+    @task(6)
+    def view_homepage(self):
+        self.client.get("/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(4)
+    def view_posts_page(self):
+        self.client.get(f"/posts/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(2)
+    def view_posts_page_paginated(self):
+        random_page = random.randrange(1, 30)
+        path = f"/posts/?page={random_page}"
+
+        with self.client.get(path, catch_response=True) as response:
+            if response.status_code in [200, 404]:
+                response.success()
+
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(2)
+    def view_posts_page_filtered(self):
+        random_topic = random.choice(["rust", "voice", "browser-extensions"])
+        path = f"/posts/?topic={random_topic}"
+        self.client.get(path)
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(4)
+    def view_events_page(self):
+        self.client.get(f"/events/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(2)
+    def view_events_page_paginated(self):
+        random_page = random.randrange(1, 30)
+        path = f"/events/?page={random_page}"
+
+        with self.client.get(path, catch_response=True) as response:
+            if response.status_code in [200, 404]:
+                response.success()
+
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(2)
+    def view_events_page_filtered(self):
+        random_country_code = random.choice(["GB", "US", "NO", "NL", "DE"])
+        path = f"/events/?date=past&date=future&location={random_country_code}"
+        self.client.get(path)
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(1)
+    def view_event_page(self):
+        self.client.get(f"/events/view-source-conference-2019/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(1)
+    def view_topics_page(self):
+        self.client.get(f"/topics/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(4)
+    def view_topic_page(self):
+        self.client.get(f"/topics/rust/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(2)
+    def view_people_page(self):
+        self.client.get(f"/communities/people/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(1)
+    def view_person_page(self):
+        self.client.get(f"/communities/people/chris-mills/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(1)
+    def view_404_page(self):
+        with self.client.get("/does_not_exist/", catch_response=True) as response:
+            if response.status_code == 404:
+                response.success()
+            for asset_path in get_asset_paths():
+                self.client.get(asset_path)
+
+    @task(1)
+    def view_video_page(self):
+        self.client.get(f"/videos/firefox-font-editor-advanced/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(1)
+    def view_about_page(self):
+        self.client.get(f"/about/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(3)
+    def view_topic__developer_tools(self):
+        # This may fail if the target site doesn't have this Topic
+        self.client.get(f"/topics/developer-tools/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(2)
+    def view_topic__voice(self):
+        # This may fail if the target site doesn't have this Topic
+        self.client.get(f"/topics/voice/")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(1)
+    def search_site_with_random_string(self):
+        param = get_random_string()
+        self.client.get(f"/search/?search={param}")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)
+
+    @task(2)
+    def search_site_with_with_repeated_params(self):
+        # These should be satisfied by the CDN after the first search
+        param = get_random_string()
+
+        param = random.choice(
+            [
+                "Hello, World!",
+                "Firefox",
+                "CSS Grid",
+                "Mixed Reality",
+                "WebThings",
+                "Mozilla",
+                "jobs",
+            ]
+        )
+        self.client.get(f"/search/?search={param}")
+        for asset_path in get_asset_paths():
+            self.client.get(asset_path)


### PR DESCRIPTION
This changeset adds support for using Locust (https://locust.io) as a convenient way to load test the developer portal.

The approach used is a Dockerized solution (from a pre-built container: https://hub.docker.com/r/locustio/locust) which spins up a lead and worker nodes to increase the number of connections a single local machine can make.

If we want to take things further, we could try a Lambda-based Locust runner.

TLDR: I think we're fine for now.

* Dev deployment, with two small pods for `app`

- 100 concurrent users, hatched at 3/sec
  - Without CDN: sustained ~42 requests per second (RPS) and no saturation issues
  - with CDN: reached ~100 RPS and no saturation issues

- 250 concurrent users, hatched at 3/sec
  - included pagination queries (which will hit the origin until they've been cached by the CDN)
    - without CDN, and with rate-limiting turned off, started saturating DB connections ~240 concurrent users
    - with warmed CDN:
    - 100RPS was acheivable once the CDN was warm
    - response times were tiny (~24ms and ~40 for 95th percentile) - thanks, CloudFront!
   - With cold CDN and no rate limiting enabled, I stepped it up 500 simulated users
     - Got up to 215 rps with no noticeable warm-up issues. Initial page load started at 1000ms (which we can improve, but production's greater number of pods might also help with contention), but soon came down to ~100ms 95th percentile, then lower still as time went on.
     - It would be nice to pre-warm the CDN, but this is non-trivial as there are various edge locations to warm

* Staging deployment, with 2x the resources of the dev deployment

  - rate limiting was enabled
  - search was included, as a minority proportion of the requests - see the locustfile.py and the weightings in the @task() decorator
  - 500 users, spawning at 3/sec
    - starting with cold CDN:
       - comfortably hit 215 rps, and triggered rate limits for 1% of requests on search and pagination after ~300 users, but that's because it's from my local IP. 
    - without CDN, Stage got rate limited fast, but didn't 500