### PR TITLE
1734: Amend wording of Prev button to Previous

### DIFF
--- a/developerportal/templates/molecules/pagination.html
+++ b/developerportal/templates/molecules/pagination.html
@@ -5,9 +5,9 @@
 
   <span class="step-links">
   {% if items.has_previous %}
-    <a class="mzp-c-button mzp-t-small" href="?{{PAGINATION_QUERYSTRING_KEY}}={{ items.previous_page_number }}{{additional_qs_params}}#results-list">Prev</a>
+    <a class="mzp-c-button mzp-t-small" href="?{{PAGINATION_QUERYSTRING_KEY}}={{ items.previous_page_number }}{{additional_qs_params}}#results-list">Previous</a>
   {% else %}
-    <button class="mzp-c-button mzp-t-small" disabled>Prev</button>
+    <button class="mzp-c-button mzp-t-small" disabled>Previous</button>
   {% endif %}
 
   <span class="pagination-current">

--- a/src/css/molecules/pagination.scss
+++ b/src/css/molecules/pagination.scss
@@ -4,10 +4,11 @@
   text-align: center;
 
   & .mzp-c-button {
-    @media #{$mq-md} {
+    min-width: 90px;
+
+    @media #{$mq-sm} {
+      min-width: 135px;
       padding: 14px 30px;
-      // This is the default for mzp-c-button, but we
-      // want to override mzp-t-small on larger viewports
     }
   }
 }


### PR DESCRIPTION
This changeset fixes up the wording of the pagination "Prev" button to be "Previous"

It also adds `min-width` values, where smallest viewport has _something_ useful to make the buttons look a bit more balanced in terms of size, while larger sizes have a min-width that ensures consistent button sizing

Note that the layout breaks a little when the viewport is smaller than 360px.


(Related issue #1734)

## How to test

- Code will be on staging

## Screenshots

![Screenshot 2020-07-29 at 15 02 10](https://user-images.githubusercontent.com/101457/88813707-2b0e5e80-d1b1-11ea-9e29-74eb9361f67e.png)

![Screenshot 2020-07-29 at 15 02 21](https://user-images.githubusercontent.com/101457/88813712-2cd82200-d1b1-11ea-84c9-28ef63937a07.png)layout 
![Screenshot 2020-07-29 at 15 02 41](https://user-images.githubusercontent.com/101457/88813716-2e094f00-d1b1-11ea-8da5-4cc8644a8974.png)
![Screenshot 2020-07-29 at 15 03 00](https://user-images.githubusercontent.com/101457/88813717-2e094f00-d1b1-11ea-9c37-d4cbee69ce70.png)
