### PR TITLE
1736: Event page - a11y improvements to four-card-row component

### DIFF
--- a/developerportal/templates/molecules/quarter-page-item.html
+++ b/developerportal/templates/molecules/quarter-page-item.html
@@ -21,7 +21,7 @@ Inputs:
 {% else %}
   {% static "img/placeholders/post_16_9.jpg" as fallback_image %}
 {% endif %}
-<section class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-16-9">
+<li class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-16-9">
   {% if external_page or resource.is_external %}
     <a
       href="{{ resource.url }}"
@@ -64,4 +64,4 @@ Inputs:
         </h2>
       </div>
     </a>
-</section>
+</li>

--- a/developerportal/templates/molecules/quarter-page-item.html
+++ b/developerportal/templates/molecules/quarter-page-item.html
@@ -57,11 +57,11 @@ Inputs:
           {{resource.primary_topic|default:"Featured"}}
         {% endif %}
         </div>
-        <h2 class="mzp-c-card-title">
+        <h3 class="mzp-c-card-title">
           <span>
             {{ resource.title }}
           </span>
-        </h2>
+        </h3>
       </div>
     </a>
 </li>

--- a/developerportal/templates/organisms/four-card-row.html
+++ b/developerportal/templates/organisms/four-card-row.html
@@ -13,7 +13,7 @@ Inputs:
 <div class="four-card-row {% if tinted_panel %}has-tint{% endif %}">
   <div class="mzp-l-content">
     {% if header_text %}
-    <h4>{{header_text}}</h4>
+    <h2>{{header_text}}</h2>
     {% endif %}
     <div class="mzp-l-card-quarter">
       {% for block in items %}

--- a/developerportal/templates/organisms/four-card-row.html
+++ b/developerportal/templates/organisms/four-card-row.html
@@ -15,7 +15,7 @@ Inputs:
     {% if header_text %}
     <h2>{{header_text}}</h2>
     {% endif %}
-    <div class="mzp-l-card-quarter">
+    <ul class="mzp-l-card-quarter">
       {% for block in items %}
         {% if block.block_type == 'post' or block.block_type == 'video' or block.block_type == 'event' %}
           {% with block.value as page %}
@@ -27,7 +27,7 @@ Inputs:
           {% endwith %}
         {% endif %}
       {% endfor %}
-    </div>
+    </ul>
   </div>
 </div>
 {% endif %}

--- a/src/css/organisms/four-card-row.scss
+++ b/src/css/organisms/four-card-row.scss
@@ -1,7 +1,8 @@
 .four-card-row {
   background-color: transparent;
-  h2,
-  h4 {
+  h2 {
+    font-size: $h4-font-size; // TODO: sweep and rename these variables
+    line-height: heading-line-height($h4-font-size-mobile);
     font-family: $body-font-family;
     margin: $spacing-md 0 $spacing-2xl;
   }

--- a/src/css/organisms/four-card-row.scss
+++ b/src/css/organisms/four-card-row.scss
@@ -10,4 +10,10 @@
   &.has-tint {
     background-color: $color-marketing-gray-20;
   }
+
+  h3.mzp-c-card-title {
+    font-size: $h2-font-size; // TODO: sweep and rename these variables
+    line-height: heading-line-height($h2-font-size-mobile);
+    font-family: $body-font-family;
+  }
 }

--- a/src/css/organisms/four-card-row.scss
+++ b/src/css/organisms/four-card-row.scss
@@ -1,9 +1,16 @@
 .four-card-row {
   background-color: transparent;
   h2 {
-    font-size: $h4-font-size; // TODO: sweep and rename these variables
-    line-height: heading-line-height($h4-font-size-mobile);
     font-family: $body-font-family;
+
+    font-size: $h4-font-size-mobile; // TODO: sweep and rename these variables
+    line-height: heading-line-height($h4-font-size-mobile);
+
+    @media #{$mq-md} {
+      font-size: $h4-font-size;
+      line-height: heading-line-height($h4-font-size);
+    }
+
     margin: $spacing-md 0 $spacing-2xl;
   }
 
@@ -12,8 +19,13 @@
   }
 
   h3.mzp-c-card-title {
-    font-size: $h2-font-size; // TODO: sweep and rename these variables
-    line-height: heading-line-height($h2-font-size-mobile);
     font-family: $body-font-family;
+    font-size: $h2-font-size-mobile; // TODO: sweep and rename these variables
+    line-height: heading-line-height($h2-font-size-mobile);
+
+    @media #{$mq-md} {
+      font-size: $h2-font-size;
+      line-height: heading-line-height($h2-font-size);
+    }
   }
 }


### PR DESCRIPTION
This changeset addresses some a11y-related markup issues in the 'Related items' panel on an Event detail page, which is actually the 'four-card-row' component used in a number of places in the site, such as the 'Featured events' block on the /events/ page and the 'What we are working on' panel on a Topic page


## How to test

- Code is on Staging. Please see #1736 for the acceptance criteria
