### PR TITLE
[1723] Improve filter-list markup

### DIFF
--- a/developerportal/apps/articles/templates/article.html
+++ b/developerportal/apps/articles/templates/article.html
@@ -32,7 +32,7 @@
     {% else %}
     {% endif %}
     {% for author_block in page.authors %}
-      {% include "molecules/cards/card-person.html" with person=author_block.value type=author_block.block_type %}
+      {% include "molecules/cards/card-person.html" with person=author_block.value type=author_block.block_type node_type="div" %}
     {% endfor %}
   </aside>
 </div>

--- a/developerportal/apps/articles/templates/articles.html
+++ b/developerportal/apps/articles/templates/articles.html
@@ -10,8 +10,8 @@
   {% static "img/icons/article-white.svg" as page_icon_asset_url %}
   {% include "molecules/header-strip.html" with content=page.title element="h1" page_icon_asset_url=page_icon_asset_url %}
 
-  <div id="results-list">
+  <main id="results-list" role="main">
     {% include "organisms/filter-list.html" with type="article_or_video" resources=resources no_resources_message="No relevant posts found" hide_pagination=False %}
-  </div>
+  </main>
   {% include "organisms/newsletter-signup.html" %}
 {% endblock content %}

--- a/developerportal/apps/events/templates/event.html
+++ b/developerportal/apps/events/templates/event.html
@@ -71,7 +71,7 @@ We only set safe_label_markup if we want to show the label, but its absence does
     {% endcomment %}
 
     {% firstof page.event_content page.official_website page.register_url as specific_link %}
-    {% include "molecules/cards/card-event.html" with resource=page no_link=True specific_link=specific_link %}
+    {% include "molecules/cards/card-event.html" with resource=page no_link=True specific_link=specific_link node_type="div" %}
 
     {% comment %} Also show a streamfield with rich text, buttons, etc all possible {% endcomment %}
     {% for block in page.sidebar %}

--- a/developerportal/apps/people/templates/person.html
+++ b/developerportal/apps/people/templates/person.html
@@ -18,7 +18,7 @@
   </main>
 
   <aside class="mzp-l-sidebar custom-width">
-    {% include "molecules/cards/card.html" with resource=page %}
+    {% include "molecules/cards/card.html" with resource=page node_type="div" %}
   </aside>
 </div>
 

--- a/developerportal/templates/molecules/cards/card-article.html
+++ b/developerportal/templates/molecules/cards/card-article.html
@@ -5,7 +5,8 @@
 {% image resource.card_image width-480 as card_image %}
 {% static "img/placeholders/post_16_9.jpg" as fallback_image %}
 
-<div class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
+{% with node_type|default:"li" as el %}
+<{{el}} class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
   <a class="mzp-c-card-block-link"
     href="{% pageurl resource %}"
     {% if resource.is_external %} target="_blank" rel="noopener noreferrer" {% endif %}
@@ -23,4 +24,5 @@
       </h2>
     </div>
   </a>
-</div>
+</{{el}}>
+{% endwith %}

--- a/developerportal/templates/molecules/cards/card-event.html
+++ b/developerportal/templates/molecules/cards/card-event.html
@@ -6,7 +6,8 @@
 {% image resource.card_image width-480 as card_image %}
 {% static "img/placeholders/event_16_9.jpg" as fallback_image %}
 
-<div class="mzp-c-card mzp-c-card-medium card-event mzp-has-aspect-16-9">
+{% with node_type|default:"li" as el %}
+<{{el}} class="mzp-c-card mzp-c-card-medium card-event mzp-has-aspect-16-9">
   <a class="mzp-c-card-block-link"
     {% if specific_link %}
       href="{{ specific_link }}"
@@ -38,4 +39,5 @@
       {% endif %}
     </div>
   </a>
-</div>
+</{{el}}>
+{% endwith %}

--- a/developerportal/templates/molecules/cards/card-person.html
+++ b/developerportal/templates/molecules/cards/card-person.html
@@ -10,7 +10,8 @@
   {% static "img/placeholders/person_16_9.jpg" as fallback_url %}
 {% endif %}
 
-<section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9 card-person">
+{% with node_type|default:"li" as el %}
+<{{el}} class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9 card-person">
   {% if type == 'speaker' or type == 'person' or type == 'author' %}
     <a href="{% pageurl person %}" class="mzp-c-card-block-link" data-type="{{ person.resource_type }}">
   {% endif %}
@@ -51,4 +52,5 @@
     </a>
   {% endif %}
 
-</section>
+</{{el}}>
+{% endwith %}

--- a/developerportal/templates/molecules/cards/card-video.html
+++ b/developerportal/templates/molecules/cards/card-video.html
@@ -5,7 +5,8 @@
 {% image resource.card_image width-480 as card_image %}
 {% static "img/placeholders/post_16_9.jpg" as fallback_image %}
 
-<div class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
+{% with node_type|default:"li" as el %}
+<{{el}} class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
   <a class="mzp-c-card-block-link {% if resource.is_external %}js-modal-trigger{% endif %}"
     href="{% pageurl resource %}"
     {% if resource.is_external %}
@@ -28,4 +29,5 @@
       </h2>
     </div>
   </a>
-</div>
+</{{el}}>
+{% endwith %}

--- a/developerportal/templates/molecules/cards/card.html
+++ b/developerportal/templates/molecules/cards/card.html
@@ -1,9 +1,9 @@
 {% if resource.resource_type == "article" %}
-  {% include "molecules/cards/card-article.html" with resource=resource show_author=show_author card_number=card_number %}
+  {% include "molecules/cards/card-article.html" with resource=resource node_type=node_type show_author=show_author card_number=card_number %}
 {% elif resource.resource_type == "event" %}
-  {% include "molecules/cards/card-event.html" with resource=resource %}
+  {% include "molecules/cards/card-event.html" with resource=resource node_type=node_type %}
 {% elif resource.resource_type == "person" %}
-  {% include "molecules/cards/card-person.html" with person=resource %}
+  {% include "molecules/cards/card-person.html" with person=resource node_type=node_type  %}
 {% elif resource.resource_type == "video" %}
-  {% include "molecules/cards/card-video.html" with resource=resource %}
+  {% include "molecules/cards/card-video.html" with resource=resource node_type=node_type %}
 {% endif %}

--- a/developerportal/templates/organisms/filter-list.html
+++ b/developerportal/templates/organisms/filter-list.html
@@ -13,7 +13,7 @@
     </div>
   </aside>
   <div class="mzp-l-main custom-width">
-    <div class="mzp-l-card-half" id="{{ type }}-cards">
+    <ul class="mzp-l-card-half" id="{{ type }}-cards">
       {% for resource in resources %}
         {% if type == "article_or_video" %}
           {% if resource.video %}
@@ -31,7 +31,7 @@
         {{ no_resources_message|default:"No results found" }}
       </h2>
       {% endfor %}
-    </div>
+    </ul>
     {% if resources and not hide_pagination %}
     {% include "molecules/pagination.html" with items=resources %}
     {% endif %}

--- a/developerportal/templates/organisms/people-section.html
+++ b/developerportal/templates/organisms/people-section.html
@@ -23,10 +23,10 @@
     </div>
 
     {# Render cards side by side, up to three, always same width #}
-    <div class="mzp-l-card-third">
+    <ul class="mzp-l-card-third">
       {% for person in people %}
         {% include "molecules/cards/card-person.html" with person=person type="person" full_width=False %}
       {% endfor %}
-    </div>
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
This changeset moves the filter-list component (used on /posts/, /events/ and /people/communities/ to mark up the results cards as a list, not div soup.

As a knock-on from that, there are a few places where the cards (which now default to using an li as their root node) need specifying to use a div instead of an li as their root nodes.

This changeset will overlap slightly with some of the work for PR#1749, but I'll deal with that in the merge once it's all signed off.

## How to test

- Code will be on Staging
- [x] Check markup
  - [x] check `/posts/` - list not divs
    - [x] check an article for the sidebar card (should be a div)
  - [x] check `/events/` - list not divs
    - [x] check an event for the sidebar card (should be a div)
  - [x] check `/communities/people/` - list not divs
    - [x] check a person page for the sidebar card (should be a div)
    - [x] check people-section in the footer of a topic page - eg https://developer-portal.stage.mdn.mozit.cloud/topics/av1-video/
