### PR TITLE
1694: Add support for responding to a third hostname, as part of prep…

### DIFF
--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -251,6 +251,11 @@ BASE_URL = os.environ.get("BASE_URL")  # eg https://cms.example.net
 # URLs generated, and we want to ensure that means the CDN.
 CDN_URL = os.environ.get("CDN_URL")  # eg https://cdn.example.net
 
+# A supplementary URL we can add to ALLOWED_HOSTS to help with domain switchover
+SUPPLEMENTARY_URL = os.environ.get(
+    "SUPPLEMENTARY_URL"
+)  # eg https://domain-alternative.example.net
+
 
 AWS_REGION = os.environ.get("AWS_REGION")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")

--- a/developerportal/settings/production.py
+++ b/developerportal/settings/production.py
@@ -16,6 +16,12 @@ if CDN_URL:
     # It is different from the BASE_URL (where Wagtail is running).
     ALLOWED_HOSTS.append(urlparse(CDN_URL).hostname)
 
+if SUPPLEMENTARY_URL:
+    # This is the URL of an additional CDN/hostname to front the site,
+    # useful for domain switchover
+    # It is different from the BASE_URL (where Wagtail is running) and the CDN_URL
+    ALLOWED_HOSTS.append(urlparse(SUPPLEMENTARY_URL).hostname)
+
 try:
     from .local import *  # noqa
 except ImportError:

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -29,6 +29,7 @@ export APP_GUNICORN_WORKERS ?= 3
 export APP_GUNICORN_TIMEOUT ?= 118
 export APP_BASE_URL ?= https://${APP_HOST}
 export APP_CDN_URL ?= https://${APP_CDN_HOST}
+export APP_SUPPLEMENTARY_URL ?= https://${APP_SUPPLEMENTARY_HOST}
 export APP_MOUNT_PATH ?= /app/media
 
 export APP_EMAIL_HOST ?= email-smtp.us-west-2.amazonaws.com

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -9,6 +9,8 @@
               value: "{{ APP_BASE_URL }}"
             - name: CDN_URL
               value: "{{ APP_CDN_URL }}"
+            - name: SUPPLEMENTARY_URL
+              value: "{{ APP_SUPPLEMENTARY_URL }}"
             - name: DJANGO_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/k8s/config/dev.sh
+++ b/k8s/config/dev.sh
@@ -22,6 +22,8 @@ export APP_MEMORY_REQUEST=1Gi
 export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal.dev.mdn.mozit.cloud
 export APP_CDN_HOST=developer-portal-cdn.dev.mdn.mozit.cloud
+# APP_SUPPLEMENTARY_HOST is temporary
+export APP_SUPPLEMENTARY_HOST=developer-portal-cdn.dev.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-dev-178589013767
 export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-dev
 export APP_AWS_BUCKET_REGION=us-west-2

--- a/k8s/config/prod.sh
+++ b/k8s/config/prod.sh
@@ -22,6 +22,8 @@ export APP_MEMORY_REQUEST=2Gi
 export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal.prod.mdn.mozit.cloud
 export APP_CDN_HOST=developer.mozilla.com
+# APP_SUPPLEMENTARY_HOST is temporary
+export APP_SUPPLEMENTARY_HOST=mozilla.dev
 export APP_AWS_BUCKET_NAME=developer-portal-prod-178589013767
 export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-prod
 export APP_AWS_BUCKET_REGION=us-west-2

--- a/k8s/config/stage.sh
+++ b/k8s/config/stage.sh
@@ -22,6 +22,8 @@ export APP_MEMORY_REQUEST=2Gi
 export APP_GUNICORN_WORKERS=2
 export APP_HOST=developer-portal.stage.mdn.mozit.cloud
 export APP_CDN_HOST=developer-portal-cdn.stage.mdn.mozit.cloud
+# APP_SUPPLEMENTARY_HOST is temporary
+export APP_SUPPLEMENTARY_HOST=developer-portal-cdn.dev.mdn.mozit.cloud
 export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
 export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-stage
 export APP_AWS_BUCKET_REGION=us-west-2


### PR DESCRIPTION
This is a temporary change, as part of prearations for a domain switchover, and will be backed out once the domain change is done.

APP_SUPPLEMENTARY_HOST is configured as a new domain for prod, and as an existing domain for stage and dev (because we don't have additional hostnames pointing at them). It's a required value, so we had to put something in there.

APP_SUPPLEMENTARY_URL is built from APP_SUPPLEMENTARY_HOST and is exposed as SUPPLEMENTARY_URL via env vars.

ALLOWED_HOSTS gets a SUPPLEMENTARY_URL value added to it. If that duplicates what BASE_URL or CDN_URL are set to, that does NOT break the site.

(Related issue #1694)
