### PR TITLE
1612: Swap order of promos in nav

### DIFF
--- a/developerportal/templates/molecules/navigation/promotion.html
+++ b/developerportal/templates/molecules/navigation/promotion.html
@@ -5,7 +5,7 @@ Expects:
   `page`- a Page subclass that we'll use to determing which promoted item to feature
 
 {% endcomment %}
-{% if page.specific.resource_type == "topics" %}
+{% if page.specific.title == "Communities" %} {% comment %} Unpleasant, but only way {% endcomment %}
 
 <div class="mzp-c-menu-panel-card">
   <section class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-3-2">
@@ -38,7 +38,7 @@ Expects:
   </section>
 </div>
 
-{% elif page.specific.title == "Communities" %} {% comment %} Unpleasant, but only way {% endcomment %}
+{% elif page.specific.resource_type == "topics" %}
 
 <div class="mzp-c-menu-panel-card">
   <section class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-3-2">


### PR DESCRIPTION
This changeset swaps the ordering of the two promo card/links to the right side of the fold-down sub-menus of the navigation.

Now, the Products & Technologies nav sub-menu contains an MDN Promo instead of a FF Developer one, and the Communities one contains FF Developer not MDN.

<img width="1359" alt="Screenshot 2020-07-11 at 19 48 47" src="https://user-images.githubusercontent.com/101457/87231657-ead96e80-c3b0-11ea-910e-212558b6c00f.png">
<img width="1321" alt="Screenshot 2020-07-11 at 19 49 00" src="https://user-images.githubusercontent.com/101457/87231659-ee6cf580-c3b0-11ea-886f-df5b868c8c0e.png">



## How to test

- Code is on Staging. Please take a look and confirm whether you're happy with the result. 
(IMO, neither Firefox Develeopr edition nor MDN are particuarly 'at home' in Communities, but that's personal opinion)

 