### PR TITLE
1720: Topics component a11y improvements

### DIFF
--- a/developerportal/apps/home/templates/home.html
+++ b/developerportal/apps/home/templates/home.html
@@ -28,7 +28,7 @@
       </section>
     {% endif %}
     {% if page.about_title %}
-      <section id="about">
+      <section id="about" aria-labelledby="about-strip-heading">
         {% include "organisms/homepage-about.html" with title=page.about_title subtitle=page.about_subtitle button_url=page.about_button_url button_text=page.about_button_text %}
       </section>
     {% endif %}

--- a/developerportal/apps/home/templates/home.html
+++ b/developerportal/apps/home/templates/home.html
@@ -18,7 +18,7 @@
       {% endif %}
     {% endwith %}
     {% if page.primary_topics.all %}
-      <section id="topics">
+      <section id="topics" aria-labelledby="topics-heading">
         {% include "organisms/topic-links.html" with topics=page.primary_topics.all pagetheme='home' %}
       </section>
     {% endif %}

--- a/developerportal/apps/topics/templates/topics.html
+++ b/developerportal/apps/topics/templates/topics.html
@@ -1,9 +1,13 @@
 {% extends "base.html" %}
+{% load static %}
 {% load app_filters %}
 
 {% block body_class %}topics{% endblock %}
 
 {% block content %}
+  {% static "img/icons/article-white.svg" as page_icon_asset_url %}
+  {% include "molecules/header-strip.html" with content=page.title element="h1" page_icon_asset_url=page_icon_asset_url %}
+
   <main role="main">
     {% with page.topics.public.live.specific as topics %}
       {% if topics %}

--- a/developerportal/templates/molecules/item-topic-link.html
+++ b/developerportal/templates/molecules/item-topic-link.html
@@ -5,11 +5,11 @@
 `two_column` is an optional param for this template. The default is four columns
 {% endcomment %}
 
-<section class="mzp-c-card {{two_column|yesno:'mzp-c-card-medium,mzp-c-card-extra-small'}}">
+<li class="mzp-c-card {{two_column|yesno:'mzp-c-card-medium,mzp-c-card-extra-small'}}">
   <a class="mzp-c-card-block-link" href="{{ topic.url }}">
     <div class="mzp-c-card-content">
       <img src="{% get_menu_item_icon topic %}" class="topic-item-icon" alt="" width="24" height="24">
-      <h2 class="mzp-c-card-title"><span>{{ topic.title }}</span></h2>
+      <h3 class="mzp-c-card-title"><span>{{ topic.title }}</span></h3>
       {% if topic.card_description %}
         <div class="mzp-c-card-desc">
         {{ topic.card_description }}
@@ -21,4 +21,4 @@
       {% endif %}
     </div>
   </a>
-</section>
+</li>

--- a/developerportal/templates/organisms/homepage-about.html
+++ b/developerportal/templates/organisms/homepage-about.html
@@ -5,7 +5,7 @@
   <div class="mzp-l-content">
     <div class="mzp-c-call-out-content">
       <div class="mzp-c-call-out-container">
-        <h2 class="mzp-c-call-out-title">{{ title }}</h2>
+        <h2 id="about-strip-heading" class="mzp-c-call-out-title">{{ title }}</h2>
         {% if subtitle %}
           <h5>{{ subtitle }}</h5>
         {% endif %}

--- a/developerportal/templates/organisms/topic-links.html
+++ b/developerportal/templates/organisms/topic-links.html
@@ -6,23 +6,23 @@
 
 {% if topics %}
   <div class="topic-links">
-    <div class="mzp-l-content topic-links-wrapper">
+    <div class="mzp-l-content topic-links">
       <div class="section-header">
         {% if pagetheme == 'home' or pagetheme == 'directory' %}
-          <h3>Browse {{TOPICS_TITLE_LABEL|lower}}</h3>
+          <h2 id="topics-heading">Browse {{TOPICS_TITLE_LABEL|lower}}</h2>
         {% endif %}
         {% if pagetheme == 'topic' %}
-          <h3>Continue exploring</h3>
+          <h2 id="topics-heading">Continue exploring</h2>
         {% endif %}
         {% if pagetheme == 'person' %}
-          <h4>{{TOPICS_TITLE_LABEL}} specialized in</h4>
+          <h2 id="topics-heading">{{TOPICS_TITLE_LABEL}} specialized in</h2>
         {% endif %}
       </div>
-      <div class="{{two_column|yesno:'mzp-l-card-half, mzp-l-card-quarter'}}">
+      <ul class="{{two_column|yesno:'mzp-l-card-half,mzp-l-card-quarter'}}">
         {% for topic in topics %}
           {% include "molecules/item-topic-link.html" with topic=topic.topic %}
         {% endfor %}
-      </div>
+      </ul>
     </div>
   </div>
 {% endif %}

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -64,6 +64,7 @@
 @import 'organisms/homepage-about';
 @import 'organisms/homepage-header';
 @import 'organisms/newsletter-signup';
+@import 'organisms/topic-links';
 @import 'organisms/people-section';
 
 // Templates.

--- a/src/css/molecules/item-topic-link.scss
+++ b/src/css/molecules/item-topic-link.scss
@@ -8,15 +8,15 @@ body.topics .topic-links .mzp-c-card {
 .topic-links {
   background-color: $color-light-gray-10;
 
-  h3 {
+  h2 {
     margin-top: $spacing-sm;
   }
-  h3,
-  h4 {
+  h2,
+  h3 {
     font-family: $body-font-family;
     font-size: 1.5rem;
   }
-  h4 {
+  h3 {
     font-size: 1.5em;
   }
 

--- a/src/css/molecules/item-topic-link.scss
+++ b/src/css/molecules/item-topic-link.scss
@@ -16,9 +16,6 @@ body.topics .topic-links .mzp-c-card {
     font-family: $body-font-family;
     font-size: 1.5rem;
   }
-  h3 {
-    font-size: 1.5em;
-  }
 
   .section-header {
     padding: $spacing-sm 0px $spacing-md;

--- a/src/css/organisms/topic-links.scss
+++ b/src/css/organisms/topic-links.scss
@@ -1,0 +1,12 @@
+.topic-links {
+  h2 {
+    font-family: $body-font-family;
+    font-size: $h4-font-size-mobile;
+    line-height: heading-line-height($h4-font-size-mobile);
+
+    @media #{$mq-md} {
+      font-size: $h4-font-size;
+      line-height: heading-line-height($h4-font-size);
+    }
+  }
+}


### PR DESCRIPTION
This changeset contains markup improvements to boost a11y, as suggested in #1720.

## How to test

- Code is being deployed to staging, so please check it out there. 
- There are three places the topics component is used:
  - homepage
  - /topics/
  - on a Person page, where they are associated with one or more topics/technologies. In this situation, the topics component renders its output as a two-column layout over four grid columns, not four cols over four.