### PR TITLE
Manually bump minimist dependency to 1.2.5 following NPM audit warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2438,9 +2438,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -9410,9 +9410,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }


### PR DESCRIPTION
https://www.npmjs.com/advisories/1179

For some reason npm audit fix and nmp update did not resolve the issues, so doing it manually seemed the next best workable approach

The static container now builds with 1.2.5 everywhere

/app # npm ls | grep minimist
| +-- minimist@1.2.5
|     `-- minimist@1.2.5
| |   `-- minimist@1.2.5
| | `-- minimist@1.2.5
|   | `-- minimist@1.2.5 deduped
|   +-- minimist@1.2.5 deduped
| | | | | `-- minimist@1.2.5 deduped
| | | | | `-- minimist@1.2.5 deduped
| | | | +-- minimist@1.2.5 deduped
npm| | +-- minimist@1.2.5 deduped
 ERR! missing: bindings@^1.5.0, required by fsevents@1.2.13
| |   `-- minimist@1.2.5
| |   `-- minimist@1.2.5 deduped

