### PR TITLE
[1722] Add main element to articles listing page

### DIFF
--- a/developerportal/apps/articles/templates/articles.html
+++ b/developerportal/apps/articles/templates/articles.html
@@ -10,8 +10,8 @@
   {% static "img/icons/article-white.svg" as page_icon_asset_url %}
   {% include "molecules/header-strip.html" with content=page.title element="h1" page_icon_asset_url=page_icon_asset_url %}
 
-  <div id="results-list">
+  <main id="results-list" role="main">
     {% include "organisms/filter-list.html" with type="article_or_video" resources=resources no_resources_message="No relevant posts found" hide_pagination=False %}
-  </div>
+  </main>
   {% include "organisms/newsletter-signup.html" %}
 {% endblock content %}


### PR DESCRIPTION
This one-item changeset contains a small markup improvement to the /articles/ page, adding a `main` node with the appropriate role attribute

This, when combined with the work done for #1723 in PR #1761 completes the work outlined in the ticket #1722

## How to test

- code will be on staging