### PR TITLE
1718 hero unit a11y improvements

### DIFF
--- a/developerportal/apps/home/models.py
+++ b/developerportal/apps/home/models.py
@@ -129,8 +129,9 @@ class HomePage(BasePage):
         MultiFieldPanel(
             [
                 FieldPanel("subtitle"),
-                FieldPanel("button_text"),
-                FieldPanel("button_url"),
+                # DISABLED - header needs a design tweak to fit in a button robustly
+                # FieldPanel("button_text"),
+                # FieldPanel("button_url"),
             ],
             heading="Header section",
             help_text="Optional fields for the header section",

--- a/developerportal/templates/organisms/homepage-header.html
+++ b/developerportal/templates/organisms/homepage-header.html
@@ -2,19 +2,12 @@
 {% load wagtailimages_tags %}
 {% load static %}
 
-<header class="homepage-header visually-hidden">
-  <h1>{{page.title}}{% if page.subtitle %} - {{page.subtitle}}{% endif %}</h1>
-</header>
-<section class="c-primary-cta devportal-branding mzp-l-content">
-    <div class="c-primary-cta-wrapper">
-      <h2 class="c-primary-cta-title">{{ page.title|linebreaksbr }}</h2>
-      {% if page.subtitle %}
-      <h5 class="c-primary-cta-desc">{{ page.subtitle }}</h5>
-      {% endif %}
-      {% if page.button_text and page.button_url %}
-      <p class="c-primary-cta-button">
-        <a href="{{ page.button_url }}" class="mzp-c-button">{{ page.button_text }}</a>
-      </p>
-      {% endif %}
-  </div>
+
+<section class="c-primary-cta devportal-branding mzp-l-content" aria-labelledby="hero-heading">
+  <hgroup id="hero-heading" class="c-primary-cta-wrapper">
+    <h1 class="c-primary-cta-title">{{page.title}}</h1>
+    {% if page.subtitle %}
+    <h2 class="c-primary-cta-desc">{{page.subtitle}}</h2>
+    {% endif %}
+  </hgroup>
 </section>


### PR DESCRIPTION
This changeset addresses duplicated content in the header of the hompage, following one of the recommendations in the ticket

(Related issue #1718)

## How to test

- Code is deployed to  [staging](developer-portal.stage.mdn.mozit.cloud/)