### PR TITLE
Hotfix: make Safari allow styling of the search input in the main nav

### DIFF
--- a/src/css/molecules/site-search-form.scss
+++ b/src/css/molecules/site-search-form.scss
@@ -9,6 +9,7 @@
     margin-bottom: $spacing-md;
     padding: $spacing-xs $spacing-xs $spacing-xs $spacing-xl;
     width: 100%;
+    -webkit-appearance: none; // override blocking of styling in Safari
 
     @media #{$mq-md} {
       width: 80%;


### PR DESCRIPTION
This changeset allows us to override the default styling of a `search` input in Safari (which is already allowed in all other target browsers)

Before, in Safari:

![Screenshot 2020-07-27 at 15 21 49](https://user-images.githubusercontent.com/101457/88553203-e94caf00-d01c-11ea-8ac7-cb7923962b67.png)

After:

![Screenshot 2020-07-27 at 15 22 21](https://user-images.githubusercontent.com/101457/88553271-fff30600-d01c-11ea-9b37-8cd7a5040db7.png)

Also in iOS (emulation):

![Screenshot 2020-07-27 at 15 17 05](https://user-images.githubusercontent.com/101457/88553319-0ed9b880-d01d-11ea-84f6-df16dc50b766.png)

## How to test

- Code is on [stage](https://developer-portal.stage.mdn.mozit.cloud). I've cross-browser tested, but another pair of eyes is very welcome