### PR TITLE
1690: Further tighten ingestion feed processing

### DIFF
--- a/developerportal/apps/common/constants.py
+++ b/developerportal/apps/common/constants.py
@@ -83,3 +83,5 @@ PAGE_TYPE_LOOKUP_FOR_LABEL = {
     "ContentPage": CONTENT,
     "Topic": TOPIC,
 }
+
+NON_SPACE_WHITESPACE = "\n\t\r"

--- a/developerportal/apps/common/utils.py
+++ b/developerportal/apps/common/utils.py
@@ -9,7 +9,11 @@ from django.utils.timezone import now as tz_now
 
 import bleach
 
-from ..common.constants import EVENTS_PAGE_SEARCH_FIELDS, POSTS_PAGE_SEARCH_FIELDS
+from ..common.constants import (
+    EVENTS_PAGE_SEARCH_FIELDS,
+    NON_SPACE_WHITESPACE,
+    POSTS_PAGE_SEARCH_FIELDS,
+)
 
 
 def _combined_query(models, fn):
@@ -30,7 +34,6 @@ def prep_search_terms(terms: str) -> str:
     """
 
     terms = unquote(terms)
-    NON_SPACE_WHITESPACE = "\n\t\r"
     terms = terms.translate(str.maketrans("", "", NON_SPACE_WHITESPACE))
     terms = bleach.clean(terms)
     terms = terms.strip()

--- a/developerportal/apps/ingestion/tests/test_utils.py
+++ b/developerportal/apps/ingestion/tests/test_utils.py
@@ -10,6 +10,7 @@ from dateutil.tz import tzlocal
 
 from developerportal.apps.ingestion.utils import (
     _get_item_description,
+    _get_item_title,
     _get_slug,
     fetch_external_data,
     ingest_content,
@@ -527,6 +528,51 @@ class UtilsTestCaseWithFixtures(TestCase):
         for case in cases:
             with self.subTest(input_=case["input"], expected=case["expected"]):
                 self.assertEqual(_get_slug(case["input"]), case["expected"])
+
+    def test_get_item_title(self):
+
+        cases = [
+            {
+                "input": "<h1>title here</h1>",
+                "expected": "title here",
+                "desc_": "drops markup 1",
+            },
+            {
+                "input": "<title>title here</title>",
+                "expected": "title here",
+                "desc_": "drops markup 2",
+            },
+            {
+                "input": "<p>title here</p>",
+                "expected": "title here",
+                "desc_": "drops markup 3",
+            },
+            {
+                "input": "<p><h1>title here</h1></p>",
+                "expected": "title here",
+                "desc_": "drops markup 4 (nested)",
+            },
+            {
+                "input": '<script>alert("boo");</script>',
+                "expected": 'alert("boo");',
+                "desc_": "drops script markup 5",
+            },
+            {
+                "input": "\ttitle\n\r\t\nhere\n\n\r\n",
+                "expected": "titlehere",
+                "desc_": "drops whitespace",
+            },
+            {
+                "input": "test title!&lt;marquee&gt;test&lt;/marquee&gt;",
+                "expected": "test title!&lt;marquee&gt;test&lt;/marquee&gt;",
+                "desc_": "Already-escaped markup is retained",
+            },
+        ]
+        for case in cases:
+            with self.subTest(label=case["desc_"]):
+                mock_entry = mock.Mock(title=case["input"])
+                assert mock_entry.title == case["input"]  # Confirm patch
+                self.assertEqual(_get_item_title(mock_entry), case["expected"])
 
     def test__get_item_description(self):
 

--- a/developerportal/apps/ingestion/tests/test_utils.py
+++ b/developerportal/apps/ingestion/tests/test_utils.py
@@ -563,6 +563,51 @@ class UtilsTestCaseWithFixtures(TestCase):
                 "expected": f"<p>{ 'x' * 393}</p>",
                 "desc_": "<p> node > 400 chars gets cut, but still wrapped in <p>",
             },
+            {
+                "input": (
+                    "<p>test description!&lt;marquee&gt;test&lt;/marquee&gt;</p>"
+                ),
+                "expected": (
+                    "<p>test description!&lt;marquee&gt;test&lt;/marquee&gt;</p>"
+                ),
+                "desc_": "Already-escaped markup is retained",
+            },
+            {
+                "input": "<p>test description!<marquee>test</marquee></p>",
+                "expected": "<p>test description!test</p>",
+                "desc_": "Unescaped markup is removed 1",
+            },
+            {
+                "input": '<p>test description!<script>alert("boo");</script></p>',
+                "expected": ('<p>test description!alert("boo");</p>'),
+                "desc_": "Unescaped markup is removed 2",
+            },
+            {
+                "input": '<script>alert("boo");</script>',
+                "expected": (""),
+                "desc_": "Unescaped markup is removed 3",
+            },
+            {
+                "input": (
+                    "<p>test description!"
+                    "<script>"
+                    '<script>alert("boo");</script>'
+                    "</script>"
+                    "</p>"
+                ),
+                "expected": (
+                    '<p>test description!&lt;script&gt;alert("boo");</p>'
+                    # Beautiful Soup drops the second </script> before we sanitise it
+                ),
+                "desc_": "Unescaped doubled-up markup is handled",
+            },
+            {
+                "input": (
+                    f"<p><script>alert('boo');</script>{ 'x' * 379}X, but not this</p>"
+                ),
+                "expected": (f"<p>alert('boo');{ 'x' * 379}X</p>"),
+                "desc_": "Truncation and removal of unescaped content",
+            },
         ]
         for case in cases:
             with self.subTest(label=case["desc_"]):

--- a/developerportal/apps/ingestion/utils.py
+++ b/developerportal/apps/ingestion/utils.py
@@ -22,7 +22,7 @@ import bleach
 import feedparser
 from bs4 import BeautifulSoup
 
-from ..common.constants import DESCRIPTION_MAX_LENGTH
+from ..common.constants import DESCRIPTION_MAX_LENGTH, NON_SPACE_WHITESPACE
 from ..externalcontent import models as externalcontent_models
 from ..mozimages.models import MozImage
 from ..videos import models as video_models
@@ -51,6 +51,17 @@ def _get_item_image(entry) -> str:
         return entry.media_content[0]["url"]
 
     return ""
+
+
+def _clean_string(string_: str) -> str:
+    "Get and clean up the given string, sanitising and dropping whitespace"
+    string_ = bleach.clean(string_, strip=True)
+    string_ = string_.translate(str.maketrans("", "", NON_SPACE_WHITESPACE))
+    return string_
+
+
+def _get_item_title(entry) -> str:
+    return _clean_string(entry.title)
 
 
 def _get_item_description(entry) -> str:
@@ -133,7 +144,7 @@ def fetch_external_data(feed_url: str, last_synced: datetime.datetime) -> list:
 
         output.append(
             dict(
-                title=entry.title,
+                title=_get_item_title(entry),
                 authors=[x["name"] for x in entry.authors],
                 url=entry.link,
                 description=_get_item_description(entry),

--- a/developerportal/apps/ingestion/utils.py
+++ b/developerportal/apps/ingestion/utils.py
@@ -18,6 +18,7 @@ from wagtail.admin.mail import send_notification
 from wagtail.core.models import Page
 from wagtail.embeds.blocks import EmbedValue
 
+import bleach
 import feedparser
 from bs4 import BeautifulSoup
 
@@ -76,6 +77,10 @@ def _get_item_description(entry) -> str:
             # truncate, allowing space to wrap in a <p>
             max_length = DESCRIPTION_MAX_LENGTH - (len("<p>") + len("</p>"))
             desc = desc[:max_length]
+
+        # Extra pass of sanitising, eg in case there are nested script tags
+        if desc:
+            desc = bleach.clean(desc, strip=False)
 
         # Ensure wrapped in something that can go into a rich-text field
         if desc:

--- a/developerportal/apps/ingestion/utils.py
+++ b/developerportal/apps/ingestion/utils.py
@@ -3,6 +3,7 @@ import datetime
 import hashlib
 import logging
 from io import BytesIO
+from typing import List
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -62,6 +63,19 @@ def _clean_string(string_: str) -> str:
 
 def _get_item_title(entry) -> str:
     return _clean_string(entry.title)
+
+
+def _get_item_authors(entry) -> List[str]:
+    "Get and clean up any string based on a list of author dicts"
+
+    cleaned_authors = []
+    for author in entry.authors:
+        author_name = author.get("name", "")
+        author_name = _clean_string(author_name)
+        if author_name:
+            cleaned_authors.append(author_name)
+
+    return cleaned_authors
 
 
 def _get_item_description(entry) -> str:
@@ -145,7 +159,7 @@ def fetch_external_data(feed_url: str, last_synced: datetime.datetime) -> list:
         output.append(
             dict(
                 title=_get_item_title(entry),
-                authors=[x["name"] for x in entry.authors],
+                authors=_get_item_authors(entry),  # Note: this isn't used yet...
                 url=entry.link,
                 description=_get_item_description(entry),
                 image_url=_get_item_image(entry),


### PR DESCRIPTION
This changeset tightens up the sanitisation of input strings we acquire from specific, explicitly-configured RSS and Atom feeds, which are then used to make draft pages. While the pages are manually checked before publication, it's still good to strip out as many potentially bad substrings as possible, even though the odds of the source feeds being bad themselves is low.

This work was done as part of pre-hard-launch hardening.

(Related issue #1609)

## Key changes:

- improve cleanup of description strings
- add cleanup of title strings
- add cleanup of author names

## How to test

- Code review only. Looking at the tests should guide you through my thinking. Please shout if you thikn there are gaps worth covering