### PR TITLE
[1759] Move newsletter <aside> out of <main> on a few pages

### DIFF
--- a/developerportal/apps/events/templates/events.html
+++ b/developerportal/apps/events/templates/events.html
@@ -48,6 +48,6 @@
     {% endfor %}
   </div>
   {% endif %}
-  {% include "organisms/newsletter-signup.html" with compact=True %}
 </main>
+{% include "organisms/newsletter-signup.html" with compact=True %}
 {% endblock content %}

--- a/developerportal/apps/home/templates/home.html
+++ b/developerportal/apps/home/templates/home.html
@@ -32,6 +32,6 @@
         {% include "organisms/homepage-about.html" with title=page.about_title subtitle=page.about_subtitle button_url=page.about_button_url button_text=page.about_button_text %}
       </section>
     {% endif %}
-    {% include "organisms/newsletter-signup.html" %}
   </main>
+  {% include "organisms/newsletter-signup.html" %}
 {% endblock content %}

--- a/developerportal/apps/people/templates/people.html
+++ b/developerportal/apps/people/templates/people.html
@@ -14,6 +14,6 @@
   <div id="results-list">
     {% include "organisms/filter-list.html" with type="person" resources=people no_resources_message="No people found" %}
   </div>
-  {% include "organisms/newsletter-signup.html" %}
 </main>
+{% include "organisms/newsletter-signup.html" %}
 {% endblock content %}

--- a/developerportal/apps/topics/templates/topic.html
+++ b/developerportal/apps/topics/templates/topic.html
@@ -32,6 +32,6 @@
   {% endif %}
   {% endwith %}
 
-  {% include "organisms/newsletter-signup.html" %}
 </main>
+{% include "organisms/newsletter-signup.html" %}
 {% endblock content %}


### PR DESCRIPTION
This changeset fixes up a markup glitch where the Newsletter component (which is in an <aside> was placed inside a <main> component.

- Events page
- Homepage
- People page
- Topic page

(Resolves #1759)

## How to test

- code is on its way to staging