### PR TITLE
1735: Update people section markup

### DIFF
--- a/developerportal/apps/articles/templates/article.html
+++ b/developerportal/apps/articles/templates/article.html
@@ -28,7 +28,7 @@
 
   <aside class="mzp-l-sidebar custom-width">
     {% if page.authors %}
-    <h4 class="authors-header">Content by</h4>
+    <h2 class="authors-header">Content by</h2>
     {% else %}
     {% endif %}
     {% for author_block in page.authors %}

--- a/developerportal/templates/molecules/cards/card-person.html
+++ b/developerportal/templates/molecules/cards/card-person.html
@@ -10,7 +10,9 @@
   {% static "img/placeholders/person_16_9.jpg" as fallback_url %}
 {% endif %}
 
-<section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9 card-person">
+{% with node_type|default:"div" as el %}
+
+<{{el}} class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9 card-person">
   {% if type == 'speaker' or type == 'person' or type == 'author' %}
     <a href="{% pageurl person %}" class="mzp-c-card-block-link" data-type="{{ person.resource_type }}">
   {% endif %}
@@ -31,11 +33,9 @@
             {{person.get_role_display}}
           {% endif %}
         </div>
-        <h2 class="mzp-c-card-title">
-          <span>
+        <h3 class="mzp-c-card-title">
             {{ person.display_title }}
-          </span>
-        </h2>
+        </h3>
         <div class="mzp-c-card-desc">
           {{ person.job_title }}
         </div>
@@ -51,4 +51,5 @@
     </a>
   {% endif %}
 
-</section>
+</{{el}}>
+{% endwith %}

--- a/developerportal/templates/organisms/people-section.html
+++ b/developerportal/templates/organisms/people-section.html
@@ -12,21 +12,19 @@
 
 <div class="people-section {% if tinted_panel %}has-tint{% endif %}">
   <div class="mzp-l-content">
-    <div class="section-header">
-      <h4>{{ title|default:"People" }}
-      {% if show_link and directory_pages.people %}
-        <span>
-          <a href="{% pageurl directory_pages.people %}{% if is_topic %}?topic={{ page.slug }}{% endif %}">See more</a>
-        </span>
-      {% endif %}
-      </h4>
-    </div>
+    <h2>{{ title|default:"People" }}
+    {% if show_link and directory_pages.people %}
+      <span>
+        <a href="{% pageurl directory_pages.people %}{% if is_topic %}?topic={{ page.slug }}{% endif %}">See more</a>
+      </span>
+    {% endif %}
+    </h2>
 
     {# Render cards side by side, up to three, always same width #}
-    <div class="mzp-l-card-third">
+    <ul class="mzp-l-card-third">
       {% for person in people %}
-        {% include "molecules/cards/card-person.html" with person=person type="person" full_width=False %}
+        {% include "molecules/cards/card-person.html" with node_type="li" person=person type="person" full_width=False %}
       {% endfor %}
-    </div>
+    </ul>
   </div>
 </div>

--- a/src/css/organisms/people-section.scss
+++ b/src/css/organisms/people-section.scss
@@ -1,14 +1,21 @@
 .people-section {
-  .section-header {
-    padding: $spacing-sm 0px $spacing-xl;
-    h4 {
-      font-family: $body-font-family;
+  h2 {
+    font-family: $body-font-family;
 
-      span {
-        display: inline-block;
-        padding-left: $spacing-sm;
-        font-size: 0.6em;
-      }
+    font-size: $h4-font-size;
+    line-height: heading-line-height($h4-font-size);
+
+    margin: $spacing-md 0 $spacing-2xl;
+
+    @media #{$mq-md} {
+      font-size: $h4-font-size;
+      line-height: heading-line-height($h4-font-size);
+    }
+
+    span {
+      display: inline-block;
+      padding-left: $spacing-sm;
+      font-size: 0.6em;
     }
   }
   &.has-tint {

--- a/src/css/templates/article.scss
+++ b/src/css/templates/article.scss
@@ -7,5 +7,12 @@ body.article {
   }
   .authors-header {
     font-family: $body-font-family;
+    font-size: $h4-font-size-mobile; // TODO: sweep and rename these variables
+    line-height: heading-line-height($h4-font-size-mobile);
+
+    @media #{$mq-md} {
+      font-size: $h4-font-size;
+      line-height: heading-line-height($h4-font-size);
+    }
   }
 }


### PR DESCRIPTION
Related to changes to the topic page requested in #1735, this changeset completes the acceptance criteria by fixing up the People section - eg see https://developer-portal.stage.mdn.mozit.cloud/topics/av1-video/

It also slides in a small change to the Article page, which also uses the parital/component updated in this PR.

## Key changes:

- 1735: Update markup for "People section" component to have better a11y

  * Fix up heading heirarchy
  * Make items a list not div soup
  * Make card-person.html take an explicitly nominated HTML element to use as its wrapping element, defaulting to div -- this is because the template partial is used now in a list but also elsewhere as a single standalone item, which doesn't make sense to mark up as a list

- 1753: Update use of people-section on the Article page, to improve a11y
  * Improve heading heirarchy while keeping the font size the same


## How to test

- code will be on staging.
- the People component is present on various page types, including https://developer-portal.stage.mdn.mozit.cloud/topics/av1-video/
- there is a test Article page which now features a person card in the sidebar: https://developer-portal.stage.mdn.mozit.cloud/posts/test-page-search/