### PR TITLE
1662: Ensure featured events show their dates

### DIFF
--- a/developerportal/apps/events/templates/events.html
+++ b/developerportal/apps/events/templates/events.html
@@ -22,7 +22,7 @@
   {% endif %}
   {% with page.featured|published as featured %}
     {% if featured %}
-      {% include "organisms/four-card-row.html" with items=featured header_text="Featured" show_domain=False tinted_panel=True %}
+      {% include "organisms/four-card-row.html" with items=featured header_text="Featured" show_dates=True show_domain=False tinted_panel=True %}
     {% endif %}
   {% endwith %}
   <div class="mzp-l-content events-middle-content">

--- a/developerportal/templates/molecules/quarter-page-item.html
+++ b/developerportal/templates/molecules/quarter-page-item.html
@@ -44,7 +44,9 @@ Inputs:
       </div>
       <div class="mzp-c-card-content">
         <div class="mzp-c-card-tag">
-        {% if show_domain %}
+        {% if show_dates %}
+          {{resource.event_dates_full}}
+        {% elif show_domain %}
           {% if external_page %}
             {{resource.url|domain_from_url:request }}
           {% else %}

--- a/developerportal/templates/organisms/four-card-row.html
+++ b/developerportal/templates/organisms/four-card-row.html
@@ -2,6 +2,7 @@
 Inputs:
   items: <List>( <StreamChild> )
   header_text: <str> - custom header text for the panel, mandatory
+  show_dates: <Boolean> - whether the quarter-page-item molecule should show dates, if available, else follow the show_domain logic below
   show_domain: <Boolean> - whether the quarter-page-item molecule should show a domain or default to the primary topic
   tinted_panel: <Boolean> - whether this panel is on a tinted background or not
 


### PR DESCRIPTION
The only place Events can currently be featured is on the Events page, so this changeset adds a new boolean possible in the four-card-row unit to handle this option, and the triggering boolean value is passed down from the parent events.html template

The four-card-row.html logic is getting a bit busy, so refactoring it is worthwhile when we have a bit more time on our hands.

(Related issue #1662)

![Screenshot 2020-07-10 at 16 41 13](https://user-images.githubusercontent.com/101457/87172718-9361d280-c2cc-11ea-8a93-b1080b158857.png)


## How to test

- Code is on its way to Staging, where you can check this change
- confirm featured events show dates
- confirm "What we're working on" on topics still shows domain names (because this it uses the HTML unit we've updated in this changeset)