### PR TITLE
1758: Ensure all external links have the same values for the rel attribute

### DIFF
--- a/developerportal/apps/common/templates/button_block.html
+++ b/developerportal/apps/common/templates/button_block.html
@@ -6,7 +6,7 @@
       {% if value.page_link %}
         <a href="{% pageurl value.page_link %}" class="mzp-c-button">
       {% elif value.external_link %}
-        <a href="{{ value.external_link }}" class="mzp-c-button" target="_blank" rel="nofollow noopener">
+        <a href="{{ value.external_link }}" class="mzp-c-button" target="_blank" rel="nofollow noopener noreferrer">
       {% endif %}
         {{ value.text }}
         </a>

--- a/developerportal/apps/common/wagtail_hooks.py
+++ b/developerportal/apps/common/wagtail_hooks.py
@@ -18,7 +18,10 @@ class NewWindowExternalLinkHandler(LinkHandler):
         href = attrs["href"]
         # Let's add the target attr, and also rel="noopener" + noreferrer fallback.
         # See https://github.com/whatwg/html/issues/4078.
-        return '<a href="%s" target="_blank" rel="noopener noreferrer">' % escape(href)
+        return (
+            '<a href="%s" target="_blank" rel="nofollow noopener noreferrer">'
+            % escape(href)
+        )
 
 
 @hooks.register("register_rich_text_features")

--- a/developerportal/templates/molecules/card-featured.html
+++ b/developerportal/templates/molecules/card-featured.html
@@ -43,7 +43,7 @@
 Note that this partial needs wrapping with a div and a section with the appropriate classes
 {% endcomment %}
 {% if external_page %}
-<a href="{{ resource.url }}" class="mzp-c-card-block-link" data-type="external_page" target="_blank" rel="nofollow noopener">
+<a href="{{ resource.url }}" class="mzp-c-card-block-link" data-type="external_page" target="_blank" rel="nofollow noopener noreferrer">
 {% else %}
 <a href="{% pageurl resource %}" class="mzp-c-card-block-link" data-type="{{ resource.resource_type }}">
 {% endif %}

--- a/developerportal/templates/molecules/cards/card-article.html
+++ b/developerportal/templates/molecules/cards/card-article.html
@@ -8,7 +8,7 @@
 <div class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
   <a class="mzp-c-card-block-link"
     href="{% pageurl resource %}"
-    {% if resource.is_external %} target="_blank" rel="noopener noreferrer" {% endif %}
+    {% if resource.is_external %} target="_blank" rel="nofollow noopener noreferrer" {% endif %}
     data-type="{{ resource.resource_type }}"
   >
     <div class="mzp-c-card-media-wrapper">

--- a/developerportal/templates/molecules/cards/card-video.html
+++ b/developerportal/templates/molecules/cards/card-video.html
@@ -12,7 +12,7 @@
     data-class-name="mzp-has-media"
     data-title="{{ resource.title }}"
     target="_blank"
-    rel="nofollow noopener"
+    rel="nofollow noopener noreferrer"
     {% endif %}
     data-type="{{ resource.resource_type }}"
   >

--- a/developerportal/templates/molecules/quarter-page-item.html
+++ b/developerportal/templates/molecules/quarter-page-item.html
@@ -28,7 +28,7 @@ Inputs:
       class="mzp-c-card-block-link {% if resource.resource_type == 'video' %} js-modal-trigger{% endif %}"
       data-type="{{resource.resource_type}}"
       target="_blank"
-      rel="nofollow noopener"
+      rel="nofollow noopener noreferrer"
     {% if resource.resource_type == 'video' %}
       data-class-name="mzp-has-media"
       data-title="{{ resource.title }}"

--- a/developerportal/templates/molecules/resource-share.html
+++ b/developerportal/templates/molecules/resource-share.html
@@ -5,17 +5,17 @@
   <div class="resource-share-buttons">
     <span class="resource-share-buttons-label">Share:</span>
     {% with url_root=current_site.root_url %}
-      <a href="http://twitter.com/share?url={{ url_root }}{{ request.path }}" target="_blank" rel="noopener noreferrer" aria-label="Share this page on Twitter">
+      <a href="http://twitter.com/share?url={{ url_root }}{{ request.path }}" target="_blank" rel="nofollow noopener noreferrer" aria-label="Share this page on Twitter">
         <span class="icon">
           {% include "atoms/icons/twitter.svg" %}
         </span>
       </a>
-      <a href="https://www.facebook.com/sharer.php?u={{ url_root }}{{ request.path }}" target="_blank" rel="noopener noreferrer" aria-label="Share this page on Facebook">
+      <a href="https://www.facebook.com/sharer.php?u={{ url_root }}{{ request.path }}" target="_blank" rel="nofollow noopener noreferrer" aria-label="Share this page on Facebook">
         <span class="icon">
           {% include "atoms/icons/facebook.svg" %}
         </span>
       </a>
-      <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ url_root }}{{ request.path }}" target="_blank" rel="noopener noreferrer" aria-label="Share this page on LinkedIn">
+      <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ url_root }}{{ request.path }}" target="_blank" rel="nofollow noopener noreferrer" aria-label="Share this page on LinkedIn">
         <span class="icon">
           {% include "atoms/icons/linkedin.svg" %}
         </span>

--- a/developerportal/templates/molecules/search-result.html
+++ b/developerportal/templates/molecules/search-result.html
@@ -9,7 +9,7 @@
       js-modal-trigger{% endif %}"
     {% if page.is_external %}
       target="_blank"
-      rel="nofollow noopener"
+      rel="nofollow noopener noreferrer"
       data-title="{{ page.title }}"
       data-type="{{ page.resource_type }}"
     {% endif %}

--- a/developerportal/templates/organisms/newsletter-signup.html
+++ b/developerportal/templates/organisms/newsletter-signup.html
@@ -27,7 +27,7 @@
           <p class="newsletter-privacy-wrapper">
             <label for="newsletter-privacy" class="mzp-u-inline">
               <input type="checkbox" name="privacy" id="newsletter-privacy" required aria-required="true">
-              I'm okay with Mozilla handling my info as explained in this <a class="privacy-link" href="https://www.mozilla.org/privacy/websites/" target="_blank" rel="noopener noreferrer">Privacy Notice</a>.
+              I'm okay with Mozilla handling my info as explained in this <a class="privacy-link" href="https://www.mozilla.org/privacy/websites/" target="_blank" rel="noopener">Privacy Notice</a>.
             </label>
           </p>
           <p>

--- a/developerportal/templates/survey.html
+++ b/developerportal/templates/survey.html
@@ -16,7 +16,7 @@
   </button>
   <p>
       Your feedback is important. Would you
-        <a target="_blank" rel="noreferrer noopener" href="{{survey_url}}" class="mzp-c-notification-bar-cta">
+        <a target="_blank" rel="nofollow noopener noreferrer" href="{{survey_url}}" class="mzp-c-notification-bar-cta">
           complete a short survey
         </a>
       after visiting?

--- a/src/js/tests/newsletter-subscription.test.js
+++ b/src/js/tests/newsletter-subscription.test.js
@@ -28,7 +28,7 @@ const exampleFormHTML = `
     <p>
       <label for="newsletter-privacy" class="mzp-u-inline">
         <input type="checkbox" name="privacy" id="newsletter-privacy" required aria-required="true">
-        I'm okay with Mozilla handling my info as explained in this <a class="privacy-link" href="https://www.mozilla.org/privacy/websites/" target="_blank" rel="noopener noreferrer">Privacy Notice</a>.
+        I'm okay with Mozilla handling my info as explained in this <a class="privacy-link" href="https://www.mozilla.org/privacy/websites/" target="_blank" rel="noopener">Privacy Notice</a>.
       </label>
     </p>
     <p>

--- a/src/js/tests/task-completion-prompt.test.js
+++ b/src/js/tests/task-completion-prompt.test.js
@@ -23,7 +23,7 @@ const promptHTMLInHiddenState = `<aside class="mzp-c-notification-bar mzp-t-clic
   <button class="mzp-c-notification-bar-button mzp-js-notification-trigger" type="button"></button>
   <p>
       Your feedback is important. Would you
-        <a target="_blank" rel="noreferrer noopener" href="https://example.com/task-completion-survey" class="mzp-c-notification-bar-cta">
+        <a target="_blank" rel="nofollow noopener noreferrer" href="https://example.com/task-completion-survey" class="mzp-c-notification-bar-cta">
           complete a short survey
         </a>
       after visiting?


### PR DESCRIPTION
For links that use `target="_blank"` we already had `rel="noopener"` set and sometimes `nofollow` and sometimes `noreferrer`, but this changeset brings them all into line so that ALL of them use `nofollow noreferrer noopener` for consistency and predictability. (I've also seen this pattern used by Mozilla Hacks blog.)

This does raise questions about SEO and analytics, regarding `nofollow` and `noreferer` and we could in the future support fine-grained control over those values for links.

Please feel free to disagree!

(Related issue #1758)

## How to test

- code will be on staging soon, so look at external links or social sharing links. However, what's more important is consensus on whether `nofollow` is definitely worth it and whether we are comfortable with/without `noreferrer`