### PR TITLE
1741: Make rendering of iframed video embeds better in the Video page

### DIFF
--- a/developerportal/apps/videos/templates/video.html
+++ b/developerportal/apps/videos/templates/video.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
+{% load app_tags %}
 
 {% block body_class %}video{% endblock %}
 
@@ -14,7 +15,8 @@
     {% comment %} the video embed comes from a video_url streamfield {% endcomment %}
     <div class="mzp-l-content">
       <div class="video-wrapper">
-        {{ page.video_url }}
+      {% comment %} page.video_url is a streamfield with one embed block (or zero...) {% endcomment %}
+      {% render_embed_with_fixups page=page embed_html=page.video_url.0.value.html %}
       </div>
       {% include "molecules/resource-share.html" %}
     </div>

--- a/src/css/atoms/embed.scss
+++ b/src/css/atoms/embed.scss
@@ -20,3 +20,7 @@
   top: 0;
   width: 100%;
 }
+
+iframe {
+  border: none;
+}


### PR DESCRIPTION
This changeset improves the accessibility of embedded videos and fixes an overlooked HTML validation error.

(Related issue #1741)

## Key changes:

* Adds a `title` attribute to the iframe, based on the page title, but only if there is not already a title present
* Drops the now-deprecated `frameborder` attribute, instead using CSS to ensure the iframe has no border

**Example:**

BEFORE
```    <iframe width="480" height="270" src="https://www.youtube.com/embed/xTH0hb1nYoE?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>```

AFTER:
```    <iframe allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="" height="270" src="https://www.youtube.com/embed/xTH0hb1nYoE?feature=oembed" title="Interview with Stan Leong" width="480">```


## How to test

- Code is on staging, please view source of a video page, such as https://developer-portal.stage.mdn.mozit.cloud/videos/coding-dark-mode-your-website/, and also run it through a HTML5 validator, such as https://validator.w3.org/