### PR TITLE
1709: Header a11y improvements

### DIFF
--- a/developerportal/templates/base.html
+++ b/developerportal/templates/base.html
@@ -66,11 +66,14 @@
   </head>
   <body class="{% block body_class %}{% endblock %}">
     {% wagtailuserbar %}
+    {% include "molecules/accessibility-nav.html"%}
     {% block survey %}{% survey_prompt %}{% endblock survey%}
     {% block header %}
       {% include "header.html" %}
     {% endblock %}
+    <div id="content">
     {% block content %}{% endblock %}
+    </div>
     {% block footer %}
       {% include "footer.html" %}
     {% endblock %}

--- a/developerportal/templates/header.html
+++ b/developerportal/templates/header.html
@@ -10,9 +10,7 @@
         <div class="mzp-c-navigation-container">
           <button class="mzp-c-navigation-menu-button" type="button" aria-controls="patterns.organisms.navigation.navigation">Menu</button>
           <div class="mzp-c-navigation-logo">
-            <a href="/">
-              <img class="mozilla-developer-logo" src="/static/img/logos/developer/black.svg" alt="Mozilla Developer logo" />
-            </a>
+            <a href="/">Mozilla Developer</a>
           </div>
           <div class="mzp-c-navigation-items" id="patterns.organisms.navigation.navigation">
             <div class="mzp-c-navigation-menu">

--- a/developerportal/templates/molecules/accessibility-nav.html
+++ b/developerportal/templates/molecules/accessibility-nav.html
@@ -2,9 +2,7 @@
   <li>
     <a id="skip-main" href="#content">Skip to main content</a>
   </li>
-  {% comment 'not rendered until search is released' %}
   <li>
     <a id="skip-search" href="#nav_search_query">Skip to search</a>
   </li>
-  {% endcomment %}
 </ul>

--- a/developerportal/templates/molecules/accessibility-nav.html
+++ b/developerportal/templates/molecules/accessibility-nav.html
@@ -1,0 +1,10 @@
+<ul id="nav-access" class="nav-access">
+  <li>
+    <a id="skip-main" href="#content">Skip to main content</a>
+  </li>
+  {% comment 'not rendered until search is released' %}
+  <li>
+    <a id="skip-search" href="#nav_search_query">Skip to search</a>
+  </li>
+  {% endcomment %}
+</ul>

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -41,6 +41,7 @@
 @import 'atoms/typography';
 
 // Molecules.
+@import 'molecules/accessibility-nav';
 @import 'molecules/card';
 @import 'molecules/card-event';
 @import 'molecules/card-featured';

--- a/src/css/molecules/accessibility-nav.scss
+++ b/src/css/molecules/accessibility-nav.scss
@@ -1,0 +1,27 @@
+/*
+Keyboard & screen reader skip link menu
+********************************************************************** */
+
+.nav-access {
+  width: 100%;
+  position: absolute;
+  top: -20em;
+  z-index: 1001;
+
+  a {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background-color: rgba(255, 255, 255, 0.9);
+    padding: 12px 10px;
+    font-weight: bold;
+    text-align: center;
+
+    &:hover,
+    &:focus {
+      box-shadow: 3px 3px 5px #aaa;
+      top: 20em;
+      text-decoration: none;
+    }
+  }
+}

--- a/src/css/molecules/header.scss
+++ b/src/css/molecules/header.scss
@@ -1,25 +1,23 @@
-.header {
-  // FIX required for mzp
-  .mzp-c-navigation-menu {
-    box-sizing: unset;
+// FIX required for mzp
+.mzp-c-navigation-menu {
+  box-sizing: unset;
+}
+
+.mzp-c-navigation-logo {
+  /* On mobile: set a negative margin to align better with hamburger menu. Remember
+    that the Mozilla Developer logo is taller than the black Mozilla bar on its own */
+  margin-top: -10px;
+  width: 165px; // This is to ensure the logo doesn't flow under the hamburger on mobile Safari
+
+  @media #{$mq-md} {
+    /* wider viewports need some specific tweaks to override the mobile defaults */
+    margin-top: 23px; // 1px less than default, but is noticeable if not set
+    width: 114px;
   }
 
-  .mzp-c-navigation-logo {
-    /* On mobile: set a negative margin to align better with hamburger menu. Remember
-      that the Mozilla Developer logo is taller than the black Mozilla bar on its own */
-    margin-top: -10px;
-    width: 165px; // This is to ensure the logo doesn't flow under the hamburger on mobile Safari
-
-    @media #{$mq-md} {
-      /* wider viewports need some specific tweaks to override the mobile defaults */
-      margin-top: 23px; // 1px less than default, but is noticeable if not set
-      width: 114px;
-    }
-  }
-
-  .mzp-c-navigation-logo a {
+  & a {
     background-image: url('../img/logos/developer/black.svg');
-    height: auto;
+    height: 70px;
     width: auto;
     margin-top: 9px;
     background-size: 160px;
@@ -30,23 +28,25 @@
       background-size: 100%;
     }
   }
-  .mzp-c-menu-item {
-    padding: 0 24px 12px 0;
-    .mzp-c-menu-item-desc {
-      margin: $spacing-sm 0 0 $spacing-2xl;
+}
 
-      p {
-        margin-bottom: 0;
-      }
+.header .mzp-c-menu-item {
+  padding: 0 24px 12px 0;
+
+  .mzp-c-menu-item-desc {
+    margin: $spacing-sm 0 0 $spacing-2xl;
+    p {
+      margin-bottom: 0;
     }
+  }
 
-    .mzp-c-menu-item-link {
-      padding-bottom: 0;
-      .mzp-c-menu-item-icon {
-        top: 0;
-        @media #{$mq-md} {
-          top: 8px;
-        }
+  .mzp-c-menu-item-link {
+    padding-bottom: 0;
+
+    .mzp-c-menu-item-icon {
+      top: 0;
+      @media #{$mq-md} {
+        top: 8px;
       }
     }
   }


### PR DESCRIPTION
This changeset addresses a11y issues with the main nav spotted by @schalkneethling (thanks!)

* remove unnecessary <img>
* SCSS cleanup
* add quick-access nav links

Note that one recommendation from the source ticket #1709 was do drop a base-64 data-uri image from the CSS, but it looks like this was actually needed as the close trigger for the nav when in mobile-viewport mode.

![Screenshot 2020-07-14 at 18 03 14](https://user-images.githubusercontent.com/101457/87455975-2f0d7e80-c5fe-11ea-8546-177915884beb.png)


## How to test

- Code will be on [staging](https://developer-portal.stage.mdn.mozit.cloud/) by the time you read this