### PR TITLE
1679: Make Products & Technologies block follow the ordering of items in the nav

### DIFF
--- a/developerportal/apps/home/models.py
+++ b/developerportal/apps/home/models.py
@@ -210,6 +210,4 @@ class HomePage(BasePage):
         """The site’s top-level topics, i.e. topics without a parent topic."""
         from ..topics.models import Topic
 
-        return Topic.published_objects.filter(parent_topics__isnull=True).order_by(
-            "title"
-        )
+        return Topic.published_objects.filter(parent_topics__isnull=True)

--- a/developerportal/apps/topics/models.py
+++ b/developerportal/apps/topics/models.py
@@ -372,4 +372,4 @@ class Topics(BasePage):
 
     @property
     def topics(self):
-        return Topic.published_objects.order_by("title")
+        return Topic.published_objects.all()


### PR DESCRIPTION
This changeset removes the order-by-title logic so that the topics block (used on the homepage and on the /topics/ page, which is live but orphaned) reflects the order of the Topic pages in the Wagtail admin

However, note that because the nav is a two-column vertical list of Topics and the topics block is a four-column horizontal list, we can't make the topics-block items appear in the same horizontal and vertical positioning/ordering as in the nav. (At least not without a HTML/CSS refactor or some extra Python logic.) So, for now the next-best-fit solution is simply to use the "top-down" ordering of the pages in the Wagtail admin as a left-to-right then top-down order (which is the natural flow of the grid)

## How to test

- Code is on staging for review and test drive. The ordering of the topics on the homepage and on /topics/ should show ordering that reflects the order/priority pages are given in the order set in the admin, even if it's not a direct/like-for-like ordering that matches the nav (see above for why)