### PR TITLE
Redirect service

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,6 +135,9 @@ node {
       break
 
     case 'prod-push':
+      stage ('Deploy ingress') {
+        sh "make k8s-redirector"
+      }
       stage('Deploy') {
         deploy('prod', 'prod', 'mdn-apps-a')
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,9 +135,6 @@ node {
       break
 
     case 'prod-push':
-      stage ('Deploy ingress') {
-        sh "make k8s-redirector"
-      }
       stage('Deploy') {
         deploy('prod', 'prod', 'mdn-apps-a')
       }

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -84,6 +84,16 @@ export RDS_BACKUP_BUCKET ?= "s3://developer-portal-backups-178589013767/backups"
 export RDS_BACKUP_DEBUG_MODE ?= 'false'
 export RDS_BACKUP_ROLE_ARN ?= "arn:aws:iam::178589013767:role/developer-portal-backups-role"
 
+# Redirector
+export REDIRECTOR_NAME ?= "redirector"
+export REDIRECTOR_NAMESPACE ?= "redirector"
+export REDIRECTOR_REPLICAS ?= 1
+export REDIRECTOR_MAX_REPLICAS ?= 4
+export REDIRECTOR_IMAGE_NAME ?= mdnwebdocs/redirector
+export REDIRECTOR_IMAGE_TAG ?= ec2daf9
+export REDIRECTOR_SERVICE_PORT ?= 80
+export REDIRECTOR_CONTAINER_PORT ?= 80
+
 ###############################
 ### core tasks
 
@@ -140,6 +150,38 @@ k8s-hpa:
 test-k8s-hpa:
 	j2 hpa.yaml.j2 | kubeval --strict --ignore-missing-schemas
 
+k8s-redirector: k8s-redirector-ingress k8s-redirector-service k8s-redirector-deployment
+
+k8s-redirector-ns:
+	kubectl create ns ${REDIRECTOR_NAMESPACE} | true
+
+k8s-redirector-ingress:
+	j2 redirector.ingress.yaml.j2 | kubectl -n ${REDIRECTOR_NAMESPACE} apply -f -
+
+test-k8s-redirector-ingress:
+	j2 redirector.ingress.yaml.j2 | kubeval --strict --ignore-missing-schemas
+
+k8s-redirector-service:
+	j2 redirector.svc.yaml.j2 | kubectl -n ${REDIRECTOR_NAMESPACE} apply -f -
+
+test-k8s-redirector-service:
+	j2 redirector.svc.yaml.j2 | kubeval --strict --ignore-missing-schemas
+
+k8s-redirector-deployment:
+	j2 redirector.deployment.yaml.j2 | kubectl -n ${REDIRECTOR_NAMESPACE} apply -f -
+
+test-k8s-redirector-deployment:
+	j2 redirector.deployment.yaml.j2 | kubeval --strict --ignore-missing-schemas
+
+k8s-delete-redirector-ingress:
+	kubectl -n ${REDIRECTOR_NAMESPACE} delete --ignore-not-found ing ${REDIRECTOR_NAME}
+
+k8s-delete-redirector-service:
+	kubectl -n ${REDIRECTOR_NAMESPACE} delete --ignore-not-found svc ${REDIRECTOR_NAME}
+
+k8s-delete-redirector-deployment:
+	kubectl -n ${REDIRECTOR_NAMESPACE} delete --ignore-not-found deploy ${REDIRECTOR_NAME}
+
 k8s-delete-hpa:
 	${KC} delete --ignode-not-found deploy ${APP_NAME}
 
@@ -191,4 +233,6 @@ k8s-jenkins-delete-rbac:
 		k8s-wagtail-deployments k8s-celery-deployments \
 		k8s-delete-wagtail-deployments k8s-delete-celery-deployments \
 		k8s-rollback k8s-history k8s-db-migration-job \
-		k8s-delete-db-migration-job
+		k8s-delete-db-migration-job \
+		k8s-redirector k8s-redirector-ingress k8s-redirector-service k8s-redirector-deployment \
+		k8s-delete-redirector-ingress k8s-delete-redirector-service k8s-delete-redirector-deployment

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -90,9 +90,11 @@ export REDIRECTOR_NAMESPACE ?= "redirector"
 export REDIRECTOR_REPLICAS ?= 1
 export REDIRECTOR_MAX_REPLICAS ?= 4
 export REDIRECTOR_IMAGE_NAME ?= mdnwebdocs/redirector
-export REDIRECTOR_IMAGE_TAG ?= ec2daf9
+export REDIRECTOR_IMAGE_TAG ?= d83919d
 export REDIRECTOR_SERVICE_PORT ?= 80
 export REDIRECTOR_CONTAINER_PORT ?= 80
+# This list must be without quotes
+export REDIRECTOR_HOSTS ?= www.mozilla.dev,developer.mozilla.com
 
 ###############################
 ### core tasks

--- a/k8s/redirector.deployment.yaml.j2
+++ b/k8s/redirector.deployment.yaml.j2
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ REDIRECTOR_NAME }}
+  namespace: {{ REDIRECTOR_NAMESPACE }}
+  labels:
+    app: {{ REDIRECTOR_NAME }}
+spec:
+  replicas: {{ REDIRECTOR_REPLICAS }}
+  selector:
+    matchLabels:
+      app: {{ REDIRECTOR_NAME }}
+  template:
+    metadata:
+      labels:
+        app: {{ REDIRECTOR_NAME }}
+    spec:
+      containers:
+        - name: {{ REDIRECTOR_NAME }}
+          image: "{{ REDIRECTOR_IMAGE_NAME }}:{{ REDIRECTOR_IMAGE_TAG }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ REDIRECTOR_CONTAINER_PORT }}
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: 1
+            requests:
+              memory: 256Mi
+              cpu: 500m

--- a/k8s/redirector.ingress.yaml.j2
+++ b/k8s/redirector.ingress.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ REDIRECTOR_NAME }}
+  namespace: {{ REDIRECTOR_NAMESPACE }}
+  labels:
+    app: {{ REDIRECTOR_NAME }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: www.mozilla.dev
+    http:
+      paths:
+      - backend:
+          serviceName: {{ REDIRECTOR_NAME }}
+          servicePort: {{ REDIRECTOR_SERVICE_PORT }}

--- a/k8s/redirector.ingress.yaml.j2
+++ b/k8s/redirector.ingress.yaml.j2
@@ -8,12 +8,14 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-  - host: www.mozilla.dev
+  {% set domains = REDIRECTOR_HOSTS.split(",") -%}
+  {% for domain in domains -%}
+  - host: {{ domain }}
     http:
       paths:
       - backend:
           serviceName: {{ REDIRECTOR_NAME }}
           servicePort: {{ REDIRECTOR_SERVICE_PORT }}
+  {% endfor %}

--- a/k8s/redirector.svc.yaml.j2
+++ b/k8s/redirector.svc.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ REDIRECTOR_NAME }}
+  namespace: {{ REDIRECTOR_NAMESPACE }}
+  labels:
+    app: {{ REDIRECTOR_NAME }}
+spec:
+  selector:
+    app: {{ REDIRECTOR_NAME }}
+  ports:
+    - name: http
+      port: {{ REDIRECTOR_SERVICE_PORT }}
+      targetPort: {{ REDIRECTOR_CONTAINER_PORT }}


### PR DESCRIPTION
This creates a redirect service for the developer-portal app, its a simple nginx ingress that redirects traffic for www.mozilla.dev to mozilla.dev as well as developer.mozilla.com to mozilla.dev

(Related issue https://github.com/mdn/infra/issues/452)

## Key changes:

- Adds a redirect service for developer-portal
