### PR TITLE
1751: Extend app-level ratelimiting so that admin/CMS editors get a higher threshold

### DIFF
--- a/developerportal/apps/common/middleware.py
+++ b/developerportal/apps/common/middleware.py
@@ -19,7 +19,6 @@ def _get_group(request):
 def _get_appropriate_rate(group):
     if group == RATELIMIT_GROUP_ADMIN_REQUESTS:
         return settings.DEVPORTAL_RATELIMIT_ADMIN_USER_LIMIT
-
     return settings.DEVPORTAL_RATELIMIT_DEFAULT_LIMIT
 
 

--- a/developerportal/apps/common/tests/test_middleware.py
+++ b/developerportal/apps/common/tests/test_middleware.py
@@ -1,12 +1,22 @@
+from operator import itemgetter
 from unittest import mock
 
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser, User
 from django.core.cache import cache
 from django.test import RequestFactory, TestCase, override_settings
 
 from ratelimit.exceptions import Ratelimited
 
-from ..middleware import rate_limiter, set_remote_addr_from_forwarded_for
+from ..middleware import (
+    ALL,
+    RATELIMIT_GROUP_ADMIN_REQUESTS,
+    RATELIMIT_GROUP_PUBLIC_REQUESTS,
+    _get_appropriate_rate,
+    _get_group,
+    rate_limiter,
+    set_remote_addr_from_forwarded_for,
+)
 
 
 @override_settings(RATELIMIT_ENABLE=True, DEVPORTAL_RATELIMIT_DEFAULT_LIMIT="2/m")
@@ -34,6 +44,7 @@ class RateLimiterMiddlewareTests(TestCase):
 
                 mock_get_response = mock.Mock(name="get_response")
                 fake_request = getattr(factory, method)("/", REMOTE_ADDR="127.0.0.1")
+                fake_request.user = AnonymousUser()
                 middleware_func = rate_limiter(mock_get_response)
 
                 # First time, no problem
@@ -61,6 +72,7 @@ class RateLimiterMiddlewareTests(TestCase):
         cache.clear()  # reset any previous rate limiting
         for i, ip in enumerate(["127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"]):
             fake_request = factory.get("/", REMOTE_ADDR=ip)
+            fake_request.user = AnonymousUser()
             middleware_func(fake_request)
             assert mock_get_response.call_count == 1 + i
 
@@ -74,6 +86,111 @@ class RateLimiterMiddlewareTests(TestCase):
         middleware_func(fake_request)
         with self.assertRaises(Ratelimited):
             middleware_func(fake_request)
+
+    def _bootstrap_users(self):
+        anonymous_user = AnonymousUser()
+        non_staff_user = User.objects.create_user(
+            is_staff=False, username="not)staff", password="password"
+        )
+        staff_user = User.objects.create_user(
+            is_staff=True, username="staff", password="password"
+        )
+
+        return anonymous_user, non_staff_user, staff_user
+
+    def test_middleware__get_group(self):
+        anonymous_user, non_staff_user, staff_user = self._bootstrap_users()
+        cases = (
+            {"user": anonymous_user, "expected": RATELIMIT_GROUP_PUBLIC_REQUESTS},
+            {"user": non_staff_user, "expected": RATELIMIT_GROUP_PUBLIC_REQUESTS},
+            {"user": staff_user, "expected": RATELIMIT_GROUP_ADMIN_REQUESTS},
+        )
+        for case in cases:
+            with self.subTest(case=case):
+                request = RequestFactory().get(path="/")
+                request.user = case["user"]
+                self.assertEqual(_get_group(request), case["expected"])
+
+    @override_settings(
+        DEVPORTAL_RATELIMIT_ADMIN_USER_LIMIT="999999/m",
+        DEVPORTAL_RATELIMIT_DEFAULT_LIMIT="3/m",
+    )
+    def test_middleware__get_appropriate_rate(self):
+        cases = (
+            {"group": RATELIMIT_GROUP_PUBLIC_REQUESTS, "expected": "3/m"},
+            {"group": RATELIMIT_GROUP_ADMIN_REQUESTS, "expected": "999999/m"},
+        )
+        for case in cases:
+            with self.subTest(case=case):
+                self.assertEqual(_get_appropriate_rate(case["group"]), case["expected"])
+
+    @override_settings(
+        DEVPORTAL_RATELIMIT_ADMIN_USER_LIMIT="999999/m",
+        DEVPORTAL_RATELIMIT_DEFAULT_LIMIT="200/m",
+    )
+    @mock.patch("developerportal.apps.common.middleware.is_ratelimited")
+    def test_middleware__is_ratelimited_calls_are_appropriate(
+        self, mock_is_ratelimited
+    ):
+
+        mock_is_ratelimited.return_value = (
+            False
+        )  # So that the middleware doesn't raise Ratelimited()
+
+        anonymous_user, non_staff_user, staff_user = self._bootstrap_users()
+        cases = (
+            {
+                "user": anonymous_user,
+                "expected": {
+                    "group": RATELIMIT_GROUP_PUBLIC_REQUESTS,
+                    "key": "ip",
+                    "rate": "200/m",
+                    "increment": True,
+                    "method": ALL,
+                },
+            },
+            {
+                "user": staff_user,
+                "expected": {
+                    "group": RATELIMIT_GROUP_ADMIN_REQUESTS,
+                    "key": "ip",
+                    "rate": "999999/m",
+                    "increment": True,
+                    "method": ALL,
+                },
+            },
+            {
+                "user": non_staff_user,
+                "expected": {
+                    "group": RATELIMIT_GROUP_PUBLIC_REQUESTS,
+                    "key": "ip",
+                    "rate": "200/m",
+                    "increment": True,
+                    "method": ALL,
+                },
+            },
+        )
+        for case in cases:
+            with self.subTest(case=case):
+                request = RequestFactory().get(path="/")
+                request.user = case["user"]
+
+                mock_get_response = mock.Mock(name="get_response")
+                middleware_func = rate_limiter(mock_get_response)
+
+                mock_is_ratelimited.reset_mock()
+
+                middleware_func(request)
+
+                mock_call_kwargs = mock_is_ratelimited.call_args_list[0][1]
+
+                # Be sure we've got the right user on the request passed to is_ratelimit
+                assert mock_call_kwargs.get("request").user == case["user"]
+
+                # Now check the rest of the args passed to is_ratelimit
+                for mock_kwarg_name, expected_val in case["expected"].items():
+                    f = itemgetter(mock_kwarg_name)
+                    self.assertEqual(f(mock_call_kwargs), expected_val)
 
 
 class RemoteAddressMiddlewareTests(TestCase):

--- a/developerportal/settings/base.py
+++ b/developerportal/settings/base.py
@@ -370,6 +370,9 @@ RATELIMIT_VIEW = "developerportal.apps.core.views.rate_limited"
 DEVPORTAL_RATELIMIT_DEFAULT_LIMIT = os.getenv(
     "DEVPORTAL_RATELIMIT_DEFAULT_LIMIT", "25/m"
 )
+DEVPORTAL_RATELIMIT_ADMIN_USER_LIMIT = os.getenv(
+    "DEVPORTAL_RATELIMIT_ADMIN_USER_LIMIT", "60/m"
+)
 
 # Whether or not to automatically create content based on feeds configured in the DB
 AUTOMATICALLY_INGEST_CONTENT = (


### PR DESCRIPTION
This changeset updates the ratelimiting middleware to apply a less strict limit on requests made by authenticated staff users (ie, those with Wagtail CMS access). This is so that things like the image search typeahead isn't blocked so readily.

The initial value for the admin-user rate limiting is now 60 requests per minute, up from 25 per minute (which remains the default for unauthenticated users).

Note that the user has to be both authenticated AND a staff/admin user to not be treated as a regular public user. At the moment, all our authenticated users are staff, but this may not always be the case.

Tests have been extended to prove this is working as expected, plus manual checks have been done, but it's still possible that we need to increase the admin-user limit further, or simply remove it and keep it only for unauthenticated users.


## How to test

- code is deployed to staging
- as an unauthenticated user (eg in an incognitio window) repeatedly load a non-CMS page from staging - eg the homepage. It should rate limit on the 26th request, if you're fast enough
- as an authenticated user, in admin, you are now allowed more requests per minute, which should not get in the way of your editing/content work. Please check things that previously tripped the rate limiter. 
  - The image-search typeahead will, for instance, still hit it if you enter 61 characters one by one

@valgrimm Am still quite tempted to remove the rate limiting for authenticated staff users altogether -- I know you were keen to keep it and only relax it, but having implemented this to bucket users as either public or authenticated staff, we could drop the limit altogether for the staff users and we'd still be running rate limiting against someone unauthenticated pointlessly hammering at the admin login screen


### Snippets from manual testing:

Public rate limiting still working:
```
In: for i in range(30): print(i+1, requests.get("http://localhost:8000"))
1 <Response [200]>
2 <Response [200]>
3 <Response [200]>
4 <Response [200]>
5 <Response [200]>
6 <Response [200]>
7 <Response [200]>
8 <Response [200]>
9 <Response [200]>
10 <Response [200]>
11 <Response [200]>
12 <Response [200]>
13 <Response [200]>
14 <Response [200]>
15 <Response [200]>
16 <Response [200]>
17 <Response [200]>
18 <Response [200]>
19 <Response [200]>
20 <Response [200]>
21 <Response [200]>
22 <Response [200]>
23 <Response [200]>
24 <Response [200]>
25 <Response [200]>
26 <Response [429]>
27 <Response [429]>
28 <Response [429]>
29 <Response [429]>
30 <Response [429]>
```

Admin rate limiting does kick in, just after more queries:

![Screenshot 2020-07-29 at 12 55 16](https://user-images.githubusercontent.com/101457/88798396-bc270a80-d19c-11ea-8bd1-bc6b7e2fca49.png)
