### PR TITLE
Add support for enabling/disabling rate-limiting via env var

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -44,6 +44,9 @@ export APP_NOTIFY_AFTER_INGESTING_CONTENT ?= False
 export APP_TASK_COMPLETION_SURVEY_URL ?= undefined
 export APP_TASK_COMPLETION_SURVEY_PERCENTAGE ?= 5.00  # default 5%
 
+# Rate limiting
+export APP_RATELIMIT_ENABLE ?= True
+
 export CELERY_WORKER_NAME ?= celery-worker
 export CELERY_WORKER_REPLICAS ?= 1
 export CELERY_WORKER_CONCURRENCY ?= 2

--- a/k8s/app.env.yaml.j2
+++ b/k8s/app.env.yaml.j2
@@ -44,6 +44,8 @@
               value: "1"
             - name: GOOGLE_ANALYTICS
               value: "{{ GOOGLE_ANALYTICS }}"
+            - name: RATELIMIT_ENABLE
+              value: "{{ APP_RATELIMIT_ENABLE }}"
             - name: MAPBOX_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/config/stage.sh
+++ b/k8s/config/stage.sh
@@ -26,6 +26,8 @@ export APP_AWS_BUCKET_NAME=developer-portal-stage-178589013767
 export APP_AWS_STORAGE_BUCKET_NAME=devportal-media-stage
 export APP_AWS_BUCKET_REGION=us-west-2
 
+export APP_RATELIMIT_ENABLE=False
+
 export GOOGLE_ANALYTICS=UA-49796218-59
 
 export ACTIVE_ENVIRONMENT=staging


### PR DESCRIPTION
This changeset allows us to disable rate limiting via k8s config, and does this (temporarily) for stage to show it works.
## How to test

- Try to make more than 30 requests against stage in 60 seconds and it WILL currenlty be allowed